### PR TITLE
feat: self-amending governance for signer rotation

### DIFF
--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 #![allow(deprecated)]
-use soroban_sdk::{contract, contractimpl, contracttype, vec, Address, Env, IntoVal, Symbol, Val, Vec};
+use soroban_sdk::{contract, contractimpl, contracttype, vec, Address, Env, IntoVal, Symbol, TryFromVal, Val, Vec};
 use nbbs_shared::GovernanceError;
 
 pub const DEFAULT_TIMELOCK_SECONDS: u64 = 172_800;
@@ -76,6 +76,126 @@ fn require_signer(env: &Env, caller: &Address) -> Result<(), GovernanceError> {
     if !signers.contains(caller.clone()) {
         return Err(GovernanceError::NotSigner);
     }
+    Ok(())
+}
+
+fn require_governance(env: &Env, caller: &Address) -> Result<(), GovernanceError> {
+    if *caller != env.current_contract_address() {
+        return Err(GovernanceError::Unauthorized);
+    }
+    Ok(())
+}
+
+fn apply_governance_action(
+    env: &Env,
+    method: &Symbol,
+    args: &Vec<Val>,
+) -> Result<(), GovernanceError> {
+    if *method == Symbol::new(env, "add_signer") {
+        let val = args.get(0).ok_or(GovernanceError::InvalidNonce)?;
+        let new_signer: Address =
+            Address::try_from_val(env, &val).map_err(|_| GovernanceError::InvalidNonce)?;
+
+        let mut signers: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Signers)
+            .ok_or(GovernanceError::NotInitialized)?;
+
+        if signers.contains(new_signer.clone()) {
+            return Err(GovernanceError::SignerAlreadyExists);
+        }
+
+        signers.push_back(new_signer.clone());
+        env.storage()
+            .instance()
+            .set(&DataKey::Signers, &signers);
+
+        env.events()
+            .publish((Symbol::new(&env, "signer_added"),), (new_signer,));
+    } else if *method == Symbol::new(env, "remove_signer") {
+        let val = args.get(0).ok_or(GovernanceError::InvalidNonce)?;
+        let signer_to_remove: Address =
+            Address::try_from_val(env, &val).map_err(|_| GovernanceError::InvalidNonce)?;
+
+        let signers: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Signers)
+            .ok_or(GovernanceError::NotInitialized)?;
+
+        if !signers.contains(signer_to_remove.clone()) {
+            return Err(GovernanceError::SignerNotFound);
+        }
+
+        if signers.len() <= 3 {
+            return Err(GovernanceError::InvalidThreshold);
+        }
+
+        let threshold: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::Threshold)
+            .unwrap_or(1);
+
+        if threshold >= signers.len() {
+            return Err(GovernanceError::InvalidThreshold);
+        }
+
+        let mut new_signers: Vec<Address> = vec![env];
+        for i in 0..signers.len() {
+            let s = signers.get(i).unwrap();
+            if s != signer_to_remove {
+                new_signers.push_back(s);
+            }
+        }
+
+        env.storage()
+            .instance()
+            .set(&DataKey::Signers, &new_signers);
+
+        env.events()
+            .publish((Symbol::new(&env, "signer_removed"),), (signer_to_remove,));
+    } else if *method == Symbol::new(env, "set_threshold") {
+        let val = args.get(0).ok_or(GovernanceError::InvalidNonce)?;
+        let new_threshold: u32 =
+            u32::try_from_val(env, &val).map_err(|_| GovernanceError::InvalidNonce)?;
+
+        let signers: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Signers)
+            .ok_or(GovernanceError::NotInitialized)?;
+
+        if new_threshold < 2 || new_threshold > signers.len() {
+            return Err(GovernanceError::InvalidThreshold);
+        }
+
+        env.storage()
+            .instance()
+            .set(&DataKey::Threshold, &new_threshold);
+
+        env.events()
+            .publish((Symbol::new(&env, "threshold_changed"),), (new_threshold,));
+    } else if *method == Symbol::new(env, "set_timelock") {
+        let val = args.get(0).ok_or(GovernanceError::InvalidNonce)?;
+        let new_timelock: u64 =
+            u64::try_from_val(env, &val).map_err(|_| GovernanceError::InvalidNonce)?;
+
+        if new_timelock == 0 {
+            return Err(GovernanceError::InvalidTimelock);
+        }
+
+        env.storage()
+            .instance()
+            .set(&DataKey::TimelockSeconds, &new_timelock);
+
+        env.events()
+            .publish((Symbol::new(&env, "timelock_changed"),), (new_timelock,));
+    } else {
+        return Err(GovernanceError::InvalidNonce);
+    }
+
     Ok(())
 }
 
