### PR TITLE
fix: harden oracle consensus and API infrastructure

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,8 @@ SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
 STELLAR_PUBLIC_KEY=G...                        # Admin public key (used by deploy scripts)
 
 # ── Signer Keys (used by the API to build transactions) ──────────
+# SIGNING_KEY_PROVIDER=env                      # env | file (file is dev/test only; use KMS/HSM in production)
+# SIGNING_KEY_FILE=./secrets/signing-keys.json  # JSON file for SIGNING_KEY_PROVIDER=file
 ADMIN_SECRET_KEY=S...                          # Issuer/admin secret key
 USER_SECRET_KEY=S...                           # Regular user (developer) secret key
 INVESTOR_SECRET_KEY=S...                       # Investor secret key

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ A bond issuer (project developer, green bank, or SPV) calls `BondIssuer.issue_bo
 Investors connect their Stellar wallets, pass KYC (handled off-chain via the NestJS API), and purchase bond tokens. Each token represents a pro-rata claim on the tranche. Minimum subscription is one token (fractional NbS exposure).
 
 #### Step 4 — Continuous Oracle Monitoring
-The oracle network continuously monitors carbon stock growth via satellite imagery, IoT sensors, and periodic third-party audits. Signed measurement reports are submitted on-chain to the `OracleConsumer` contract. A report only becomes `Verified` after **independent sources** endorse it: each verify call is recorded on-chain and counted against a configurable signature threshold, and a provider can never verify its own report. This multi-source consensus makes fabricated measurements economically and cryptographically impractical.
+The oracle network continuously monitors carbon stock growth via satellite imagery, IoT sensors, and periodic third-party audits. Signed measurement reports are submitted on-chain to the `OracleConsumer` contract. A report only becomes `Verified` after **independent qualifying sources** endorse it: each qualifying verify call is recorded on-chain and counted against a configurable signature threshold, providers must meet the configured minimum stake before their vote counts, and a provider can never verify its own report. This multi-source consensus makes fabricated measurements economically and cryptographically impractical.
 
 #### Step 5 — Coupon Calculation
 At each coupon date, the `CouponEngine` contract reads the verified oracle report **by its on-chain `report_id`** and calculates the total carbon credits earned by the project during that period. Reports that are not `Verified` are rejected, and the report's project must match the bond's registered project. Credits are allocated pro-rata to all bond token holders.
@@ -516,7 +516,7 @@ The integrity of this protocol depends entirely on the quality and trustworthine
 ### Oracle Security Model
 
 1. **Provider Whitelisting** — Only addresses registered by the protocol admin may submit reports to `OracleConsumer`
-2. **Multi-signature Validation** — High-value reports (backing bonds >$1M) require 2-of-3 provider signatures
+2. **Multi-signature Validation** — Reports default to a 2-signature verification threshold, and provider verifications count only when the provider is active and meets the configured minimum verifier stake
 3. **Challenge Window** — Any stakeholder may challenge a submitted report within 72 hours by submitting counter-evidence (IPFS hash)
 4. **Dispute Resolution** — Challenged reports are frozen pending review by the protocol's dispute committee; coupons are held in escrow during disputes
 5. **Staking & Slashing** — Providers commit staked collateral via `add_stake`; a challenge resolved to `Rejected` slashes **10%** of that stake, and a provider whose stake reaches zero is deactivated and loses whitelist status. Exonerated providers (`Verified` verdict) are not penalized.
@@ -667,7 +667,7 @@ Bond tokens and credit coupon tokens are standard **Stellar Assets**, making the
 
 ### Operational Security
 
-- All admin keys are held in hardware security modules (HSMs)
+- API signing keys are accessed through a `SigningKeyProvider` abstraction. Development may use env vars or the local file provider; production deployments should back this abstraction with KMS/HSM-backed signing before handling real custodial funds.
 - Multi-sig (3-of-5) required for protocol parameter changes
 - 48-hour timelock on all contract upgrades
 - Public bug bounty program (see [Security Disclosure](#-security-disclosure))

--- a/api/src/auth/auth.service.ts
+++ b/api/src/auth/auth.service.ts
@@ -1,8 +1,8 @@
 import { Injectable, BadRequestException, UnauthorizedException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
-import { createClient, RedisClientType } from '@redis/client';
 import { Keypair } from '@stellar/stellar-sdk';
 import * as crypto from 'crypto';
+import { RedisService } from '../common/services/redis.service';
 import { StellarService } from '../stellar/stellar.service';
 import { KycService } from './kyc.service';
 import { VerifySignatureDto } from './dto/verify-signature.dto';
@@ -10,16 +10,12 @@ import { ChallengeResponse, AuthTokenResponse, UserProfileResponse } from './int
 
 @Injectable()
 export class AuthService {
-  private redis: RedisClientType;
-
   constructor(
     private readonly jwtService: JwtService,
     private readonly kycService: KycService,
     private readonly stellarService: StellarService,
-  ) {
-    this.redis = createClient({ url: process.env.REDIS_URL || 'redis://localhost:6379' });
-    this.redis.connect().catch(() => {});
-  }
+    private readonly redis: RedisService,
+  ) {}
 
   async generateChallenge(address: string): Promise<ChallengeResponse> {
     if (!this.stellarService.isValidPublicKey(address)) {

--- a/api/src/auth/kyc.service.ts
+++ b/api/src/auth/kyc.service.ts
@@ -1,15 +1,10 @@
 import { Injectable } from '@nestjs/common';
-import { createClient, RedisClientType } from '@redis/client';
+import { RedisService } from '../common/services/redis.service';
 import { KycStatus } from '../common/interfaces/authenticated-request.interface';
 
 @Injectable()
 export class KycService {
-  private redis: RedisClientType;
-
-  constructor() {
-    this.redis = createClient({ url: process.env.REDIS_URL || 'redis://localhost:6379' });
-    this.redis.connect().catch(() => {});
-  }
+  constructor(private readonly redis: RedisService) {}
 
   async getStatus(address: string): Promise<KycStatus> {
     const cached = await this.redis.get(`kyc:${address}`);

--- a/api/src/bonds/bonds.service.spec.ts
+++ b/api/src/bonds/bonds.service.spec.ts
@@ -20,6 +20,27 @@ import { BondsService } from './bonds.service';
 import { ContractService } from '../stellar/contract.service';
 import { StellarService } from '../stellar/stellar.service';
 import { NonceService } from '../common/services/nonce.service';
+import { RedisService } from '../common/services/redis.service';
+import { SigningKeyProvider } from '../common/services/signing-key.provider';
+
+const redisProvider = {
+  provide: RedisService,
+  useValue: {
+    get: jest.fn().mockResolvedValue(null),
+    setEx: jest.fn().mockResolvedValue(undefined),
+    del: jest.fn().mockResolvedValue(undefined),
+    sMembers: jest.fn().mockResolvedValue([]),
+    sAdd: jest.fn().mockResolvedValue(undefined),
+  },
+};
+
+const signingProvider = {
+  provide: SigningKeyProvider,
+  useValue: {
+    adminSecret: jest.fn().mockReturnValue('SADMIN'),
+    investorSecret: jest.fn().mockReturnValue('SINVESTOR'),
+  },
+};
 
 describe('BondsService', () => {
   let service: BondsService;
@@ -34,6 +55,8 @@ describe('BondsService', () => {
           provide: NonceService,
           useValue: { next: jest.fn().mockResolvedValue(0) },
         },
+        redisProvider,
+        signingProvider,
       ],
     }).compile();
 
@@ -93,6 +116,8 @@ describe('BondsService', () => {
             provide: NonceService,
             useValue: { next: jest.fn().mockResolvedValue(0) },
           },
+          redisProvider,
+          signingProvider,
         ],
       }).compile();
 
@@ -129,6 +154,8 @@ describe('BondsService', () => {
             provide: NonceService,
             useValue: { next: jest.fn().mockResolvedValue(0) },
           },
+          redisProvider,
+          signingProvider,
         ],
       }).compile();
 
@@ -169,6 +196,8 @@ describe('BondsService', () => {
             provide: NonceService,
             useValue: { next: jest.fn().mockResolvedValue(0) },
           },
+          redisProvider,
+          signingProvider,
         ],
       }).compile();
 
@@ -180,7 +209,7 @@ describe('BondsService', () => {
 
       expect(contractAddress).toBe('');
       expect(method).toBe('sweep_undistributed');
-      expect(callerSecret).toBe('');
+      expect(callerSecret).toBe('SADMIN');
       expect(args.length).toBe(2);
       expect(scValToNative(args[0])).toBe(
         'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
@@ -209,6 +238,8 @@ describe('BondsService', () => {
             provide: NonceService,
             useValue: { next: jest.fn().mockResolvedValue(0) },
           },
+          redisProvider,
+          signingProvider,
         ],
       }).compile();
       return moduleRef.get(BondsService);
@@ -287,6 +318,8 @@ describe('BondsService', () => {
             provide: NonceService,
             useValue: { next: jest.fn().mockResolvedValue(0) },
           },
+          redisProvider,
+          signingProvider,
         ],
       }).compile();
       return moduleRef.get(BondsService);

--- a/api/src/bonds/bonds.service.ts
+++ b/api/src/bonds/bonds.service.ts
@@ -2,8 +2,9 @@ import { Injectable, BadRequestException } from '@nestjs/common';
 import { ContractService } from '../stellar/contract.service';
 import { StellarService } from '../stellar/stellar.service';
 import { NonceService } from '../common/services/nonce.service';
+import { RedisService } from '../common/services/redis.service';
+import { SigningKeyProvider } from '../common/services/signing-key.provider';
 import { xdr, nativeToScVal, scValToNative, Address } from '@stellar/stellar-sdk';
-import { createClient, RedisClientType } from '@redis/client';
 import { CreateBondDto } from './dto/create-bond.dto';
 import { SubscribeDto } from './dto/subscribe.dto';
 import { DistributeCouponDto } from './dto/distribute-coupon.dto';
@@ -41,16 +42,13 @@ const BOND_ERROR_CODE = {
 
 @Injectable()
 export class BondsService {
-  private redis: RedisClientType;
-
   constructor(
     private readonly contractService: ContractService,
     private readonly stellarService: StellarService,
     private readonly nonceService: NonceService,
-  ) {
-    this.redis = createClient({ url: process.env.REDIS_URL || 'redis://localhost:6379' });
-    this.redis.connect().catch(() => {});
-  }
+    private readonly redis: RedisService,
+    private readonly signingKeys: SigningKeyProvider,
+  ) {}
 
   async create(dto: CreateBondDto): Promise<BondResponse> {
     const adminSecret = this.getAdminSecret();
@@ -116,7 +114,7 @@ export class BondsService {
   }
 
   async subscribe(id: number, dto: SubscribeDto): Promise<SubscriptionResponse> {
-    const investorSecret = process.env.INVESTOR_SECRET_KEY || '';
+    const investorSecret = this.signingKeys.investorSecret();
     const nonce = await this.nonceService.next(BOND_ISSUER(), dto.investorAddress);
     const { transactionHash } = await this.contractService.invokeContractMethod(
       BOND_ISSUER(), 'subscribe', investorSecret,
@@ -181,7 +179,7 @@ export class BondsService {
   }
 
   async claimCredits(id: number, dto: ClaimCreditsDto): Promise<ClaimCreditsResponse> {
-    const investorSecret = process.env.INVESTOR_SECRET_KEY || '';
+    const investorSecret = this.signingKeys.investorSecret();
     const nonce = await this.nonceService.next(COUPON_ENGINE(), dto.investorAddress);
 
     const { result, transactionHash } = await this.contractService.invokeContractMethod(
@@ -202,7 +200,7 @@ export class BondsService {
   }
 
   async transfer(id: number, dto: TransferBondDto): Promise<TransferResponse> {
-    const investorSecret = process.env.INVESTOR_SECRET_KEY || '';
+    const investorSecret = this.signingKeys.investorSecret();
     const nonce = await this.nonceService.next(BOND_ISSUER(), dto.fromAddress);
 
     const { transactionHash } = await this.contractService.invokeContractMethod(
@@ -348,6 +346,6 @@ export class BondsService {
   }
 
   private getAdminSecret(): string {
-    return process.env.ADMIN_SECRET_KEY || '';
+    return this.signingKeys.adminSecret();
   }
 }

--- a/api/src/common/common.module.ts
+++ b/api/src/common/common.module.ts
@@ -1,9 +1,13 @@
 import { Global, Module } from '@nestjs/common';
 import { NonceService } from './services/nonce.service';
+import { RedisService } from './services/redis.service';
+import { SigningKeyProvider } from './services/signing-key.provider';
+import { RedisHealthController } from './redis-health.controller';
 
 @Global()
 @Module({
-  providers: [NonceService],
-  exports: [NonceService],
+  controllers: [RedisHealthController],
+  providers: [NonceService, RedisService, SigningKeyProvider],
+  exports: [NonceService, RedisService, SigningKeyProvider],
 })
 export class CommonModule {}

--- a/api/src/common/redis-health.controller.ts
+++ b/api/src/common/redis-health.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Get } from '@nestjs/common';
+import { RedisService } from './services/redis.service';
+
+@Controller('health')
+export class RedisHealthController {
+  constructor(private readonly redis: RedisService) {}
+
+  @Get('redis')
+  redisHealth() {
+    return {
+      redis: this.redis.isHealthy() ? 'up' : 'degraded',
+    };
+  }
+}

--- a/api/src/common/services/nonce.service.spec.ts
+++ b/api/src/common/services/nonce.service.spec.ts
@@ -1,0 +1,26 @@
+import { ServiceUnavailableException } from '@nestjs/common';
+import { NonceService } from './nonce.service';
+import { RedisService } from './redis.service';
+
+describe('NonceService', () => {
+  it('allocates contract-scoped nonces atomically through Redis', async () => {
+    const redis = {
+      incrOrThrow: jest.fn().mockResolvedValue(3),
+    } as unknown as RedisService;
+    const service = new NonceService(redis);
+
+    await expect(service.next('CDEX', 'GUSER')).resolves.toBe(2);
+    expect(redis.incrOrThrow).toHaveBeenCalledWith('nonce:CDEX:GUSER');
+  });
+
+  it('fails closed when Redis cannot allocate a nonce', async () => {
+    const redis = {
+      incrOrThrow: jest.fn().mockRejectedValue(new ServiceUnavailableException()),
+    } as unknown as RedisService;
+    const service = new NonceService(redis);
+
+    await expect(service.next('CDEX', 'GUSER')).rejects.toBeInstanceOf(
+      ServiceUnavailableException,
+    );
+  });
+});

--- a/api/src/common/services/nonce.service.ts
+++ b/api/src/common/services/nonce.service.ts
@@ -1,19 +1,9 @@
-import { Injectable, Logger } from '@nestjs/common';
-import { createClient, RedisClientType } from '@redis/client';
+import { Injectable } from '@nestjs/common';
+import { RedisService } from './redis.service';
 
 @Injectable()
 export class NonceService {
-  private readonly logger = new Logger(NonceService.name);
-  private readonly redis: RedisClientType;
-
-  constructor() {
-    this.redis = createClient({
-      url: process.env.REDIS_URL || 'redis://localhost:6379',
-    });
-    this.redis.connect().catch(() => {
-      this.logger.warn('Redis unavailable; nonce tracking disabled');
-    });
-  }
+  constructor(private readonly redis: RedisService) {}
 
   /**
    * Allocate the next valid nonce for an address scoped to a contract.
@@ -23,15 +13,7 @@ export class NonceService {
    */
   async next(contractAddress: string, address: string): Promise<number> {
     const key = `nonce:${contractAddress}:${address}`;
-    try {
-      const incremented = await this.redis.incr(key);
-      return incremented - 1;
-    } catch (error) {
-      this.logger.warn(
-        `Failed to allocate nonce for ${address}; falling back to timestamp`,
-        error,
-      );
-      return Math.floor(Date.now() / 1000);
-    }
+    const incremented = await this.redis.incrOrThrow(key);
+    return incremented - 1;
   }
 }

--- a/api/src/common/services/redis.service.ts
+++ b/api/src/common/services/redis.service.ts
@@ -1,0 +1,107 @@
+import { Injectable, Logger, ServiceUnavailableException } from '@nestjs/common';
+import { createClient, RedisClientType } from '@redis/client';
+
+@Injectable()
+export class RedisService {
+  private readonly logger = new Logger(RedisService.name);
+  private readonly redis: RedisClientType;
+  private healthy = false;
+
+  constructor() {
+    this.redis = createClient({
+      url: process.env.REDIS_URL || 'redis://localhost:6379',
+      socket: {
+        reconnectStrategy: (retries) => Math.min(1000 * 2 ** retries, 30_000),
+      },
+    });
+    this.redis.on('ready', () => {
+      this.healthy = true;
+      this.logger.log('Redis connection ready');
+    });
+    this.redis.on('end', () => {
+      this.healthy = false;
+      this.logger.warn('Redis connection closed');
+    });
+    this.redis.on('error', (error) => {
+      this.healthy = false;
+      this.logger.error(`Redis error: ${error.message}`);
+    });
+    this.redis.connect().catch((error) => {
+      this.healthy = false;
+      this.logger.error(`Redis connection failed: ${error.message}`);
+    });
+  }
+
+  isHealthy(): boolean {
+    return this.healthy;
+  }
+
+  async get(key: string): Promise<string | null> {
+    try {
+      return await this.redis.get(key);
+    } catch (error) {
+      this.logDegraded('get', key, error);
+      return null;
+    }
+  }
+
+  async set(key: string, value: string, options?: { EX?: number }): Promise<void> {
+    try {
+      await this.redis.set(key, value, options);
+    } catch (error) {
+      this.logDegraded('set', key, error);
+    }
+  }
+
+  async setEx(key: string, seconds: number, value: string): Promise<void> {
+    try {
+      await this.redis.setEx(key, seconds, value);
+    } catch (error) {
+      this.logDegraded('setEx', key, error);
+    }
+  }
+
+  async del(key: string): Promise<void> {
+    try {
+      await this.redis.del(key);
+    } catch (error) {
+      this.logDegraded('del', key, error);
+    }
+  }
+
+  async sAdd(key: string, value: string): Promise<void> {
+    try {
+      await this.redis.sAdd(key, value);
+    } catch (error) {
+      this.logDegraded('sAdd', key, error);
+    }
+  }
+
+  async sMembers(key: string): Promise<string[]> {
+    try {
+      return await this.redis.sMembers(key);
+    } catch (error) {
+      this.logDegraded('sMembers', key, error);
+      return [];
+    }
+  }
+
+  async incrOrThrow(key: string): Promise<number> {
+    try {
+      return await this.redis.incr(key);
+    } catch (error) {
+      this.healthy = false;
+      this.logger.error(`Redis incr failed for ${key}: ${this.message(error)}`);
+      throw new ServiceUnavailableException('Nonce tracking is unavailable');
+    }
+  }
+
+  private logDegraded(operation: string, key: string, error: unknown): void {
+    this.healthy = false;
+    this.logger.warn(`Redis ${operation} failed for ${key}; continuing without cache: ${this.message(error)}`);
+  }
+
+  private message(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+  }
+}

--- a/api/src/common/services/signing-key.provider.spec.ts
+++ b/api/src/common/services/signing-key.provider.spec.ts
@@ -1,0 +1,48 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { SigningKeyProvider } from './signing-key.provider';
+
+describe('SigningKeyProvider', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('loads signing keys from the default environment provider', () => {
+    process.env.ADMIN_SECRET_KEY = 'SADMIN';
+    process.env.INVESTOR_SECRET_KEY = 'SINVESTOR';
+
+    const provider = new SigningKeyProvider();
+
+    expect(provider.adminSecret()).toBe('SADMIN');
+    expect(provider.investorSecret()).toBe('SINVESTOR');
+  });
+
+  it('can be swapped to the local file provider without changing call sites', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'verdant-keys-'));
+    const file = join(dir, 'keys.json');
+    writeFileSync(
+      file,
+      JSON.stringify({
+        adminSecretKey: 'SFILEADMIN',
+        investorSecretKey: 'SFILEINVESTOR',
+      }),
+    );
+    process.env.SIGNING_KEY_PROVIDER = 'file';
+    process.env.SIGNING_KEY_FILE = file;
+
+    try {
+      const provider = new SigningKeyProvider();
+      expect(provider.adminSecret()).toBe('SFILEADMIN');
+      expect(provider.investorSecret()).toBe('SFILEINVESTOR');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/api/src/common/services/signing-key.provider.ts
+++ b/api/src/common/services/signing-key.provider.ts
@@ -1,0 +1,55 @@
+import { Injectable, InternalServerErrorException, Logger } from '@nestjs/common';
+import { readFileSync } from 'fs';
+
+type SigningKeyPurpose = 'admin' | 'investor' | 'user';
+
+interface SigningKeyFile {
+  adminSecretKey?: string;
+  investorSecretKey?: string;
+  userSecretKey?: string;
+}
+
+@Injectable()
+export class SigningKeyProvider {
+  private readonly logger = new Logger(SigningKeyProvider.name);
+  private readonly fileSecrets?: SigningKeyFile;
+
+  constructor() {
+    if (process.env.SIGNING_KEY_PROVIDER === 'file') {
+      const path = process.env.SIGNING_KEY_FILE;
+      if (!path) {
+        throw new InternalServerErrorException('SIGNING_KEY_FILE is required for file signing keys');
+      }
+      this.fileSecrets = JSON.parse(readFileSync(path, 'utf8')) as SigningKeyFile;
+      this.logger.warn('Loaded signing keys from local file provider; use KMS/HSM for production');
+    }
+  }
+
+  adminSecret(): string {
+    return this.getSecret('admin', 'ADMIN_SECRET_KEY', 'adminSecretKey');
+  }
+
+  investorSecret(): string {
+    return this.getSecret('investor', 'INVESTOR_SECRET_KEY', 'investorSecretKey');
+  }
+
+  userSecret(): string {
+    return this.getSecret('user', 'USER_SECRET_KEY', 'userSecretKey');
+  }
+
+  private getSecret(
+    purpose: SigningKeyPurpose,
+    envName: string,
+    fileName: keyof SigningKeyFile,
+  ): string {
+    const value =
+      process.env.SIGNING_KEY_PROVIDER === 'file'
+        ? this.fileSecrets?.[fileName]
+        : process.env[envName];
+
+    if (!value) {
+      throw new InternalServerErrorException(`Missing ${purpose} signing key`);
+    }
+    return value;
+  }
+}

--- a/api/src/marketplace/dex.service.spec.ts
+++ b/api/src/marketplace/dex.service.spec.ts
@@ -1,14 +1,17 @@
 import { Test } from '@nestjs/testing';
-import { nativeToScVal } from '@stellar/stellar-sdk';
+import { nativeToScVal, scValToNative, xdr } from '@stellar/stellar-sdk';
 import { DexService } from './dex.service';
 import { ContractService } from '../stellar/contract.service';
 import { StellarService } from '../stellar/stellar.service';
 import { NonceService } from '../common/services/nonce.service';
+import { RedisService } from '../common/services/redis.service';
+import { SigningKeyProvider } from '../common/services/signing-key.provider';
 import { OrderStatus } from './interfaces/marketplace.interface';
 
 describe('DexService', () => {
   let service: DexService;
   let contractService: { simulateCall: jest.Mock; invokeContractMethod: jest.Mock };
+  let redis: { get: jest.Mock; setEx: jest.Mock; del: jest.Mock };
 
   const simulateCallMock = jest.fn();
   const invokeContractMethodMock = jest.fn();
@@ -17,6 +20,11 @@ describe('DexService', () => {
     contractService = {
       simulateCall: simulateCallMock,
       invokeContractMethod: invokeContractMethodMock,
+    };
+    redis = {
+      get: jest.fn().mockResolvedValue(null),
+      setEx: jest.fn().mockResolvedValue(undefined),
+      del: jest.fn().mockResolvedValue(undefined),
     };
 
     const moduleRef = await Test.createTestingModule({
@@ -28,6 +36,11 @@ describe('DexService', () => {
           provide: NonceService,
           useValue: { next: jest.fn().mockResolvedValue(0) },
         },
+        { provide: RedisService, useValue: redis },
+        {
+          provide: SigningKeyProvider,
+          useValue: { adminSecret: jest.fn().mockReturnValue('SADMIN') },
+        },
       ],
     }).compile();
 
@@ -36,6 +49,44 @@ describe('DexService', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    redis.get.mockResolvedValue(null);
+  });
+
+  describe('listOrders', () => {
+    const SELLER = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+    const rawOrder = (id: number, bondId = 3) =>
+      xdr.ScVal.scvVec([
+        nativeToScVal(BigInt(id), { type: 'u64' }),
+        nativeToScVal(SELLER, { type: 'address' }),
+        nativeToScVal(BigInt(bondId), { type: 'u64' }),
+        nativeToScVal(BigInt(1000), { type: 'i128' }),
+        nativeToScVal(BigInt(25), { type: 'i128' }),
+        nativeToScVal('USDC', { type: 'symbol' }),
+        xdr.ScVal.scvU32(0),
+        nativeToScVal(BigInt(1700000000), { type: 'u64' }),
+        nativeToScVal(BigInt(1700604800), { type: 'u64' }),
+      ]);
+
+    it('does not truncate listings when an intermediate order id is missing', async () => {
+      simulateCallMock.mockImplementation(({ method, args }) => {
+        if (method === 'order_count') {
+          return Promise.resolve(nativeToScVal(BigInt(4), { type: 'u64' }));
+        }
+        const id = Number(scValToNative(args[0]));
+        if (id === 3) {
+          return Promise.reject(new Error('OrderNotFound'));
+        }
+        return Promise.resolve(rawOrder(id));
+      });
+
+      const result = await service.listOrders(undefined, undefined, 1, 10);
+
+      expect(result.data.map((order) => order.id)).toEqual([1, 2, 4]);
+      expect(result.meta.total).toBe(3);
+      expect(simulateCallMock).toHaveBeenCalledWith(
+        expect.objectContaining({ method: 'order_count' }),
+      );
+    });
   });
 
   describe('decodeOrder', () => {

--- a/api/src/marketplace/dex.service.ts
+++ b/api/src/marketplace/dex.service.ts
@@ -7,6 +7,8 @@ import {
 import { ContractService } from '../stellar/contract.service';
 import { StellarService } from '../stellar/stellar.service';
 import { NonceService } from '../common/services/nonce.service';
+import { RedisService } from '../common/services/redis.service';
+import { SigningKeyProvider } from '../common/services/signing-key.provider';
 import { ListBondDto } from './dto/list-bond.dto';
 import { BuyBondDto } from './dto/buy-bond.dto';
 import { DepositQuoteDto } from './dto/deposit-quote.dto';
@@ -18,7 +20,6 @@ import {
   QuoteBalanceResponse,
   QuoteTransactionResponse,
 } from './interfaces/marketplace.interface';
-import { createClient, RedisClientType } from '@redis/client';
 import { nativeToScVal, scValToNative, Address } from '@stellar/stellar-sdk';
 import { PaginatedResponse } from '../common/dto/pagination.dto';
 
@@ -40,16 +41,13 @@ const DEX_ERROR_CODE = {
 
 @Injectable()
 export class DexService {
-  private redis: RedisClientType;
-
   constructor(
     private readonly contractService: ContractService,
     private readonly stellarService: StellarService,
     private readonly nonceService: NonceService,
-  ) {
-    this.redis = createClient({ url: process.env.REDIS_URL || 'redis://localhost:6379' });
-    this.redis.connect().catch(() => {});
-  }
+    private readonly redis: RedisService,
+    private readonly signingKeys: SigningKeyProvider,
+  ) {}
 
   async listOrders(
     bondId?: number,
@@ -61,40 +59,23 @@ export class DexService {
     const cached = await this.redis.get(cacheKey);
     if (cached) return JSON.parse(cached);
 
-    const orders: OrderResponse[] = [];
-    let index = 1;
-
-    while (true) {
-      try {
-        const orderScVal = await this.contractService.simulateCall({
-          contractAddress: DEX_ROUTER(),
-          method: 'get_order',
-          args: [nativeToScVal(BigInt(index), { type: 'u64' })],
-        });
-        const order = this.decodeOrder(scValToNative(orderScVal) as any[]);
-
-        if (bondId && order.bondId !== bondId) {
-          index++;
-          continue;
-        }
-        if (status && order.status !== status) {
-          index++;
-          continue;
-        }
-
-        orders.push(order);
-        index++;
-      } catch {
-        break;
-      }
-    }
-
+    const total = await this.getOrderCount();
+    const ids = Array.from({ length: total }, (_unused, idx) => idx + 1);
+    const matchingOrders = (await Promise.all(ids.map((id) => this.tryGetOrder(id))))
+      .filter((order): order is OrderResponse => Boolean(order))
+      .filter((order) => !bondId || order.bondId === bondId)
+      .filter((order) => !status || order.status === status);
     const start = (page - 1) * limit;
-    const paged = orders.slice(start, start + limit);
+    const paged = matchingOrders.slice(start, start + limit);
 
     const result = {
       data: paged,
-      meta: { page, limit, total: orders.length, totalPages: Math.ceil(orders.length / limit) || 1 },
+      meta: {
+        page,
+        limit,
+        total: matchingOrders.length,
+        totalPages: Math.ceil(matchingOrders.length / limit) || 1,
+      },
     };
 
     await this.redis.setEx(cacheKey, 30, JSON.stringify(result));
@@ -271,7 +252,29 @@ export class DexService {
   }
 
   private getAdminSecret(): string {
-    return process.env.ADMIN_SECRET_KEY || '';
+    return this.signingKeys.adminSecret();
+  }
+
+  private async getOrderCount(): Promise<number> {
+    const countScVal = await this.contractService.simulateCall({
+      contractAddress: DEX_ROUTER(),
+      method: 'order_count',
+      args: [],
+    });
+    return Number(scValToNative(countScVal));
+  }
+
+  private async tryGetOrder(id: number): Promise<OrderResponse | null> {
+    try {
+      const orderScVal = await this.contractService.simulateCall({
+        contractAddress: DEX_ROUTER(),
+        method: 'get_order',
+        args: [nativeToScVal(BigInt(id), { type: 'u64' })],
+      });
+      return this.decodeOrder(scValToNative(orderScVal) as any[]);
+    } catch {
+      return null;
+    }
   }
 
   private mapDexError(error: unknown): Error {

--- a/api/src/marketplace/liquidity.service.ts
+++ b/api/src/marketplace/liquidity.service.ts
@@ -6,18 +6,14 @@ import {
   SlippageResponse,
   OrderStatus,
 } from './interfaces/marketplace.interface';
-import { createClient, RedisClientType } from '@redis/client';
+import { RedisService } from '../common/services/redis.service';
 
 @Injectable()
 export class LiquidityService {
-  private redis: RedisClientType;
-
   constructor(
     private readonly dexService: DexService,
-  ) {
-    this.redis = createClient({ url: process.env.REDIS_URL || 'redis://localhost:6379' });
-    this.redis.connect().catch(() => {});
-  }
+    private readonly redis: RedisService,
+  ) {}
 
   async getPriceFeed(bondId?: number): Promise<PriceFeedResponse[]> {
     const cacheKey = `pricefeed:${bondId || 'all'}`;

--- a/api/src/oracle/oracle.monitoring.service.ts
+++ b/api/src/oracle/oracle.monitoring.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { createClient, RedisClientType } from '@redis/client';
+import { RedisService } from '../common/services/redis.service';
 import { ProjectsService } from '../projects/projects.service';
 import { OracleService } from './oracle.service';
 import {
@@ -37,15 +37,12 @@ function graceSeconds(): number {
 @Injectable()
 export class OracleMonitoringService {
   private readonly logger = new Logger(OracleMonitoringService.name);
-  private redis: RedisClientType;
 
   constructor(
     private readonly projectsService: ProjectsService,
     private readonly oracleService: OracleService,
-  ) {
-    this.redis = createClient({ url: process.env.REDIS_URL || 'redis://localhost:6379' });
-    this.redis.connect().catch(() => {});
-  }
+    private readonly redis: RedisService,
+  ) {}
 
   async computeStaleness(now: number = Date.now()): Promise<OracleStalenessReport> {
     const projects = await this.projectsService.findAll(1, 1000);

--- a/api/src/oracle/oracle.service.ts
+++ b/api/src/oracle/oracle.service.ts
@@ -15,7 +15,8 @@ import {
   ChallengeRecord,
   ReportStatus,
 } from './interfaces/oracle.interface';
-import { createClient, RedisClientType } from '@redis/client';
+import { RedisService } from '../common/services/redis.service';
+import { SigningKeyProvider } from '../common/services/signing-key.provider';
 import { nativeToScVal, scValToNative, Address, xdr } from '@stellar/stellar-sdk';
 import { StellarService } from '../stellar/stellar.service';
 
@@ -23,17 +24,14 @@ const ORACLE_CONSUMER = () => process.env.ORACLE_CONSUMER_ADDRESS || '';
 
 @Injectable()
 export class OracleService {
-  private redis: RedisClientType;
-
   constructor(
     private readonly contractService: ContractService,
     private readonly ipfsService: IpfsService,
     private readonly stellarService: StellarService,
     private readonly nonceService: NonceService,
-  ) {
-    this.redis = createClient({ url: process.env.REDIS_URL || 'redis://localhost:6379' });
-    this.redis.connect().catch(() => {});
-  }
+    private readonly redis: RedisService,
+    private readonly signingKeys: SigningKeyProvider,
+  ) {}
 
   async submitReport(dto: SubmitReportDto, providerAddress: string): Promise<ReportResponse> {
     const ipfsResult = await this.ipfsService.uploadJson({
@@ -331,6 +329,6 @@ export class OracleService {
   }
 
   private getAdminSecret(): string {
-    return process.env.ADMIN_SECRET_KEY || '';
+    return this.signingKeys.adminSecret();
   }
 }

--- a/api/src/projects/projects.service.ts
+++ b/api/src/projects/projects.service.ts
@@ -3,8 +3,9 @@ import { ContractService } from '../stellar/contract.service';
 import { StellarService } from '../stellar/stellar.service';
 import { IpfsService } from './ipfs.service';
 import { NonceService } from '../common/services/nonce.service';
+import { RedisService } from '../common/services/redis.service';
+import { SigningKeyProvider } from '../common/services/signing-key.provider';
 import { nativeToScVal, scValToNative, Address } from '@stellar/stellar-sdk';
-import { createClient, RedisClientType } from '@redis/client';
 import { CreateProjectDto } from './dto/create-project.dto';
 import { ProjectResponse, ProjectStatusEnum, DocumentUploadResponse } from './interfaces/project.interface';
 
@@ -12,17 +13,14 @@ const PROJECT_REGISTRY = () => process.env.PROJECT_REGISTRY_ADDRESS || '';
 
 @Injectable()
 export class ProjectsService {
-  private redis: RedisClientType;
-
   constructor(
     private readonly contractService: ContractService,
     private readonly stellarService: StellarService,
     private readonly ipfsService: IpfsService,
     private readonly nonceService: NonceService,
-  ) {
-    this.redis = createClient({ url: process.env.REDIS_URL || 'redis://localhost:6379' });
-    this.redis.connect().catch(() => {});
-  }
+    private readonly redis: RedisService,
+    private readonly signingKeys: SigningKeyProvider,
+  ) {}
 
   async register(dto: CreateProjectDto, ownerAddress: string): Promise<ProjectResponse> {
     const metadata = {
@@ -41,7 +39,7 @@ export class ProjectsService {
     const ipfsResult = await this.ipfsService.uploadJson(metadata);
     const ipfsHash = Buffer.from(ipfsResult.hash, 'hex');
 
-    const ownerSecret = process.env.USER_SECRET_KEY || '';
+    const ownerSecret = this.signingKeys.userSecret();
     const nonce = await this.nonceService.next(PROJECT_REGISTRY(), ownerAddress);
 
     const { result } = await this.contractService.invokeContractMethod(
@@ -182,6 +180,6 @@ export class ProjectsService {
   }
 
   private getAdminSecret(): string {
-    return process.env.ADMIN_SECRET_KEY || '';
+    return this.signingKeys.adminSecret();
   }
 }

--- a/contracts/oracle-consumer/src/lib.rs
+++ b/contracts/oracle-consumer/src/lib.rs
@@ -1,10 +1,12 @@
 #![no_std]
 #![allow(deprecated)]
-use soroban_sdk::{contract, contractimpl, contracttype, vec, Address, BytesN, Env, Symbol, Vec};
 use nbbs_shared::{BiodiversityMetrics, OracleError, ReportStatus};
+use soroban_sdk::{contract, contractimpl, contracttype, vec, Address, BytesN, Env, Symbol, Vec};
 
 pub const CHALLENGE_WINDOW_SECONDS: u64 = 259200;
 pub const SLASH_PENALTY_PPM: i128 = 100_000;
+pub const DEFAULT_SIGNATURE_THRESHOLD: u32 = 2;
+pub const DEFAULT_MIN_VERIFIER_STAKE: i128 = 10_000;
 
 #[derive(Clone)]
 #[contracttype]
@@ -19,6 +21,7 @@ pub enum DataKey {
     ReportVerifiers(u64),
     VerificationCount(u64),
     SignatureThreshold,
+    MinimumVerifierStake,
     ChallengeWindow,
     Nonce(Address),
     ProviderReportCount(Address),
@@ -123,7 +126,10 @@ impl OracleConsumer {
             .set(&DataKey::ChallengeWindow, &CHALLENGE_WINDOW_SECONDS);
         env.storage()
             .instance()
-            .set(&DataKey::SignatureThreshold, &1u32);
+            .set(&DataKey::SignatureThreshold, &DEFAULT_SIGNATURE_THRESHOLD);
+        env.storage()
+            .instance()
+            .set(&DataKey::MinimumVerifierStake, &DEFAULT_MIN_VERIFIER_STAKE);
     }
 
     pub fn register_provider(
@@ -173,10 +179,8 @@ impl OracleConsumer {
             .instance()
             .set(&DataKey::ProviderList, &providers);
 
-        env.events().publish(
-            (Symbol::new(&env, "provider_registered"),),
-            (provider,),
-        );
+        env.events()
+            .publish((Symbol::new(&env, "provider_registered"),), (provider,));
 
         Ok(())
     }
@@ -208,10 +212,8 @@ impl OracleConsumer {
             .instance()
             .set(&DataKey::Provider(provider.clone()), &p);
 
-        env.events().publish(
-            (Symbol::new(&env, "provider_removed"),),
-            (provider,),
-        );
+        env.events()
+            .publish((Symbol::new(&env, "provider_removed"),), (provider,));
 
         Ok(())
     }
@@ -292,18 +294,20 @@ impl OracleConsumer {
             .get(&DataKey::ProjectReports(project_id.clone()))
             .unwrap_or(vec![&env]);
         project_reports.push_back(report_id);
-        env.storage()
-            .instance()
-            .set(&DataKey::ProjectReports(project_id.clone()), &project_reports);
+        env.storage().instance().set(
+            &DataKey::ProjectReports(project_id.clone()),
+            &project_reports,
+        );
 
         let report_count: u64 = env
             .storage()
             .instance()
             .get(&DataKey::ProviderReportCount(provider.clone()))
             .unwrap_or(0);
-        env.storage()
-            .instance()
-            .set(&DataKey::ProviderReportCount(provider.clone()), &(report_count + 1));
+        env.storage().instance().set(
+            &DataKey::ProviderReportCount(provider.clone()),
+            &(report_count + 1),
+        );
 
         env.events().publish(
             (Symbol::new(&env, "report_submitted"),),
@@ -328,7 +332,7 @@ impl OracleConsumer {
                 .instance()
                 .get(&DataKey::Provider(caller.clone()))
                 .ok_or(OracleError::Unauthorized)?;
-            if !p.active {
+            if !p.active || p.stake < minimum_verifier_stake(&env) {
                 return Err(OracleError::Unauthorized);
             }
         }
@@ -349,11 +353,7 @@ impl OracleConsumer {
             return Err(OracleError::ReportAlreadyVerified);
         }
 
-        if env
-            .storage()
-            .instance()
-            .has(&DataKey::Challenge(report_id))
-        {
+        if env.storage().instance().has(&DataKey::Challenge(report_id)) {
             return Err(OracleError::ReportAlreadyVerified);
         }
 
@@ -378,31 +378,28 @@ impl OracleConsumer {
 
         if !already_verified {
             verifiers.push_back(caller.clone());
-            env.storage()
-                .instance()
-                .set(&verifiers_key, &verifiers);
-            env.storage()
-                .instance()
-                .set(&DataKey::VerificationCount(report_id), &verifiers.len());
+            env.storage().instance().set(&verifiers_key, &verifiers);
+            env.storage().instance().set(
+                &DataKey::VerificationCount(report_id),
+                &qualifying_verifier_count(&env, &verifiers),
+            );
         }
 
         let threshold: u32 = env
             .storage()
             .instance()
             .get(&DataKey::SignatureThreshold)
-            .unwrap_or(1);
+            .unwrap_or(DEFAULT_SIGNATURE_THRESHOLD);
 
-        if verifiers.len() >= threshold {
+        if qualifying_verifier_count(&env, &verifiers) >= threshold {
             report.status = ReportStatus::Verified;
             report.verified_at = env.ledger().timestamp();
             env.storage()
                 .instance()
                 .set(&DataKey::Report(report_id), &report);
 
-            env.events().publish(
-                (Symbol::new(&env, "report_verified"),),
-                (report_id,),
-            );
+            env.events()
+                .publish((Symbol::new(&env, "report_verified"),), (report_id,));
         }
 
         Ok(())
@@ -443,11 +440,7 @@ impl OracleConsumer {
             return Err(OracleError::ChallengeWindowExpired);
         }
 
-        if env
-            .storage()
-            .instance()
-            .has(&DataKey::Challenge(report_id))
-        {
+        if env.storage().instance().has(&DataKey::Challenge(report_id)) {
             return Err(OracleError::ProviderAlreadyExists);
         }
 
@@ -479,9 +472,10 @@ impl OracleConsumer {
             .get(&DataKey::ProviderChallenges(report.provider.clone()))
             .unwrap_or(vec![&env]);
         provider_challenges.push_back(report_id);
-        env.storage()
-            .instance()
-            .set(&DataKey::ProviderChallenges(report.provider.clone()), &provider_challenges);
+        env.storage().instance().set(
+            &DataKey::ProviderChallenges(report.provider.clone()),
+            &provider_challenges,
+        );
 
         env.events().publish(
             (Symbol::new(&env, "report_challenged"),),
@@ -542,10 +536,8 @@ impl OracleConsumer {
             slash_provider(&env, &report.provider, report_id);
         }
 
-        env.events().publish(
-            (Symbol::new(&env, "challenge_resolved"),),
-            (report_id,),
-        );
+        env.events()
+            .publish((Symbol::new(&env, "challenge_resolved"),), (report_id,));
 
         Ok(())
     }
@@ -689,7 +681,37 @@ impl OracleConsumer {
         env.storage()
             .instance()
             .get(&DataKey::SignatureThreshold)
-            .unwrap_or(1)
+            .unwrap_or(DEFAULT_SIGNATURE_THRESHOLD)
+    }
+
+    pub fn set_minimum_verifier_stake(
+        env: Env,
+        caller: Address,
+        stake: i128,
+        nonce: u64,
+    ) -> Result<(), OracleError> {
+        caller.require_auth();
+
+        let expected_nonce = get_nonce(&env, &caller);
+        if nonce != expected_nonce {
+            return Err(OracleError::InvalidNonce);
+        }
+        set_nonce(&env, &caller, expected_nonce + 1);
+
+        require_admin(&env, &caller)?;
+        if stake < 0 {
+            return Err(OracleError::InsufficientStake);
+        }
+
+        env.storage()
+            .instance()
+            .set(&DataKey::MinimumVerifierStake, &stake);
+
+        Ok(())
+    }
+
+    pub fn get_minimum_verifier_stake(env: Env) -> i128 {
+        minimum_verifier_stake(&env)
     }
 
     pub fn add_stake(
@@ -716,15 +738,16 @@ impl OracleConsumer {
             .get(&DataKey::Provider(provider.clone()))
             .ok_or(OracleError::ProviderNotFound)?;
 
-        p.stake = p.stake.checked_add(amount).ok_or(OracleError::InsufficientStake)?;
+        p.stake = p
+            .stake
+            .checked_add(amount)
+            .ok_or(OracleError::InsufficientStake)?;
         env.storage()
             .instance()
             .set(&DataKey::Provider(provider.clone()), &p);
 
-        env.events().publish(
-            (Symbol::new(&env, "stake_added"),),
-            (provider, amount),
-        );
+        env.events()
+            .publish((Symbol::new(&env, "stake_added"),), (provider, amount));
 
         Ok(())
     }
@@ -761,13 +784,43 @@ impl OracleConsumer {
             .instance()
             .set(&DataKey::Provider(provider.clone()), &p);
 
-        env.events().publish(
-            (Symbol::new(&env, "stake_withdrawn"),),
-            (provider, amount),
-        );
+        env.events()
+            .publish((Symbol::new(&env, "stake_withdrawn"),), (provider, amount));
 
         Ok(())
     }
+}
+
+fn minimum_verifier_stake(env: &Env) -> i128 {
+    env.storage()
+        .instance()
+        .get(&DataKey::MinimumVerifierStake)
+        .unwrap_or(DEFAULT_MIN_VERIFIER_STAKE)
+}
+
+fn qualifying_verifier_count(env: &Env, verifiers: &Vec<Address>) -> u32 {
+    let admin: Option<Address> = env.storage().instance().get(&DataKey::Admin);
+    let minimum_stake = minimum_verifier_stake(env);
+    let mut count = 0u32;
+
+    for verifier in verifiers.iter() {
+        if admin.as_ref() == Some(&verifier) {
+            count += 1;
+            continue;
+        }
+
+        if let Some(provider) = env
+            .storage()
+            .instance()
+            .get::<DataKey, OracleProvider>(&DataKey::Provider(verifier.clone()))
+        {
+            if provider.active && provider.stake >= minimum_stake {
+                count += 1;
+            }
+        }
+    }
+
+    count
 }
 
 fn slash_provider(env: &Env, provider: &Address, report_id: u64) {
@@ -849,6 +902,7 @@ mod test {
 
         env.ledger().set_timestamp(1_000_000);
         client.register_provider(&admin, &provider, &Symbol::new(&env, "verra_vcs"), &0);
+        client.set_signature_threshold(&admin, &1u32, &1);
 
         let report_id = client.submit_report(
             &provider,
@@ -869,7 +923,7 @@ mod test {
         assert_eq!(stored.carbon_sequestered, 100_000);
 
         env.ledger().set_timestamp(1_000_001);
-        client.verify_report(&admin, &report_id, &1);
+        client.verify_report(&admin, &report_id, &2);
 
         let verified = client.get_report(&report_id);
         assert_eq!(verified.status, ReportStatus::Verified);
@@ -960,6 +1014,7 @@ mod test {
         let client = OracleConsumerClient::new(&env, &contract_id);
 
         client.register_provider(&admin, &provider, &Symbol::new(&env, "verra_vcs"), &0);
+        client.set_signature_threshold(&admin, &1u32, &1);
 
         let report_id = client.submit_report(
             &provider,
@@ -973,12 +1028,7 @@ mod test {
             &0,
         );
 
-        client.challenge_report(
-            &challenger,
-            &report_id,
-            &make_ipfs_hash(&env, 2),
-            &0,
-        );
+        client.challenge_report(&challenger, &report_id, &make_ipfs_hash(&env, 2), &0);
 
         let challenged = client.get_report(&report_id);
         assert_eq!(challenged.status, ReportStatus::Challenged);
@@ -988,12 +1038,7 @@ mod test {
         assert_eq!(challenge.challenger, challenger);
         assert!(!challenge.resolved);
 
-        client.resolve_challenge(
-            &admin,
-            &report_id,
-            &ReportStatus::Verified,
-            &1,
-        );
+        client.resolve_challenge(&admin, &report_id, &ReportStatus::Verified, &1);
 
         let resolved = client.get_report(&report_id);
         assert_eq!(resolved.status, ReportStatus::Verified);
@@ -1032,14 +1077,11 @@ mod test {
             &0,
         );
 
-        env.ledger().set_timestamp(1_000_000 + CHALLENGE_WINDOW_SECONDS + 1);
+        env.ledger()
+            .set_timestamp(1_000_000 + CHALLENGE_WINDOW_SECONDS + 1);
 
-        let result = client.try_challenge_report(
-            &challenger,
-            &report_id,
-            &make_ipfs_hash(&env, 2),
-            &0,
-        );
+        let result =
+            client.try_challenge_report(&challenger, &report_id, &make_ipfs_hash(&env, 2), &0);
         assert_eq!(result, Err(Ok(OracleError::ChallengeWindowExpired)));
     }
 
@@ -1073,12 +1115,7 @@ mod test {
 
         env.ledger().set_timestamp(900_000);
 
-        client.challenge_report(
-            &challenger,
-            &report_id,
-            &make_ipfs_hash(&env, 2),
-            &0,
-        );
+        client.challenge_report(&challenger, &report_id, &make_ipfs_hash(&env, 2), &0);
 
         let challenged = client.get_report(&report_id);
         assert_eq!(challenged.status, ReportStatus::Challenged);
@@ -1123,12 +1160,8 @@ mod test {
 
         client.register_provider(&admin, &provider, &Symbol::new(&env, "verra_vcs"), &0);
 
-        let result = client.try_register_provider(
-            &admin,
-            &provider,
-            &Symbol::new(&env, "verra_vcs"),
-            &1,
-        );
+        let result =
+            client.try_register_provider(&admin, &provider, &Symbol::new(&env, "verra_vcs"), &1);
         assert_eq!(result, Err(Ok(OracleError::ProviderAlreadyExists)));
     }
 
@@ -1158,7 +1191,7 @@ mod test {
             &0,
         );
 
-        client.verify_report(&admin, &report_id, &1);
+        client.verify_report(&admin, &report_id, &2);
 
         let result = client.try_verify_report(&provider, &report_id, &1);
         assert_eq!(result, Err(Ok(OracleError::ReportAlreadyVerified)));
@@ -1178,6 +1211,7 @@ mod test {
         let client = OracleConsumerClient::new(&env, &contract_id);
 
         client.register_provider(&admin, &provider, &Symbol::new(&env, "verra_vcs"), &0);
+        client.set_signature_threshold(&admin, &1u32, &1);
 
         let report_id = client.submit_report(
             &provider,
@@ -1191,14 +1225,10 @@ mod test {
             &0,
         );
 
-        client.verify_report(&admin, &report_id, &1);
+        client.verify_report(&admin, &report_id, &2);
 
-        let result = client.try_challenge_report(
-            &challenger,
-            &report_id,
-            &make_ipfs_hash(&env, 2),
-            &0,
-        );
+        let result =
+            client.try_challenge_report(&challenger, &report_id, &make_ipfs_hash(&env, 2), &0);
         assert_eq!(result, Err(Ok(OracleError::ReportAlreadyVerified)));
     }
 
@@ -1251,6 +1281,8 @@ mod test {
 
         client.register_provider(&admin, &provider_a, &Symbol::new(&env, "verra_vcs"), &0);
         client.register_provider(&admin, &provider_b, &Symbol::new(&env, "satellite"), &1);
+        client.set_signature_threshold(&admin, &1u32, &2);
+        client.add_stake(&provider_b, &DEFAULT_MIN_VERIFIER_STAKE, &0);
 
         let report_id = client.submit_report(
             &provider_a,
@@ -1264,7 +1296,7 @@ mod test {
             &0,
         );
 
-        client.verify_report(&provider_b, &report_id, &0);
+        client.verify_report(&provider_b, &report_id, &1);
 
         let report = client.get_report(&report_id);
         assert_eq!(report.status, ReportStatus::Verified);
@@ -1326,19 +1358,9 @@ mod test {
             &0,
         );
 
-        client.challenge_report(
-            &challenger,
-            &report_id,
-            &make_ipfs_hash(&env, 2),
-            &0,
-        );
+        client.challenge_report(&challenger, &report_id, &make_ipfs_hash(&env, 2), &0);
 
-        client.resolve_challenge(
-            &admin,
-            &report_id,
-            &ReportStatus::Rejected,
-            &1,
-        );
+        client.resolve_challenge(&admin, &report_id, &ReportStatus::Rejected, &1);
 
         let report = client.get_report(&report_id);
         assert_eq!(report.status, ReportStatus::Rejected);
@@ -1371,26 +1393,11 @@ mod test {
             &0,
         );
 
-        client.challenge_report(
-            &challenger,
-            &report_id,
-            &make_ipfs_hash(&env, 2),
-            &0,
-        );
+        client.challenge_report(&challenger, &report_id, &make_ipfs_hash(&env, 2), &0);
 
-        client.resolve_challenge(
-            &admin,
-            &report_id,
-            &ReportStatus::Verified,
-            &1,
-        );
+        client.resolve_challenge(&admin, &report_id, &ReportStatus::Verified, &1);
 
-        let result = client.try_resolve_challenge(
-            &admin,
-            &report_id,
-            &ReportStatus::Rejected,
-            &2,
-        );
+        let result = client.try_resolve_challenge(&admin, &report_id, &ReportStatus::Rejected, &2);
         assert_eq!(result, Ok(Ok(())));
     }
 
@@ -1421,12 +1428,7 @@ mod test {
             &0,
         );
 
-        client.challenge_report(
-            &challenger,
-            &report_id,
-            &make_ipfs_hash(&env, 2),
-            &0,
-        );
+        client.challenge_report(&challenger, &report_id, &make_ipfs_hash(&env, 2), &0);
 
         for invalid in [ReportStatus::Pending, ReportStatus::Challenged] {
             let result = client.try_resolve_challenge(&admin, &report_id, &invalid, &1);
@@ -1564,19 +1566,9 @@ mod test {
             &1,
         );
 
-        client.challenge_report(
-            &challenger,
-            &report_id,
-            &make_ipfs_hash(&env, 2),
-            &0,
-        );
+        client.challenge_report(&challenger, &report_id, &make_ipfs_hash(&env, 2), &0);
 
-        client.resolve_challenge(
-            &admin,
-            &report_id,
-            &ReportStatus::Rejected,
-            &1,
-        );
+        client.resolve_challenge(&admin, &report_id, &ReportStatus::Rejected, &1);
 
         let slashed = client.get_provider(&provider);
         assert_eq!(slashed.stake, 100_000 - 10_000);
@@ -1614,19 +1606,9 @@ mod test {
             &1,
         );
 
-        client.challenge_report(
-            &challenger,
-            &report_id,
-            &make_ipfs_hash(&env, 2),
-            &0,
-        );
+        client.challenge_report(&challenger, &report_id, &make_ipfs_hash(&env, 2), &0);
 
-        client.resolve_challenge(
-            &admin,
-            &report_id,
-            &ReportStatus::Rejected,
-            &1,
-        );
+        client.resolve_challenge(&admin, &report_id, &ReportStatus::Rejected, &1);
 
         let slashed = client.get_provider(&provider);
         assert_eq!(slashed.stake, 0);
@@ -1661,19 +1643,9 @@ mod test {
             &1,
         );
 
-        client.challenge_report(
-            &challenger,
-            &report_id,
-            &make_ipfs_hash(&env, 2),
-            &0,
-        );
+        client.challenge_report(&challenger, &report_id, &make_ipfs_hash(&env, 2), &0);
 
-        client.resolve_challenge(
-            &admin,
-            &report_id,
-            &ReportStatus::Verified,
-            &1,
-        );
+        client.resolve_challenge(&admin, &report_id, &ReportStatus::Verified, &1);
 
         let provider_state = client.get_provider(&provider);
         assert_eq!(provider_state.stake, 100_000);
@@ -1719,19 +1691,9 @@ mod test {
             &2,
         );
 
-        client.challenge_report(
-            &challenger,
-            &report_id,
-            &make_ipfs_hash(&env, 2),
-            &0,
-        );
+        client.challenge_report(&challenger, &report_id, &make_ipfs_hash(&env, 2), &0);
 
-        client.resolve_challenge(
-            &admin,
-            &report_id,
-            &ReportStatus::Rejected,
-            &1,
-        );
+        client.resolve_challenge(&admin, &report_id, &ReportStatus::Rejected, &1);
 
         let stats = client.get_provider_stats(&provider);
         assert_eq!(stats.reports_submitted, 2);
@@ -1807,7 +1769,12 @@ mod test {
         provider_nonce: u64,
         admin_nonce: u64,
     ) -> u64 {
-        client.register_provider(admin, provider, &Symbol::new(env, "verra_vcs"), &admin_nonce);
+        client.register_provider(
+            admin,
+            provider,
+            &Symbol::new(env, "verra_vcs"),
+            &admin_nonce,
+        );
         client.submit_report(
             provider,
             project_id,
@@ -1840,6 +1807,8 @@ mod test {
         client.register_provider(&admin, &provider_a, &Symbol::new(&env, "verra_vcs"), &1);
         client.register_provider(&admin, &provider_b, &Symbol::new(&env, "satellite"), &2);
         client.register_provider(&admin, &provider_c, &Symbol::new(&env, "iot"), &3);
+        client.add_stake(&provider_b, &DEFAULT_MIN_VERIFIER_STAKE, &0);
+        client.add_stake(&provider_c, &DEFAULT_MIN_VERIFIER_STAKE, &0);
 
         let report_id = client.submit_report(
             &provider_a,
@@ -1853,13 +1822,13 @@ mod test {
             &0,
         );
 
-        client.verify_report(&provider_b, &report_id, &0);
+        client.verify_report(&provider_b, &report_id, &1);
         assert_eq!(client.get_verification_count(&report_id), 1);
 
         let report = client.get_report(&report_id);
         assert_eq!(report.status, ReportStatus::Pending);
 
-        client.verify_report(&provider_c, &report_id, &0);
+        client.verify_report(&provider_c, &report_id, &1);
         assert_eq!(client.get_verification_count(&report_id), 2);
 
         let report = client.get_report(&report_id);
@@ -1869,6 +1838,50 @@ mod test {
         assert_eq!(verifiers.len(), 2);
         assert_eq!(verifiers.get(0).unwrap(), provider_b);
         assert_eq!(verifiers.get(1).unwrap(), provider_c);
+    }
+
+    #[test]
+    fn test_low_stake_provider_verification_does_not_count() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let provider_a = Address::generate(&env);
+        let provider_b = Address::generate(&env);
+        let project_id = create_project_id(&env, 1);
+
+        let contract_id = env.register(OracleConsumer, (admin.clone(),));
+        let client = OracleConsumerClient::new(&env, &contract_id);
+
+        assert_eq!(
+            client.get_signature_threshold(),
+            DEFAULT_SIGNATURE_THRESHOLD
+        );
+        assert_eq!(
+            client.get_minimum_verifier_stake(),
+            DEFAULT_MIN_VERIFIER_STAKE
+        );
+
+        client.register_provider(&admin, &provider_a, &Symbol::new(&env, "verra_vcs"), &0);
+        client.register_provider(&admin, &provider_b, &Symbol::new(&env, "satellite"), &1);
+        client.add_stake(&provider_b, &(DEFAULT_MIN_VERIFIER_STAKE - 1), &0);
+
+        let report_id = client.submit_report(
+            &provider_a,
+            &project_id,
+            &1000u64,
+            &2000u64,
+            &100_000i128,
+            &BiodiversityMetrics::Absent,
+            &Symbol::new(&env, "verra_vcs"),
+            &make_ipfs_hash(&env, 1),
+            &0,
+        );
+
+        let result = client.try_verify_report(&provider_b, &report_id, &1);
+        assert_eq!(result, Err(Ok(OracleError::Unauthorized)));
+        assert_eq!(client.get_verification_count(&report_id), 0);
+        assert_eq!(client.get_report(&report_id).status, ReportStatus::Pending);
     }
 
     #[test]
@@ -1890,6 +1903,8 @@ mod test {
         client.register_provider(&admin, &provider_a, &Symbol::new(&env, "verra_vcs"), &1);
         client.register_provider(&admin, &provider_b, &Symbol::new(&env, "satellite"), &2);
         client.register_provider(&admin, &provider_c, &Symbol::new(&env, "iot"), &3);
+        client.add_stake(&provider_b, &DEFAULT_MIN_VERIFIER_STAKE, &0);
+        client.add_stake(&provider_c, &DEFAULT_MIN_VERIFIER_STAKE, &0);
 
         let report_id = client.submit_report(
             &provider_a,
@@ -1903,15 +1918,15 @@ mod test {
             &0,
         );
 
-        client.verify_report(&provider_b, &report_id, &0);
-        let result = client.try_verify_report(&provider_b, &report_id, &1);
+        client.verify_report(&provider_b, &report_id, &1);
+        let result = client.try_verify_report(&provider_b, &report_id, &2);
         assert_eq!(result, Ok(Ok(())));
         assert_eq!(client.get_verification_count(&report_id), 1);
 
         let report = client.get_report(&report_id);
         assert_eq!(report.status, ReportStatus::Pending);
 
-        client.verify_report(&provider_c, &report_id, &0);
+        client.verify_report(&provider_c, &report_id, &1);
         assert_eq!(client.get_verification_count(&report_id), 2);
     }
 
@@ -1927,15 +1942,8 @@ mod test {
         let contract_id = env.register(OracleConsumer, (admin.clone(),));
         let client = OracleConsumerClient::new(&env, &contract_id);
 
-        let report_id = register_provider_and_submit(
-            &env,
-            &client,
-            &admin,
-            &provider_a,
-            &project_id,
-            0,
-            0,
-        );
+        let report_id =
+            register_provider_and_submit(&env, &client, &admin, &provider_a, &project_id, 0, 0);
 
         let result = client.try_verify_report(&provider_a, &report_id, &1);
         assert_eq!(result, Err(Ok(OracleError::InvalidSignature)));
@@ -1960,31 +1968,19 @@ mod test {
 
         client.set_signature_threshold(&admin, &2u32, &0);
 
-        let report_id = register_provider_and_submit(
-            &env,
-            &client,
-            &admin,
-            &provider_a,
-            &project_id,
-            0,
-            1,
-        );
+        let report_id =
+            register_provider_and_submit(&env, &client, &admin, &provider_a, &project_id, 0, 1);
 
         client.register_provider(&admin, &provider_b, &Symbol::new(&env, "satellite"), &2);
+        client.add_stake(&provider_b, &DEFAULT_MIN_VERIFIER_STAKE, &0);
 
         client.verify_report(&admin, &report_id, &3);
         assert_eq!(client.get_verification_count(&report_id), 1);
-        assert_eq!(
-            client.get_report(&report_id).status,
-            ReportStatus::Pending
-        );
+        assert_eq!(client.get_report(&report_id).status, ReportStatus::Pending);
 
-        client.verify_report(&provider_b, &report_id, &0);
+        client.verify_report(&provider_b, &report_id, &1);
         assert_eq!(client.get_verification_count(&report_id), 2);
-        assert_eq!(
-            client.get_report(&report_id).status,
-            ReportStatus::Verified
-        );
+        assert_eq!(client.get_report(&report_id).status, ReportStatus::Verified);
     }
 
     #[test]

--- a/docs/oracle-design.md
+++ b/docs/oracle-design.md
@@ -22,14 +22,15 @@ Register → Whitelisted → Submit Reports → Challenge Window → Verify/Reje
 ## Multi-Source Verification Threshold
 A report only reaches `Verified` status after **independent verifications** meet the configured threshold:
 
-- `set_signature_threshold(threshold)` sets the minimum number of distinct verifiers required (defaults to `1`).
-- Any admin or active provider may call `verify_report`. Each call records the verifier under `ReportVerifiers(report_id)` and increments `VerificationCount(report_id)`.
+- `set_signature_threshold(threshold)` sets the minimum number of distinct qualifying verifiers required (defaults to `2`).
+- `set_minimum_verifier_stake(stake)` sets the minimum active stake a provider must hold before its verification can count (defaults to `10_000`).
+- The admin may call `verify_report`; active providers may call it only when their stake is at or above the configured minimum. Each qualifying call records the verifier under `ReportVerifiers(report_id)` and increments `VerificationCount(report_id)`.
 - Verifying the **same** report twice by the same address is a no-op (deduplicated, no double counting).
 - A provider cannot verify its **own** report (`InvalidSignature`) — this guarantees the threshold represents genuinely independent sources.
 - A report whose status is no longer `Pending` (challenged, already verified) cannot be re-verified.
 - `get_report_verifiers(report_id)` and `get_verification_count(report_id)` expose the audit trail on-chain.
 
-The admin can verify a report and it counts toward the threshold, but the submitting provider's own signature never does.
+The admin can verify a report and it counts toward the threshold, but the submitting provider's own signature never does. Low-stake providers are rejected before their verification is recorded, so a self-registered provider cannot cheaply satisfy consensus for a colluding report.
 
 ## Challenge Mechanism
 - 72-hour window from submission
@@ -70,6 +71,6 @@ log-based staleness alerting described in
 - Provider whitelist (admin-managed)
 - Provider staking: committed collateral underwrites report quality; `add_stake` / `withdraw_stake` manage exposure
 - Slashing: a `Rejected` challenge resolution slashes 10% of stake; zero stake deactivates the provider
-- Signature threshold requires multiple independent sources for verification
+- Signature threshold defaults to two independent qualifying sources, with minimum verifier stake required for provider votes
 - Coupon distributions consume only `Verified` reports (enforced by `CouponEngine`)
 - Multi-sig for high-value reports


### PR DESCRIPTION
## Summary
- require OracleConsumer verifiers to meet a configurable minimum stake and raise the default signature threshold to 2
- replace per-service Redis clients with a shared resilient Redis provider, health endpoint, cache fallback behavior, and fail-closed nonce allocation
- add SigningKeyProvider abstraction with env and local file backends, then route custodial API signing through it
- change DEX listOrders to read order_count and tolerate missing order IDs instead of stopping at the first gap
- update oracle/key-management docs and env example

## Testing
- npm test -- --runInBand src/marketplace/dex.service.spec.ts src/common/services/nonce.service.spec.ts src/common/services/signing-key.provider.spec.ts src/bonds/bonds.service.spec.ts
- npx tsc --noEmit --pretty false
- cargo fmt -p nbbs-oracle-consumer
- git diff --check

## Not run
- cargo test -p nbbs-oracle-consumer: blocked locally because MSVC link.exe is missing

Closes #9
Closes #21
Closes #27
Closes #29