### PR TITLE
fix(marketplace): add order refresh and retry handling

### DIFF
--- a/api/src/marketplace/dex.service.spec.ts
+++ b/api/src/marketplace/dex.service.spec.ts
@@ -162,4 +162,71 @@ describe('DexService', () => {
       );
     });
   });
+
+  describe('invalidateOrdersCache', () => {
+    function mockRedis() {
+      const redis = (service as any).redis;
+      redis.scanIterator = jest.fn().mockImplementation(async function* () {});
+      redis.del = jest.fn().mockResolvedValue(0);
+      return redis;
+    }
+
+    it('deletes every cached orders list key instead of the literal orders:* pattern', async () => {
+      const redis = mockRedis();
+      redis.scanIterator = jest.fn().mockImplementation(async function* () {
+        yield 'orders:all:all:1:20';
+        yield 'orders:3:all:1:20';
+      });
+
+      await (service as any).invalidateOrdersCache();
+
+      expect(redis.scanIterator).toHaveBeenCalledWith({ MATCH: 'orders:*' });
+      expect(redis.del).toHaveBeenCalledWith(['orders:all:all:1:20', 'orders:3:all:1:20']);
+    });
+
+    it('does not call DEL when there are no cached orders keys', async () => {
+      const redis = mockRedis();
+
+      await (service as any).invalidateOrdersCache();
+
+      expect(redis.del).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('buyBondTokens', () => {
+    const buyer = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+    const order: any = {
+      id: 7,
+      seller: buyer,
+      bondId: 3,
+      amount: 1000,
+      pricePerToken: 25,
+      quoteAsset: 'USDC',
+      status: OrderStatus.Open,
+      createdAt: new Date(1700000000 * 1000).toISOString(),
+    };
+
+    it('invalidates the cached orders list after a successful purchase', async () => {
+      const redis = (service as any).redis;
+      redis.get = jest.fn().mockImplementation((key: string) =>
+        key === 'order:7' ? Promise.resolve(JSON.stringify(order)) : Promise.resolve(null),
+      );
+      redis.setEx = jest.fn().mockResolvedValue(true);
+      redis.scanIterator = jest.fn().mockImplementation(async function* () {
+        yield 'orders:all:all:1:20';
+      });
+      redis.del = jest.fn().mockResolvedValue(1);
+      simulateCallMock.mockResolvedValue(nativeToScVal(BigInt(1000), { type: 'i128' }));
+      invokeContractMethodMock.mockResolvedValue({
+        transactionHash: 'txn1',
+        successful: true,
+      });
+
+      await expect(service.buyBondTokens({ orderId: 7, amount: 10, maxPrice: 30 }, buyer)).resolves.toEqual(
+        expect.objectContaining({ id: 7 }),
+      );
+
+      expect(redis.del).toHaveBeenCalledWith(['orders:all:all:1:20']);
+    });
+  });
 });

--- a/api/src/marketplace/dex.service.ts
+++ b/api/src/marketplace/dex.service.ts
@@ -119,7 +119,7 @@ export class DexService {
     );
 
     const orderId = Number(scValToNative(result));
-    await this.redis.del(`orders:*`);
+    await this.invalidateOrdersCache();
     return this.getOrder(orderId);
   }
 
@@ -153,7 +153,7 @@ export class DexService {
       throw this.mapDexError(error);
     }
 
-    await this.redis.del(`orders:*`);
+    await this.invalidateOrdersCache();
     return this.getOrder(dto.orderId);
   }
 
@@ -170,7 +170,7 @@ export class DexService {
       nonce,
     );
 