@@ -333,13 +453,20 @@ impl Governance {
         }
 
         let exec_nonce = get_execution_nonce(&env, &proposal.target);
-        let mut full_args: Vec<Val> = vec![&env, env.current_contract_address().into_val(&env)];
-        for arg in proposal.args.iter() {
-            full_args.push_back(arg);
-        }
-        full_args.push_back(exec_nonce.into_val(&env));
 
-        env.invoke_contract::<Val>(&proposal.target, &proposal.method, full_args);
+        if proposal.target == env.current_contract_address() {
+            apply_governance_action(&env, &proposal.method, &proposal.args)?;
+        } else {
+            let mut full_args: Vec<Val> =
+                vec![&env, env.current_contract_address().into_val(&env)];
+            for arg in proposal.args.iter() {
+                full_args.push_back(arg);
+            }
+            full_args.push_back(exec_nonce.into_val(&env));
+
+            env.invoke_contract::<Val>(&proposal.target, &proposal.method, full_args);
+        }
+
         set_execution_nonce(&env, &proposal.target, exec_nonce + 1);
 
         proposal.status = ProposalStatus::Executed;
@@ -404,6 +531,151 @@ impl Governance {
             .get::<_, Vec<Address>>(&DataKey::Signers)
             .map(|signers| signers.contains(address))
             .unwrap_or(false)
+    }
+
+    pub fn add_signer(
+        env: Env,
+        caller: Address,
+        new_signer: Address,
+        nonce: u64,
+    ) -> Result<(), GovernanceError> {
+        caller.require_auth();
+        check_nonce(&env, &caller, nonce)?;
+        require_governance(&env, &caller)?;
+
+        let mut signers: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Signers)
+            .ok_or(GovernanceError::NotInitialized)?;
+
+        if signers.contains(new_signer.clone()) {
+            return Err(GovernanceError::SignerAlreadyExists);
+        }
+
+        signers.push_back(new_signer.clone());
+        env.storage()
+            .instance()
+            .set(&DataKey::Signers, &signers);
+
+        env.events().publish(
+            (Symbol::new(&env, "signer_added"),),
+            (new_signer,),
+        );
+
+        Ok(())
+    }
+
+    pub fn remove_signer(
+        env: Env,
+        caller: Address,
+        signer_to_remove: Address,
+        nonce: u64,
+    ) -> Result<(), GovernanceError> {
+        caller.require_auth();
+        check_nonce(&env, &caller, nonce)?;
+        require_governance(&env, &caller)?;
+
+        let signers: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Signers)
+            .ok_or(GovernanceError::NotInitialized)?;
+
+        if !signers.contains(signer_to_remove.clone()) {
+            return Err(GovernanceError::SignerNotFound);
+        }
+
+        if signers.len() <= 3 {
+            return Err(GovernanceError::InvalidThreshold);
+        }
+
+        let threshold: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::Threshold)
+            .unwrap_or(1);
+
+        if threshold >= signers.len() {
+            return Err(GovernanceError::InvalidThreshold);
+        }
+
+        let mut new_signers: Vec<Address> = vec![&env];
+        for i in 0..signers.len() {
+            let s = signers.get(i).unwrap();
+            if s != signer_to_remove {
+                new_signers.push_back(s);
+            }
+        }
+
+        env.storage()
+            .instance()
+            .set(&DataKey::Signers, &new_signers);
+
+        env.events().publish(
+            (Symbol::new(&env, "signer_removed"),),
+            (signer_to_remove,),
+        );
+
+        Ok(())
+    }
+
+    pub fn set_threshold(
+        env: Env,
+        caller: Address,
+        new_threshold: u32,
+        nonce: u64,
+    ) -> Result<(), GovernanceError> {
+        caller.require_auth();
+        check_nonce(&env, &caller, nonce)?;
+        require_governance(&env, &caller)?;
+
+        let signers: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Signers)
+            .ok_or(GovernanceError::NotInitialized)?;
+
+        if new_threshold < 2 || new_threshold > signers.len() {
+            return Err(GovernanceError::InvalidThreshold);
+        }
+
+        env.storage()
+            .instance()
+            .set(&DataKey::Threshold, &new_threshold);
+
+        env.events().publish(
+            (Symbol::new(&env, "threshold_changed"),),
+            (new_threshold,),
+        );
+
+        Ok(())
+    }
+
+    pub fn set_timelock(
+        env: Env,
+        caller: Address,
+        new_timelock: u64,
+        nonce: u64,
+    ) -> Result<(), GovernanceError> {
+        caller.require_auth();
+        check_nonce(&env, &caller, nonce)?;
+        require_governance(&env, &caller)?;
+
+        if new_timelock == 0 {
+            return Err(GovernanceError::InvalidTimelock);
+        }
+
+        env.storage()
+            .instance()
+            .set(&DataKey::TimelockSeconds, &new_timelock);
+
+        env.events().publish(
+            (Symbol::new(&env, "timelock_changed"),),
+            (new_timelock,),
+        );
+
+        Ok(())
     }
 }
 
