### PR TITLE
Floor negative carbon_sequestered in iot-aggregator

### DIFF
--- a/oracle/iot-aggregator.spec.ts
+++ b/oracle/iot-aggregator.spec.ts
@@ -105,6 +105,27 @@ describe('aggregateIotProject', () => {
     expect(meanSoilCarbonDeltaPpm([READINGS[0]] as any)).toBeNull();
   });
 
+  it('floors carbon_sequestered at zero for a net soil-carbon loss period', async () => {
+    // NBS-SOIL-001 loses soil carbon over the period (4350 -> 4200 ppm),
+    // producing a negative delta. OracleConsumer.submit_report rejects
+    // carbon_sequestered < 0, so the report must clamp it to zero while
+    // still surfacing the raw negative delta in evidence for context.
+    const lossReadings = [
+      { ...READINGS[0], timestamp: '2025-02-15T06:00:00Z', metrics: { ...READINGS[0].metrics, soil_carbon_ppm: 4350 } },
+      { ...READINGS[0], timestamp: '2025-03-15T06:00:00Z', metrics: { ...READINGS[0].metrics, soil_carbon_ppm: 4200 } },
+    ];
+    const http = new MockHttpClient([{ status: 200, data: { readings: lossReadings } }]);
+    const report = await aggregateIotProject(
+      { ...PROJECT, device_ids: ['NBS-SOIL-001'] },
+      PERIOD,
+      { baseUrl: BASE_URL, http },
+    );
+
+    expect(report.evidence.soil_carbon_delta_ppm).toBe(-150);
+    expect(report.carbon_sequestered).toBe(0);
+    expect(report.carbon_sequestered).toBeGreaterThanOrEqual(0);
+  });
+
   it('throws IotSchemaError when a reading violates the schema', async () => {
     const http = new MockHttpClient([
       {

--- a/oracle/iot-aggregator.ts
+++ b/oracle/iot-aggregator.ts
@@ -176,8 +176,15 @@ export async function aggregateIotProject(
   }
 
   const aggregate = aggregateSensorReadings(validReadings);
-  const carbonSequestered =
-    soilCarbonDeltaPpm * validatedProject.area_ha * KG_CO2E_PER_HA_PER_PPM;
+  // Mirror blue-carbon-adapter.ts's floor: a period of net soil-carbon loss
+  // yields a negative delta, and OracleConsumer.submit_report rejects
+  // carbon_sequestered < 0 outright. Floor the reported value at zero so such
+  // periods are handled gracefully. The raw (possibly negative) delta is still
+  // surfaced in evidence.soil_carbon_delta_ppm to preserve carbon-loss context.
+  const carbonSequestered = Math.max(
+    0,
+    soilCarbonDeltaPpm * validatedProject.area_ha * KG_CO2E_PER_HA_PER_PPM,
+  );
 
   return buildOracleReport({
     project_id: validatedProject.project_id,


### PR DESCRIPTION
Closes #35

## Problem
`oracle/iot-aggregator.ts`'s `aggregateIotProject()` computed `carbon_sequestered = soilCarbonDeltaPpm * area_ha * KG_CO2E_PER_HA_PER_PPM` with no lower bound. A period of net soil-carbon loss yields a negative value, which `OracleConsumer.submit_report` (`contracts/oracle-consumer/src/lib.rs`, `carbon_sequestered < 0`) rejects outright — an opaque contract-level failure instead of graceful handling at the adapter layer. `blue-carbon-adapter.ts`'s `carbonSequesteredKg()` already floors this case at zero.

## Fix
- Floor the reported value at zero with `Math.max(0, ...)`, mirroring `blue-carbon-adapter.ts`. The raw (possibly negative) delta is still surfaced in `evidence.soil_carbon_delta_ppm`, so carbon-loss periods are handled gracefully without discarding context.
- Added a unit test in `oracle/iot-aggregator.spec.ts` for a device with net soil-carbon loss (4350 -> 4200 ppm), asserting the report carries a negative `soil_carbon_delta_ppm` but a non-negative `carbon_sequestered` that passes on-chain validation.

## Cross-check (per issue)
- `oracle/satellite-processor.ts`: **already safe** — `calculateBiomassChange()` floors the NDVI-derived cover at zero via `Math.max(0, fractionalCover)`, so `carbon_sequestered` cannot go negative.
- `oracle/verra-adapter.ts`: **already safe** — it sums per-report `carbon_sequestered_kg`, and `schemas.ts` constrains that field with `z.number().nonnegative()`, so the sum is always non-negative.

No dependencies added.