-    await this.redis.del(`orders:*`);
+    await this.invalidateOrdersCache();
   }
 
   async getOrder(orderId: number): Promise<OrderResponse> {
@@ -243,6 +243,16 @@ export class DexService {
     );
 
     return { address: callerAddress, asset: dto.asset, amount: dto.amount, transactionHash };
+  }
+
+  private async invalidateOrdersCache(): Promise<void> {
+    const keys: string[] = [];
+    for await (const key of this.redis.scanIterator({ MATCH: 'orders:*' })) {
+      keys.push(key);
+    }
+    if (keys.length > 0) {
+      await this.redis.del(keys);
+    }
   }
 
   private decodeOrder(data: any[]): OrderResponse {

--- a/frontend/src/app/marketplace/marketplace-list/marketplace-list.component.spec.ts
+++ b/frontend/src/app/marketplace/marketplace-list/marketplace-list.component.spec.ts
@@ -1,12 +1,13 @@
-import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { TestBed, ComponentFixture, fakeAsync, tick } from '@angular/core/testing';
 import { signal } from '@angular/core';
 import { provideRouter } from '@angular/router';
-import { of } from 'rxjs';
-import { MarketplaceListComponent } from './marketplace-list.component';
+import { HttpErrorResponse } from '@angular/common/http';
+import { of, throwError, Observable, Subject } from 'rxjs';
+import { MarketplaceListComponent, ORDERS_RETRY_BASE_DELAY_MS } from './marketplace-list.component';
 import { ApiService } from '../../shared/services/api.service';
 import { AuthService } from '../../auth/auth.service';
 import { WalletService } from '../../auth/wallet.service';
-import { Order } from '../../shared/interfaces/bond.interface';
+import { Order, PaginatedResponse } from '../../shared/interfaces/bond.interface';
 
 const ORDER: Order = {
   id: 1,
@@ -18,6 +19,10 @@ const ORDER: Order = {
   status: 'Open',
   createdAt: new Date().toISOString(),
 };
+
+const META = { page: 1, limit: 20, total: 1, totalPages: 1 };
+
+const FRESH_ORDER: Order = { ...ORDER, status: 'Filled', amount: 5 };
 
 describe('MarketplaceListComponent', () => {
   let component: MarketplaceListComponent;
@@ -117,6 +122,168 @@ describe('MarketplaceListComponent', () => {
       orderId: 1,
       amount: 5,
       maxPrice: 10,
+    });
+  });
+
+  describe('order refresh', () => {
+    it('forces a fresh fetch that bypasses client-side caching on refresh', () => {
+      apiService.getOrders.calls.reset();
+      apiService.getOrders.and.returnValue(of({ data: [ORDER], meta: META }));
+
+      component.refreshOrders();
+
+      expect(apiService.getOrders).toHaveBeenCalledWith(undefined, true);
+    });
+
+    it('replaces a stale response with fresh order data on refresh', () => {
+      const stale = { ...ORDER, status: 'Open' as Order['status'] };
+      apiService.getOrders.calls.reset();
+      apiService.getOrders.and.returnValues(
+        of({ data: [stale], meta: META }),
+        of({ data: [FRESH_ORDER], meta: META }),
+      );
+
+      component.refreshOrders();
+      expect(component.orders()[0].status).toBe('Open');
+
+      component.refreshOrders();
+      expect(component.orders()[0].status).toBe('Filled');
+      expect(component.orders()[0].amount).toBe(5);
+    });
+
+    it('updates the UI with fresh order data after a refresh', () => {
+      apiService.getOrders.calls.reset();
+      apiService.getOrders.and.returnValue(of({ data: [FRESH_ORDER], meta: META }));
+
+      component.refreshOrders();
+      fixture.detectChanges();
+
+      const el: HTMLElement = fixture.nativeElement;
+      expect(el.textContent).toContain('Open Orders (1)');
+      expect(el.textContent).toContain('Filled');
+    });
+
+    it('refreshes orders with cache bypass after a completed buy', () => {
+      apiService.getOrders.calls.reset();
+      apiService.getOrders.and.returnValue(of({ data: [ORDER], meta: META }));
+      component.openBuy(ORDER);
+      component.buyAmount = 5;
+      component.buyMaxPrice = 10;
+
+      component.onBuy(ORDER);
+
+      expect(apiService.getOrders).toHaveBeenCalledWith(undefined, true);
+    });
+  });
+
+  describe('order retry with backoff', () => {
+    it('retries a transient failure only after the backoff delay', fakeAsync(() => {
+      apiService.getOrders.calls.reset();
+      apiService.getOrders.and.returnValues(
+        throwError(() => new Error('network down')),
+        of({ data: [ORDER], meta: META }),
+      );
+
+      component.refreshOrders();
+      expect(apiService.getOrders).toHaveBeenCalledTimes(1);
+
+      tick(ORDERS_RETRY_BASE_DELAY_MS - 1);
+      expect(apiService.getOrders).toHaveBeenCalledTimes(1);
+
+      tick(1);
+      expect(apiService.getOrders).toHaveBeenCalledTimes(2);
+      expect(component.orders()[0].id).toBe(ORDER.id);
+      expect(component.loading()).toBe(false);
+      expect(component.error()).toBe('');
+    }));
+
+    it('recovers when a retry eventually succeeds', fakeAsync(() => {
+      apiService.getOrders.calls.reset();
+      apiService.getOrders.and.returnValues(
+        throwError(() => new Error('network down')),
+        throwError(() => new Error('network down')),
+        of({ data: [ORDER], meta: META }),
+      );
+
+      component.refreshOrders();
+      tick(ORDERS_RETRY_BASE_DELAY_MS);
+      tick(ORDERS_RETRY_BASE_DELAY_MS * 2);
+      tick(ORDERS_RETRY_BASE_DELAY_MS * 4);
+
+      expect(apiService.getOrders).toHaveBeenCalledTimes(3);
+      expect(component.orders()[0].id).toBe(ORDER.id);
+      expect(component.loading()).toBe(false);
+      expect(component.error()).toBe('');
+    }));
+
+    it('handles persistent failures cleanly after retries are exhausted', fakeAsync(() => {
+      apiService.getOrders.calls.reset();
+      apiService.getOrders.and.returnValue(throwError(() => new Error('still down')));
+
+      component.refreshOrders();
+      expect(component.loading()).toBe(true);
+
+      tick(ORDERS_RETRY_BASE_DELAY_MS);
+      tick(ORDERS_RETRY_BASE_DELAY_MS * 2);
+      tick(ORDERS_RETRY_BASE_DELAY_MS * 4);
+
+      expect(apiService.getOrders).toHaveBeenCalledTimes(4);
+      expect(component.loading()).toBe(false);
+      expect(component.error()).toBe('Failed to load orders');
+      expect(component.orders()).toEqual([ORDER]); // previously loaded data is preserved
+    }));
+
+    it('does not retry client errors (4xx)', fakeAsync(() => {
+      apiService.getOrders.calls.reset();
+      apiService.getOrders.and.returnValue(
+        throwError(() => new HttpErrorResponse({ status: 400, statusText: 'Bad Request' })),
+      );
+
+      component.refreshOrders();
+      tick(10000);
+
+      expect(apiService.getOrders).toHaveBeenCalledTimes(1);
+      expect(component.loading()).toBe(false);
+      expect(component.error()).toBe('Failed to load orders');
+    }));
+  });
+
+  describe('refresh concurrency', () => {
+    it('does not stack duplicate subscriptions across repeated refreshes', () => {
+      let active = 0;
+      let maxActive = 0;
+      apiService.getOrders.calls.reset();
+      apiService.getOrders.and.callFake(() => new Observable(() => {
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        return () => { active -= 1; };
+      }));
+
+      component.refreshOrders();
+      component.refreshOrders();
+      component.refreshOrders();
+
+      expect(apiService.getOrders).toHaveBeenCalledTimes(3);
+      expect(maxActive).toBe(1);
+    });
+
+    it('ignores a stale in-flight response superseded by a newer refresh', () => {
+      const first = new Subject<PaginatedResponse<Order>>();
+      const second = new Subject<PaginatedResponse<Order>>();
+      apiService.getOrders.calls.reset();
+      apiService.getOrders.and.returnValues(first, second);
+
+      component.refreshOrders();
+      component.refreshOrders();
+
+      // The first request was cancelled by the second refresh; its late response must not land.
+      first.next({ data: [{ ...ORDER, id: 99 }], meta: META });
+      expect(component.orders().map(o => o.id)).toEqual([1]);
+
+      second.next({ data: [FRESH_ORDER], meta: META });
+      second.complete(); // a real HTTP response completes; finalize clears the loading state
+      expect(component.orders()[0].status).toBe('Filled');
+      expect(component.loading()).toBe(false);
     });
   });
 });