@@ -732,5 +1004,427 @@ mod test {
 
         let project = registry.get_project(&pid);
         assert_eq!(project.status, nbbs_shared::ProjectStatus::Approved);
+    }
+
+    #[test]
+    fn test_add_signer_via_governance() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set_timestamp(1_000_000);
+
+        let signers = make_signers(&env, 5);
+        let threshold: u32 = 3;
+        let gov_id = env.register(Governance, (&signers, &threshold, &DEFAULT_TIMELOCK_SECONDS));
+        let gov_client = GovernanceClient::new(&env, &gov_id);
+
+        let new_signer = Address::generate(&env);
+        assert!(!gov_client.is_signer(&new_signer));
+
+        let proposal_id = gov_client.propose(
+            &signers.get(0).unwrap(),
+            &gov_id,
+            &Symbol::new(&env, "add_signer"),
+            &vec![&env, new_signer.clone().into_val(&env)],
+            &Symbol::new(&env, "add"),
+            &0,
+        );
+        gov_client.vote_approve(&signers.get(1).unwrap(), &proposal_id, &0);
+        gov_client.vote_approve(&signers.get(2).unwrap(), &proposal_id, &0);
+        gov_client.vote_approve(&signers.get(3).unwrap(), &proposal_id, &0);
+
+        assert_eq!(gov_client.get_proposal(&proposal_id).status, ProposalStatus::Queued);
+
+        env.ledger().set_timestamp(1_000_000 + DEFAULT_TIMELOCK_SECONDS);
+        gov_client.execute(&signers.get(0).unwrap(), &proposal_id, &1);
+
+        assert!(gov_client.is_signer(&new_signer));
+        assert_eq!(gov_client.get_signers().len(), 6);
+    }
+
+    #[test]
+    fn test_remove_signer_via_governance() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set_timestamp(1_000_000);
+
+        let signers = make_signers(&env, 5);
+        let threshold: u32 = 3;
+        let gov_id = env.register(Governance, (&signers, &threshold, &DEFAULT_TIMELOCK_SECONDS));
+        let gov_client = GovernanceClient::new(&env, &gov_id);
+
+        let to_remove = signers.get(4).unwrap();
+        assert!(gov_client.is_signer(&to_remove));
+
+        let proposal_id = gov_client.propose(
+            &signers.get(0).unwrap(),
+            &gov_id,
+            &Symbol::new(&env, "remove_signer"),
+            &vec![&env, to_remove.clone().into_val(&env)],
+            &Symbol::new(&env, "remove"),
+            &0,
+        );
+        gov_client.vote_approve(&signers.get(1).unwrap(), &proposal_id, &0);
+        gov_client.vote_approve(&signers.get(2).unwrap(), &proposal_id, &0);
+        gov_client.vote_approve(&signers.get(3).unwrap(), &proposal_id, &0);
+
+        env.ledger().set_timestamp(1_000_000 + DEFAULT_TIMELOCK_SECONDS);
+        gov_client.execute(&signers.get(0).unwrap(), &proposal_id, &1);
+
+        assert!(!gov_client.is_signer(&to_remove));
+        assert_eq!(gov_client.get_signers().len(), 4);
+    }
+
+    #[test]
+    fn test_remove_signer_below_minimum_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set_timestamp(1_000_000);
+
+        let signers = make_signers(&env, 3);
+        let threshold: u32 = 2;
+        let gov_id = env.register(Governance, (&signers, &threshold, &DEFAULT_TIMELOCK_SECONDS));
+        let gov_client = GovernanceClient::new(&env, &gov_id);
+
+        let to_remove = signers.get(2).unwrap();
+
+        let proposal_id = gov_client.propose(
+            &signers.get(0).unwrap(),
+            &gov_id,
+            &Symbol::new(&env, "remove_signer"),
+            &vec![&env, to_remove.clone().into_val(&env)],
+            &Symbol::new(&env, "remove"),
+            &0,
+        );
+        gov_client.vote_approve(&signers.get(1).unwrap(), &proposal_id, &0);
+        gov_client.vote_approve(&signers.get(2).unwrap(), &proposal_id, &0);
+
+        env.ledger().set_timestamp(1_000_000 + DEFAULT_TIMELOCK_SECONDS);
+        let result = gov_client.try_execute(&signers.get(0).unwrap(), &proposal_id, &1);
+        assert_eq!(result, Err(Ok(GovernanceError::InvalidThreshold)));
+    }
+
+    #[test]
+    fn test_remove_signer_threshold_exceeded_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set_timestamp(1_000_000);
+
+        let signers = make_signers(&env, 5);
+        let threshold: u32 = 5;
+        let gov_id = env.register(Governance, (&signers, &threshold, &DEFAULT_TIMELOCK_SECONDS));
+        let gov_client = GovernanceClient::new(&env, &gov_id);
+
+        let to_remove = signers.get(4).unwrap();
+
+        let proposal_id = gov_client.propose(
+            &signers.get(0).unwrap(),
+            &gov_id,
+            &Symbol::new(&env, "remove_signer"),
+            &vec![&env, to_remove.clone().into_val(&env)],
+            &Symbol::new(&env, "remove"),
+            &0,
+        );
+        gov_client.vote_approve(&signers.get(0).unwrap(), &proposal_id, &1);
+        gov_client.vote_approve(&signers.get(1).unwrap(), &proposal_id, &0);
+        gov_client.vote_approve(&signers.get(2).unwrap(), &proposal_id, &0);
+        gov_client.vote_approve(&signers.get(3).unwrap(), &proposal_id, &0);
+        gov_client.vote_approve(&signers.get(4).unwrap(), &proposal_id, &0);
+
+        env.ledger().set_timestamp(1_000_000 + DEFAULT_TIMELOCK_SECONDS);
+        let result = gov_client.try_execute(&signers.get(0).unwrap(), &proposal_id, &2);
+        assert_eq!(result, Err(Ok(GovernanceError::InvalidThreshold)));
+    }
+
+    #[test]
+    fn test_set_threshold_via_governance() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set_timestamp(1_000_000);
+
+        let signers = make_signers(&env, 5);
+        let threshold: u32 = 3;
+        let gov_id = env.register(Governance, (&signers, &threshold, &DEFAULT_TIMELOCK_SECONDS));
+        let gov_client = GovernanceClient::new(&env, &gov_id);
+
+        let proposal_id = gov_client.propose(
+            &signers.get(0).unwrap(),
+            &gov_id,
+            &Symbol::new(&env, "set_threshold"),
+            &vec![&env, 4_u32.into_val(&env)],
+            &Symbol::new(&env, "threshold"),
+            &0,
+        );
+        gov_client.vote_approve(&signers.get(1).unwrap(), &proposal_id, &0);
+        gov_client.vote_approve(&signers.get(2).unwrap(), &proposal_id, &0);
+        gov_client.vote_approve(&signers.get(3).unwrap(), &proposal_id, &0);
+
+        env.ledger().set_timestamp(1_000_000 + DEFAULT_TIMELOCK_SECONDS);
+        gov_client.execute(&signers.get(0).unwrap(), &proposal_id, &1);
+
+        assert_eq!(gov_client.get_threshold(), 4);
+    }
+
+    #[test]
+    fn test_set_threshold_too_high_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set_timestamp(1_000_000);
+
+        let signers = make_signers(&env, 5);
+        let threshold: u32 = 3;
+        let gov_id = env.register(Governance, (&signers, &threshold, &DEFAULT_TIMELOCK_SECONDS));
+        let gov_client = GovernanceClient::new(&env, &gov_id);
+
+        let proposal_id = gov_client.propose(
+            &signers.get(0).unwrap(),
+            &gov_id,
+            &Symbol::new(&env, "set_threshold"),
+            &vec![&env, 6_u32.into_val(&env)],
+            &Symbol::new(&env, "threshold"),
+            &0,
+        );
+        gov_client.vote_approve(&signers.get(1).unwrap(), &proposal_id, &0);
+        gov_client.vote_approve(&signers.get(2).unwrap(), &proposal_id, &0);
+        gov_client.vote_approve(&signers.get(3).unwrap(), &proposal_id, &0);
+
+        env.ledger().set_timestamp(1_000_000 + DEFAULT_TIMELOCK_SECONDS);
+        let result = gov_client.try_execute(&signers.get(0).unwrap(), &proposal_id, &1);
+        assert_eq!(result, Err(Ok(GovernanceError::InvalidThreshold)));
+    }
+
+    #[test]
+    fn test_set_threshold_below_minimum_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set_timestamp(1_000_000);
+
+        let signers = make_signers(&env, 5);
+        let threshold: u32 = 3;
+        let gov_id = env.register(Governance, (&signers, &threshold, &DEFAULT_TIMELOCK_SECONDS));
+        let gov_client = GovernanceClient::new(&env, &gov_id);
+
+        let proposal_id = gov_client.propose(
+            &signers.get(0).unwrap(),
+            &gov_id,
+            &Symbol::new(&env, "set_threshold"),
+            &vec![&env, 1_u32.into_val(&env)],
+            &Symbol::new(&env, "threshold"),
+            &0,
+        );
+        gov_client.vote_approve(&signers.get(1).unwrap(), &proposal_id, &0);
+        gov_client.vote_approve(&signers.get(2).unwrap(), &proposal_id, &0);
+        gov_client.vote_approve(&signers.get(3).unwrap(), &proposal_id, &0);
+
+        env.ledger().set_timestamp(1_000_000 + DEFAULT_TIMELOCK_SECONDS);
+        let result = gov_client.try_execute(&signers.get(0).unwrap(), &proposal_id, &1);
+        assert_eq!(result, Err(Ok(GovernanceError::InvalidThreshold)));
+    }
+
+    #[test]
+    fn test_set_timelock_via_governance() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set_timestamp(1_000_000);
+
+        let signers = make_signers(&env, 5);
+        let threshold: u32 = 3;
+        let gov_id = env.register(Governance, (&signers, &threshold, &DEFAULT_TIMELOCK_SECONDS));
+        let gov_client = GovernanceClient::new(&env, &gov_id);
+
+        let new_timelock: u64 = 86_400;
+        let proposal_id = gov_client.propose(
+            &signers.get(0).unwrap(),
+            &gov_id,
+            &Symbol::new(&env, "set_timelock"),
+            &vec![&env, new_timelock.into_val(&env)],
+            &Symbol::new(&env, "timelock"),
+            &0,
+        );
+        gov_client.vote_approve(&signers.get(1).unwrap(), &proposal_id, &0);
+        gov_client.vote_approve(&signers.get(2).unwrap(), &proposal_id, &0);
+        gov_client.vote_approve(&signers.get(3).unwrap(), &proposal_id, &0);
+
+        env.ledger().set_timestamp(1_000_000 + DEFAULT_TIMELOCK_SECONDS);
+        gov_client.execute(&signers.get(0).unwrap(), &proposal_id, &1);
+
+        assert_eq!(gov_client.get_timelock(), new_timelock);
+    }
+
+    #[test]
+    fn test_set_timelock_zero_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set_timestamp(1_000_000);
+
+        let signers = make_signers(&env, 5);
+        let threshold: u32 = 3;
+        let gov_id = env.register(Governance, (&signers, &threshold, &DEFAULT_TIMELOCK_SECONDS));
+        let gov_client = GovernanceClient::new(&env, &gov_id);
+
+        let proposal_id = gov_client.propose(
+            &signers.get(0).unwrap(),
+            &gov_id,
+            &Symbol::new(&env, "set_timelock"),
+            &vec![&env, 0_u64.into_val(&env)],
+            &Symbol::new(&env, "timelock"),
+            &0,
+        );
+        gov_client.vote_approve(&signers.get(1).unwrap(), &proposal_id, &0);
+        gov_client.vote_approve(&signers.get(2).unwrap(), &proposal_id, &0);
+        gov_client.vote_approve(&signers.get(3).unwrap(), &proposal_id, &0);
+
+        env.ledger().set_timestamp(1_000_000 + DEFAULT_TIMELOCK_SECONDS);
+        let result = gov_client.try_execute(&signers.get(0).unwrap(), &proposal_id, &1);
+        assert_eq!(result, Err(Ok(GovernanceError::InvalidTimelock)));
+    }
+
+    #[test]
+    fn test_add_signer_duplicate_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set_timestamp(1_000_000);
+
+        let signers = make_signers(&env, 5);
+        let threshold: u32 = 3;
+        let gov_id = env.register(Governance, (&signers, &threshold, &DEFAULT_TIMELOCK_SECONDS));
+        let gov_client = GovernanceClient::new(&env, &gov_id);
+
+        let existing = signers.get(0).unwrap();
+
+        let proposal_id = gov_client.propose(
+            &signers.get(0).unwrap(),
+            &gov_id,
+            &Symbol::new(&env, "add_signer"),
+            &vec![&env, existing.clone().into_val(&env)],
+            &Symbol::new(&env, "add"),
+            &0,
+        );
+        gov_client.vote_approve(&signers.get(1).unwrap(), &proposal_id, &0);
+        gov_client.vote_approve(&signers.get(2).unwrap(), &proposal_id, &0);
+        gov_client.vote_approve(&signers.get(3).unwrap(), &proposal_id, &0);
+
+        env.ledger().set_timestamp(1_000_000 + DEFAULT_TIMELOCK_SECONDS);
+        let result = gov_client.try_execute(&signers.get(0).unwrap(), &proposal_id, &1);
+        assert_eq!(result, Err(Ok(GovernanceError::SignerAlreadyExists)));
+    }
+
+    #[test]
+    fn test_remove_signer_not_found_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set_timestamp(1_000_000);
+
+        let signers = make_signers(&env, 5);
+        let threshold: u32 = 3;
+        let gov_id = env.register(Governance, (&signers, &threshold, &DEFAULT_TIMELOCK_SECONDS));
+        let gov_client = GovernanceClient::new(&env, &gov_id);
+
+        let stranger = Address::generate(&env);
+
+        let proposal_id = gov_client.propose(
+            &signers.get(0).unwrap(),
+            &gov_id,
+            &Symbol::new(&env, "remove_signer"),
+            &vec![&env, stranger.clone().into_val(&env)],
+            &Symbol::new(&env, "remove"),
+            &0,
+        );
+        gov_client.vote_approve(&signers.get(1).unwrap(), &proposal_id, &0);
+        gov_client.vote_approve(&signers.get(2).unwrap(), &proposal_id, &0);
+        gov_client.vote_approve(&signers.get(3).unwrap(), &proposal_id, &0);
+
+        env.ledger().set_timestamp(1_000_000 + DEFAULT_TIMELOCK_SECONDS);
+        let result = gov_client.try_execute(&signers.get(0).unwrap(), &proposal_id, &1);
+        assert_eq!(result, Err(Ok(GovernanceError::SignerNotFound)));
+    }
+
+    #[test]
+    fn test_pending_proposals_survive_signer_change() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set_timestamp(1_000_000);
+
+        let signers = make_signers(&env, 5);
+        let threshold: u32 = 3;
+        let gov_id = env.register(Governance, (&signers, &threshold, &DEFAULT_TIMELOCK_SECONDS));
+        let gov_client = GovernanceClient::new(&env, &gov_id);
+
+        let target = make_target(&env);
+
+        let p1 = gov_client.propose(
+            &signers.get(0).unwrap(),
+            &target,
+            &Symbol::new(&env, "set_something"),
+            &args_for(&env, 42),
+            &Symbol::new(&env, "desc"),
+            &0,
+        );
+        assert_eq!(gov_client.get_proposal(&p1).status, ProposalStatus::Pending);
+        assert_eq!(gov_client.get_proposal(&p1).approval_count, 0);
+
+        let add_id = gov_client.propose(
+            &signers.get(0).unwrap(),
+            &gov_id,
+            &Symbol::new(&env, "add_signer"),
+            &vec![&env, Address::generate(&env).into_val(&env)],
+            &Symbol::new(&env, "add"),
+            &1,
+        );
+        gov_client.vote_approve(&signers.get(1).unwrap(), &add_id, &0);
+        gov_client.vote_approve(&signers.get(2).unwrap(), &add_id, &0);
+        gov_client.vote_approve(&signers.get(3).unwrap(), &add_id, &0);
+
+        env.ledger().set_timestamp(1_000_000 + DEFAULT_TIMELOCK_SECONDS);
+        gov_client.execute(&signers.get(0).unwrap(), &add_id, &2);
+
+        let proposal_after = gov_client.get_proposal(&p1);
+        assert_eq!(proposal_after.status, ProposalStatus::Pending);
+        assert_eq!(proposal_after.approval_count, 0);
+        assert_eq!(proposal_after.target, target);
+    }
+
+    #[test]
+    fn test_direct_call_to_add_signer_rejected() {
+        let (_env, client, signers) = setup();
+        let new_signer = Address::generate(&_env);
+        let result = client.try_add_signer(
+            &signers.get(0).unwrap(),
+            &new_signer,
+            &0,
+        );
+        assert_eq!(result, Err(Ok(GovernanceError::Unauthorized)));
+    }
+
+    #[test]
+    fn test_direct_call_to_remove_signer_rejected() {
+        let (_env, client, signers) = setup();
+        let result = client.try_remove_signer(
+            &signers.get(0).unwrap(),
+            &signers.get(1).unwrap(),
+            &0,
+        );
+        assert_eq!(result, Err(Ok(GovernanceError::Unauthorized)));
+    }
+
+    #[test]
+    fn test_direct_call_to_set_threshold_rejected() {
+        let (_env, client, signers) = setup();
+        let result = client.try_set_threshold(
+            &signers.get(0).unwrap(),
+            &4,
+            &0,
+        );
+        assert_eq!(result, Err(Ok(GovernanceError::Unauthorized)));
+    }
+
+    #[test]
+    fn test_direct_call_to_set_timelock_rejected() {
+        let (_env, client, signers) = setup();
+        let result = client.try_set_timelock(
+            &signers.get(0).unwrap(),
+            &86_400,
+            &0,
+        );
+        assert_eq!(result, Err(Ok(GovernanceError::Unauthorized)));
     }
 }

--- a/contracts/shared/src/errors.rs
+++ b/contracts/shared/src/errors.rs
@@ -85,4 +85,8 @@ pub enum GovernanceError {
     TimelockNotElapsed = 8,
     NotQueued = 9,
     AlreadyExecuted = 10,
+    InvalidThreshold = 11,
+    SignerAlreadyExists = 12,
+    SignerNotFound = 13,
+    InvalidTimelock = 14,
 }

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -13,3 +13,52 @@
 - Deploy contract upgrades (48h timelock)
 - Modify KYC requirements
 - Adjust dispute resolution parameters
+
+## Self-Amending Governance
+
+The governance contract supports modifying its own parameters through the standard proposal/timelock/multi-sig flow. This means signer rotation, threshold changes, and timelock adjustments go through the same governance process as any other action — no admin backdoor.
+
+### Available Self-Amendment Functions
+
+All self-amendment functions can only be called by the governance contract itself (routed through `propose` → `vote_approve` → `execute`). Direct external calls are rejected with `Unauthorized`.
+
+| Function | Description | Guardrails |
+|---|---|---|
+| `add_signer(new_signer)` | Add a new signer to the multi-sig set | Rejected if signer already exists |
+| `remove_signer(signer_to_remove)` | Remove an existing signer | Rejected if removal would leave fewer than 3 signers, or if threshold would exceed new signer count |
+| `set_threshold(new_threshold)` | Change the approval threshold | Must be ≥ 2 and ≤ current signer count |
+| `set_timelock(new_timelock)` | Change the proposal timelock | Must be > 0 |
+
+### Self-Amendment Flow
+
+1. A signer calls `propose` with `target` set to the governance contract's own address and `method` set to one of the self-amendment function names (e.g., `"add_signer"`)
+2. The proposal args contain only the function-specific parameters (not the `caller` — that is automatically set to the governance contract address during execution)
+3. Signers vote via `vote_approve` as usual
+4. After the timelock period, anyone calls `execute`
+5. The governance contract invokes the self-amendment function on itself, with `caller = env.current_contract_address()`
+
+### Example: Adding a Signer
+
+```
+propose(
+  caller: signer_A,
+  target: governance_contract_address,
+  method: "add_signer",
+  args: [new_signer_address],
+  description: "Replace departing team member",
+  nonce: 0
+)
+// 3 signers approve...
+execute(caller: signer_A, proposal_id: 1, nonce: 1)
+// governance contract calls add_signer on itself
+// new_signer is now part of the multi-sig set
+```
+
+### Safety Guarantees
+
+- **No admin backdoor**: All signer/threshold/timelock changes require the full governance process
+- **Threshold floor**: Threshold can never drop below 2
+- **Signer floor**: Signer count can never drop below 3
+- **Threshold bound**: Threshold can never exceed signer count
+- **Proposal safety**: Existing pending proposals are not affected by mid-flight signer changes
+- **Replay protection**: All self-amendment functions use nonce-based replay protection


### PR DESCRIPTION
Adds self-amendment capabilities to the governance contract.

- apply_governance_action() handles self-targeted proposals without contract re-entry
- execute() special-cases self-targets
- Public self-amendment functions gated by require_governance
- 4 new error variants, 16 new unit tests, updated docs/governance.md

29/29 tests pass, 0 warnings.

Closes #15