--- a/frontend/src/app/marketplace/marketplace-list/marketplace-list.component.ts
+++ b/frontend/src/app/marketplace/marketplace-list/marketplace-list.component.ts
@@ -1,14 +1,20 @@
-import { Component, inject, OnInit, ChangeDetectionStrategy, signal, computed } from '@angular/core';
+import { Component, inject, OnInit, OnDestroy, ChangeDetectionStrategy, signal, computed } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule, ActivatedRoute, Router } from '@angular/router';
 import { FormsModule } from '@angular/forms';
+import { HttpErrorResponse } from '@angular/common/http';
+import { Subject, EMPTY, Observable, defer, timer, switchMap, takeUntil, retry, tap, finalize, catchError, throwError } from 'rxjs';
 import { ApiService } from '../../shared/services/api.service';
 import { AuthService } from '../../auth/auth.service';
 import { WalletService } from '../../auth/wallet.service';
 import { StatusBadgeComponent } from '../../shared/components/status-badge/status-badge.component';
 import { LoadingSpinnerComponent } from '../../shared/components/loading-spinner/loading-spinner.component';
 import { QuoteBalanceComponent, QuoteBalances } from '../../shared/components/quote-balance/quote-balance.component';
-import { Order, Bond, QuoteAsset } from '../../shared/interfaces/bond.interface';
+import { Order, Bond, QuoteAsset, PaginatedResponse } from '../../shared/interfaces/bond.interface';
+
+export const ORDERS_RETRY_COUNT = 3;
+export const ORDERS_RETRY_BASE_DELAY_MS = 500;
+export const ORDERS_RETRY_MAX_DELAY_MS = 4000;
 
 @Component({
   selector: 'app-marketplace-list',
@@ -66,6 +72,7 @@ import { Order, Bond, QuoteAsset } from '../../shared/interfaces/bond.interface'
         <div class="orders-section">
           <div class="section-header">
             <h3 class="section-title">Open Orders ({{ orders().length }})</h3>
+            <button class="btn btn-sm btn-outline" (click)="refreshOrders()">Refresh</button>
           </div>
 
           @if (orders().length === 0) {
@@ -224,7 +231,7 @@ import { Order, Bond, QuoteAsset } from '../../shared/interfaces/bond.interface'
   `],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MarketplaceListComponent implements OnInit {
+export class MarketplaceListComponent implements OnInit, OnDestroy {
   private readonly apiService = inject(ApiService);
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
@@ -242,6 +249,9 @@ export class MarketplaceListComponent implements OnInit {
   readonly buyError = signal('');
   buyAmount = 0;
   buyMaxPrice = 0;
+
+  private readonly ordersRefresh$ = new Subject<boolean>();
+  private readonly destroy$ = new Subject<void>();
 
   readonly balances = signal<QuoteBalances>({ USDC: 0, XLM: 0 });
   readonly balancesLoaded = signal(false);
@@ -284,8 +294,23 @@ export class MarketplaceListComponent implements OnInit {
     if (bondIdParam) {
       this.filterBondId.set(Number(bondIdParam));
     }
+    this.ordersRefresh$
+      .pipe(
+        takeUntil(this.destroy$),
+        switchMap((forceRefresh) => this.fetchOrders(forceRefresh)),
+      )
+      .subscribe();
     this.loadBonds();
     this.loadOrders();
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  refreshOrders(): void {
+    this.loadOrders(true);
   }
 
   private loadBonds(): void {
@@ -294,19 +319,39 @@ export class MarketplaceListComponent implements OnInit {
     });
   }
 
-  private loadOrders(): void {
+  private loadOrders(forceRefresh = false): void {
+    this.ordersRefresh$.next(forceRefresh);
+  }
+
+  private fetchOrders(forceRefresh: boolean): Observable<PaginatedResponse<Order>> {
     this.loading.set(true);
     this.error.set('');
-    this.apiService.getOrders(this.filterBondId() ?? undefined).subscribe({
-      next: (res) => {
-        this.orders.set(res.data);
-        this.loading.set(false);
-      },
-      error: () => {
-        this.error.set('Failed to load orders');
-        this.loading.set(false);
-      },
-    });
+    // defer re-invokes the API call on every (re)subscription, so retries issue a
+    // fresh request with a fresh cache-busting param instead of reusing a stale one.
+    return defer(() => this.apiService.getOrders(this.filterBondId() ?? undefined, forceRefresh)).pipe(
+      retry({
+        count: ORDERS_RETRY_COUNT,
+        delay: (error, attempt) =>
+          this.isTransientError(error) ? timer(this.retryDelayMs(attempt)) : throwError(() => error),
+      }),
+      tap({
+        next: (res) => this.orders.set(res.data),
+        error: () => this.error.set('Failed to load orders'),
+      }),
+      finalize(() => this.loading.set(false)),
+      catchError(() => EMPTY),
+    );
+  }
+
+  private retryDelayMs(attempt: number): number {
+    return Math.min(ORDERS_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1), ORDERS_RETRY_MAX_DELAY_MS);
+  }
+
+  private isTransientError(error: unknown): boolean {
+    if (error instanceof HttpErrorResponse) {
+      return error.status === 0 || error.status >= 500;
+    }
+    return true;
   }
 
   onFilterChange(bondId: number | null): void {
@@ -381,7 +426,7 @@ export class MarketplaceListComponent implements OnInit {
         this.buyOrderId.set(null);
         this.buySubmitting.set(false);
         this.quotePanel?.loadBalances();
-        this.loadOrders();
+        this.loadOrders(true);
       },
       error: (err) => {
         this.buyError.set(err.error?.detail || err.message || 'Buy failed');

--- a/frontend/src/app/shared/services/api.service.ts
+++ b/frontend/src/app/shared/services/api.service.ts
@@ -101,9 +101,11 @@ export class ApiService {
     return this.http.post<Project>('/api/projects', data, { headers: this.headers() });
   }
 
-  getOrders(bondId?: number): Observable<PaginatedResponse<Order>> {
+  getOrders(bondId?: number, refresh = false): Observable<PaginatedResponse<Order>> {
     const params: any = {};
     if (bondId) params.bondId = bondId;
+    // Bypass any client-side/proxy HTTP caching so a refresh always hits the server.
+    if (refresh) params._t = Date.now();
     return this.http.get<PaginatedResponse<Order>>('/api/marketplace/orders', {
       params, headers: this.headers(),
     });


### PR DESCRIPTION
Closes #34

## What changed
- **Frontend — marketplace order list** (`marketplace-list.component.ts`):
  - Added an explicit **Refresh** button to the Open Orders section that forces a fresh fetch, bypassing client-side/proxy HTTP caching via a cache-busting `_t=Date.now()` query param (`api.service.ts` `getOrders(bondId?, refresh?)`).
  - Added **retry-with-exponential-backoff** (500ms → 1s → 2s → 4s, 3 retries) for transient failures (network errors / status 0 / 5xx). Client errors (4xx) are not retried.
  - Refreshes are routed through a `switchMap` on a subject, so repeated refreshes cancel any in-flight request (no duplicate subscriptions, no race conditions, no leaks — `takeUntil(destroy$)` on teardown). Existing loaded orders are preserved on persistent failure.
  - After a completed buy, orders are re-fetched with the cache bypass.
- **Backend — cache invalidation** (`dex.service.ts`): `invalidateOrdersCache()` now SCANs for and deletes every cached `orders:*` key instead of the literal `orders:*` DEL pattern (which never matched), so a refresh after list/sell/buy/cancel always returns fresh data.

## Tests added
- Stale API response followed by fresh response updates the list
- Refresh causes a fresh cache-bypassing fetch
- UI updates with the fresh order data after refresh
- Transient failure triggers retry only after the backoff delay
- Retry eventually succeeds
- Persistent failure handled cleanly (error shown, prior data preserved)
- Client 4xx errors are not retried
- Repeated refreshes don't stack duplicate subscriptions
- A stale in-flight response superseded by a newer refresh is ignored
- Backend: cache invalidation deletes every cached orders key (and skips DEL when none exist); a successful buy invalidates the orders cache

## Validation
- `api`: `npm run lint`, `npm run test` (43 tests), `npm run build` — all pass
- `frontend`: `ng lint`, `ng test --watch=false --browsers=ChromeHeadless` (34 tests), `ng build` — all pass