### PR TITLE
dex.service.ts cache invalidation

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -236,7 +236,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -1678,7 +1677,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-10.4.22.tgz",
       "integrity": "sha512-fxJ4v85nDHaqT1PmfNCQ37b/jcv2OojtXTaK1P2uAXhzLf9qq6WNUOFvxBrV4fhQek1EQoT1o9oj5xAZmv3NRw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "file-type": "20.4.1",
         "iterare": "1.2.1",
@@ -1710,7 +1708,6 @@
       "integrity": "sha512-6IX9+VwjiKtCjx+mXVPncpkQ5ZjKfmssOZPFexmT+6T9H9wZ3svpYACAo7+9e7Nr9DZSoRZw3pffkJP7Z0UjaA==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nuxtjs/opencollective": "0.3.2",
         "fast-safe-stringify": "2.1.1",
@@ -1791,7 +1788,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-10.4.22.tgz",
       "integrity": "sha512-ySSq7Py/DFozzZdNDH67m/vHoeVdphDniWBnl6q5QVoXldDdrZIHLXLRMPayTDh5A95nt7jjJzmD4qpTbNQ6tA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "body-parser": "1.20.4",
         "cors": "2.8.5",
@@ -2375,7 +2371,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
       "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2553,7 +2548,6 @@
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -3009,7 +3003,6 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3023,6 +3016,7 @@
       "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.13.0"
       },
@@ -3094,7 +3088,6 @@
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -3643,7 +3636,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3920,15 +3912,13 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/class-validator": {
       "version": "0.14.4",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.4.tgz",
       "integrity": "sha512-AwNusCCam51q703dW82x95tOqQp6oC9HNUl724KxJJOfnKscI8dOloXFgyez7LbTTKWuRBA37FScqVbJEoq8Yw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -4588,7 +4578,8 @@
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
       "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
@@ -4650,7 +4641,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -6360,7 +6350,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -7902,7 +7891,6 @@
       "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
       "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "passport-strategy": "1.x.x",
         "pause": "0.0.1",
@@ -8299,8 +8287,7 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/repeat-string": {
       "version": "1.6.1",
@@ -8575,7 +8562,6 @@
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -9596,7 +9582,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -9763,7 +9748,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10063,6 +10047,7 @@
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -10073,6 +10058,7 @@
       "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",

--- a/api/src/common/services/redis.service.ts
+++ b/api/src/common/services/redis.service.ts
@@ -69,6 +69,28 @@ export class RedisService {
     }
   }
 
+  /**
+   * Delete all keys matching a glob pattern.
+   *
+   * Uses SCAN with MATCH to enumerate matching keys without blocking Redis,
+   * then DELs them in a single batched call per cursor page.
+   * Never calls KEYS, which blocks the server on large keyspaces.
+   */
+  async delPattern(pattern: string): Promise<void> {
+    try {
+      let cursor = 0;
+      do {
+        const reply = await this.redis.scan(cursor, { MATCH: pattern, COUNT: 100 });
+        cursor = reply.cursor;
+        if (reply.keys.length > 0) {
+          await this.redis.del(reply.keys);
+        }
+      } while (cursor !== 0);
+    } catch (error) {
+      this.logDegraded('delPattern', pattern, error);
+    }
+  }
+
   async sAdd(key: string, value: string): Promise<void> {
     try {
       await this.redis.sAdd(key, value);

--- a/api/src/marketplace/dex.service.spec.ts
+++ b/api/src/marketplace/dex.service.spec.ts
@@ -8,10 +8,56 @@ import { RedisService } from '../common/services/redis.service';
 import { SigningKeyProvider } from '../common/services/signing-key.provider';
 import { OrderStatus } from './interfaces/marketplace.interface';
 
+// ---------------------------------------------------------------------------
+// Minimal in-memory Redis stub used by cache-staleness tests.
+// Implements only the methods DexService calls, plus delPattern.
+// ---------------------------------------------------------------------------
+class InMemoryRedis {
+  private store = new Map<string, string>();
+
+  async get(key: string): Promise<string | null> {
+    return this.store.get(key) ?? null;
+  }
+
+  async setEx(key: string, _ttl: number, value: string): Promise<void> {
+    this.store.set(key, value);
+  }
+
+  async del(key: string): Promise<void> {
+    this.store.delete(key);
+  }
+
+  /** Emulates SCAN+DEL for prefix* patterns. */
+  async delPattern(pattern: string): Promise<void> {
+    const prefix = pattern.endsWith('*') ? pattern.slice(0, -1) : pattern;
+    for (const key of this.store.keys()) {
+      if (key.startsWith(prefix)) {
+        this.store.delete(key);
+      }
+    }
+  }
+
+  async sAdd(_key: string, _value: string): Promise<void> {}
+  async sMembers(_key: string): Promise<string[]> {
+    return [];
+  }
+
+  keys(): string[] {
+    return [...this.store.keys()];
+  }
+
+  clear(): void {
+    this.store.clear();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Suite 1 – existing unit tests (unchanged behaviour)
+// ---------------------------------------------------------------------------
 describe('DexService', () => {
   let service: DexService;
   let contractService: { simulateCall: jest.Mock; invokeContractMethod: jest.Mock };
-  let redis: { get: jest.Mock; setEx: jest.Mock; del: jest.Mock };
+  let redis: { get: jest.Mock; setEx: jest.Mock; del: jest.Mock; delPattern: jest.Mock };
 
   const simulateCallMock = jest.fn();
   const invokeContractMethodMock = jest.fn();
@@ -25,6 +71,7 @@ describe('DexService', () => {
       get: jest.fn().mockResolvedValue(null),
       setEx: jest.fn().mockResolvedValue(undefined),
       del: jest.fn().mockResolvedValue(undefined),
+      delPattern: jest.fn().mockResolvedValue(undefined),
     };
 
     const moduleRef = await Test.createTestingModule({
@@ -32,10 +79,7 @@ describe('DexService', () => {
         DexService,
         { provide: ContractService, useValue: contractService },
         { provide: StellarService, useValue: {} },
-        {
-          provide: NonceService,
-          useValue: { next: jest.fn().mockResolvedValue(0) },
-        },
+        { provide: NonceService, useValue: { next: jest.fn().mockResolvedValue(0) } },
         { provide: RedisService, useValue: redis },
         {
           provide: SigningKeyProvider,
@@ -68,7 +112,7 @@ describe('DexService', () => {
       ]);
 
     it('does not truncate listings when an intermediate order id is missing', async () => {
-      simulateCallMock.mockImplementation(({ method, args }) => {
+      simulateCallMock.mockImplementation(({ method, args }: { method: string; args: any[] }) => {
         if (method === 'order_count') {
           return Promise.resolve(nativeToScVal(BigInt(4), { type: 'u64' }));
         }
@@ -92,7 +136,7 @@ describe('DexService', () => {
   describe('decodeOrder', () => {
     const SELLER = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
 
-    it('maps the contract Order struct to an OrderResponse', async () => {
+    it('maps the contract Order struct to an OrderResponse', () => {
       const raw = [
         BigInt(7),
         SELLER,
@@ -123,7 +167,7 @@ describe('DexService', () => {
       [2, OrderStatus.Filled],
       [3, OrderStatus.Cancelled],
       [4, OrderStatus.Expired],
-    ])('maps status index %i to %s', async (index, expected) => {
+    ])('maps status index %i to %s', (index, expected) => {
       const raw = [
         BigInt(1),
         SELLER,
@@ -212,5 +256,305 @@ describe('DexService', () => {
         0,
       );
     });
+  });
+
+  describe('cache invalidation — delPattern is called on mutations', () => {
+    const SELLER = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+
+    const rawOrderScVal = (id: number, statusIndex = 0) =>
+      xdr.ScVal.scvVec([
+        nativeToScVal(BigInt(id), { type: 'u64' }),
+        nativeToScVal(SELLER, { type: 'address' }),
+        nativeToScVal(BigInt(1), { type: 'u64' }),
+        nativeToScVal(BigInt(100), { type: 'i128' }),
+        nativeToScVal(BigInt(10), { type: 'i128' }),
+        nativeToScVal('USDC', { type: 'symbol' }),
+        xdr.ScVal.scvU32(statusIndex),
+        nativeToScVal(BigInt(1700000000), { type: 'u64' }),
+        nativeToScVal(BigInt(1700604800), { type: 'u64' }),
+      ]);
+
+    it('listBondTokens calls delPattern("orders:*") and del("order:<id>")', async () => {
+      invokeContractMethodMock.mockResolvedValue({
+        result: nativeToScVal(BigInt(5), { type: 'u64' }),
+        transactionHash: 'tx-list',
+        successful: true,
+      });
+      simulateCallMock.mockImplementation(({ method, args }: { method: string; args: any[] }) => {
+        if (method === 'get_order') return Promise.resolve(rawOrderScVal(Number(scValToNative(args[0]))));
+        return Promise.reject(new Error(`unexpected: ${method}`));
+      });
+
+      await service.listBondTokens(
+        { bondId: 1, amount: 100, pricePerToken: 10, quoteAsset: 'USDC' } as any,
+        SELLER,
+      );
+
+      expect(redis.delPattern).toHaveBeenCalledWith('orders:*');
+      expect(redis.del).toHaveBeenCalledWith('order:5');
+    });
+
+    it('buyBondTokens calls delPattern("orders:*") and del("order:<id>")', async () => {
+      simulateCallMock.mockImplementation(({ method, args }: { method: string; args: any[] }) => {
+        if (method === 'get_order') return Promise.resolve(rawOrderScVal(Number(scValToNative(args[0])), 2));
+        if (method === 'get_quote_balance') return Promise.resolve(nativeToScVal(BigInt(9_999_999), { type: 'i128' }));
+        return Promise.reject(new Error(`unexpected: ${method}`));
+      });
+      invokeContractMethodMock.mockResolvedValue({ transactionHash: 'tx-buy', successful: true });
+
+      await service.buyBondTokens({ orderId: 3, amount: 10, maxPrice: 10 } as any, SELLER);
+
+      expect(redis.delPattern).toHaveBeenCalledWith('orders:*');
+      expect(redis.del).toHaveBeenCalledWith('order:3');
+    });
+
+    it('cancelOrder calls delPattern("orders:*") and del("order:<id>")', async () => {
+      invokeContractMethodMock.mockResolvedValue({ transactionHash: 'tx-cancel', successful: true });
+
+      await service.cancelOrder(7, SELLER);
+
+      expect(redis.delPattern).toHaveBeenCalledWith('orders:*');
+      expect(redis.del).toHaveBeenCalledWith('order:7');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite 2 – cache-staleness integration tests (InMemoryRedis)
+//
+// These tests prove that after a mutation the stale orders:* cache entries are
+// actually gone so the *next* listOrders() call fetches fresh data from the
+// contract rather than serving the pre-mutation snapshot.
+// ---------------------------------------------------------------------------
+describe('DexService — cache staleness (in-memory Redis)', () => {
+  const SELLER = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+  // Use the same valid checksum address; buyer identity doesn't affect the cache-invalidation assertions.
+  const BUYER = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+
+  let service: DexService;
+  let inMemRedis: InMemoryRedis;
+  let simulateCall: jest.Mock;
+  let invokeContractMethod: jest.Mock;
+
+  const rawOrderScVal = (id: number, statusIndex = 0) =>
+    xdr.ScVal.scvVec([
+      nativeToScVal(BigInt(id), { type: 'u64' }),
+      nativeToScVal(SELLER, { type: 'address' }),
+      nativeToScVal(BigInt(1), { type: 'u64' }),
+      nativeToScVal(BigInt(100), { type: 'i128' }),
+      nativeToScVal(BigInt(10), { type: 'i128' }),
+      nativeToScVal('USDC', { type: 'symbol' }),
+      xdr.ScVal.scvU32(statusIndex),
+      nativeToScVal(BigInt(1700000000), { type: 'u64' }),
+      nativeToScVal(BigInt(1700604800), { type: 'u64' }),
+    ]);
+
+  beforeEach(async () => {
+    inMemRedis = new InMemoryRedis();
+    simulateCall = jest.fn();
+    invokeContractMethod = jest.fn();
+
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        DexService,
+        { provide: ContractService, useValue: { simulateCall, invokeContractMethod } },
+        { provide: StellarService, useValue: {} },
+        { provide: NonceService, useValue: { next: jest.fn().mockResolvedValue(0) } },
+        { provide: RedisService, useValue: inMemRedis },
+        {
+          provide: SigningKeyProvider,
+          useValue: { adminSecret: jest.fn().mockReturnValue('SADMIN') },
+        },
+      ],
+    }).compile();
+
+    service = moduleRef.get(DexService);
+  });
+
+  /**
+   * Seeds a stale orders:* cache entry, runs the mutation, then asserts:
+   * 1. All orders:* keys are gone after the mutation.
+   * 2. A subsequent listOrders() call hits the contract (not cache) and
+   *    returns fresh data (empty list, because we mock order_count → 0).
+   */
+  async function assertOrdersCacheInvalidated(
+    triggerMutation: () => Promise<unknown>,
+  ): Promise<void> {
+    const staleResult = {
+      data: [
+        {
+          id: 1,
+          seller: SELLER,
+          bondId: 1,
+          amount: 100,
+          pricePerToken: 10,
+          quoteAsset: 'USDC',
+          status: OrderStatus.Open,
+          createdAt: new Date().toISOString(),
+        },
+      ],
+      meta: { page: 1, limit: 20, total: 1, totalPages: 1 },
+    };
+    await inMemRedis.setEx('orders:all:all:1:20', 30, JSON.stringify(staleResult));
+
+    // Sanity: stale key is present before mutation.
+    expect(inMemRedis.keys().some((k) => k.startsWith('orders:'))).toBe(true);
+
+    await triggerMutation();
+
+    // All orders:* keys must be gone after the mutation.
+    const remaining = inMemRedis.keys().filter((k) => k.startsWith('orders:'));
+    expect(remaining).toHaveLength(0);
+
+    // The next listOrders() must bypass cache and call the contract.
+    simulateCall.mockImplementation(({ method }: { method: string }) => {
+      if (method === 'order_count') {
+        return Promise.resolve(nativeToScVal(BigInt(0), { type: 'u64' }));
+      }
+      return Promise.reject(new Error(`unexpected: ${method}`));
+    });
+
+    const fresh = await service.listOrders(undefined, undefined, 1, 20);
+    expect(fresh.meta.total).toBe(0);
+    expect(fresh.data).toHaveLength(0);
+  }
+
+  it('listBondTokens: stale orders:* cache is evicted so the next listOrders returns fresh data', async () => {
+    invokeContractMethod.mockResolvedValue({
+      result: nativeToScVal(BigInt(2), { type: 'u64' }),
+      transactionHash: 'tx-list',
+      successful: true,
+    });
+    simulateCall.mockImplementation(({ method, args }: { method: string; args: any[] }) => {
+      if (method === 'get_order') {
+        return Promise.resolve(rawOrderScVal(Number(scValToNative(args[0]))));
+      }
+      if (method === 'order_count') {
+        return Promise.resolve(nativeToScVal(BigInt(0), { type: 'u64' }));
+      }
+      return Promise.reject(new Error(`unexpected: ${method}`));
+    });
+
+    await assertOrdersCacheInvalidated(() =>
+      service.listBondTokens(
+        { bondId: 1, amount: 100, pricePerToken: 10, quoteAsset: 'USDC' } as any,
+        SELLER,
+      ),
+    );
+  });
+
+  it('buyBondTokens: stale orders:* cache is evicted so the next listOrders returns fresh data', async () => {
+    simulateCall.mockImplementation(({ method, args }: { method: string; args: any[] }) => {
+      if (method === 'get_order') {
+        return Promise.resolve(rawOrderScVal(Number(scValToNative(args[0])), 2));
+      }
+      if (method === 'get_quote_balance') {
+        return Promise.resolve(nativeToScVal(BigInt(9_999_999), { type: 'i128' }));
+      }
+      if (method === 'order_count') {
+        return Promise.resolve(nativeToScVal(BigInt(0), { type: 'u64' }));
+      }
+      return Promise.reject(new Error(`unexpected: ${method}`));
+    });
+    invokeContractMethod.mockResolvedValue({ transactionHash: 'tx-buy', successful: true });
+
+    await assertOrdersCacheInvalidated(() =>
+      service.buyBondTokens({ orderId: 1, amount: 10, maxPrice: 10 } as any, BUYER),
+    );
+  });
+
+  it('cancelOrder: stale orders:* cache is evicted so the next listOrders returns fresh data', async () => {
+    invokeContractMethod.mockResolvedValue({ transactionHash: 'tx-cancel', successful: true });
+    simulateCall.mockImplementation(({ method }: { method: string }) => {
+      if (method === 'order_count') {
+        return Promise.resolve(nativeToScVal(BigInt(0), { type: 'u64' }));
+      }
+      return Promise.reject(new Error(`unexpected: ${method}`));
+    });
+
+    await assertOrdersCacheInvalidated(() => service.cancelOrder(1, SELLER));
+  });
+
+  it('buyBondTokens: individual order:N key is evicted so getOrder returns fresh data', async () => {
+    const orderId = 1;
+    await inMemRedis.setEx(
+      `order:${orderId}`,
+      60,
+      JSON.stringify({ id: orderId, status: OrderStatus.Open }),
+    );
+
+    simulateCall.mockImplementation(({ method, args }: { method: string; args: any[] }) => {
+      if (method === 'get_order') {
+        // Fresh call returns Filled (statusIndex = 2)
+        return Promise.resolve(rawOrderScVal(Number(scValToNative(args[0])), 2));
+      }
+      if (method === 'get_quote_balance') {
+        return Promise.resolve(nativeToScVal(BigInt(9_999_999), { type: 'i128' }));
+      }
+      return Promise.reject(new Error(`unexpected: ${method}`));
+    });
+    invokeContractMethod.mockResolvedValue({ transactionHash: 'tx-buy', successful: true });
+
+    await service.buyBondTokens({ orderId, amount: 10, maxPrice: 10 } as any, BUYER);
+
+    // After buyBondTokens: the stale Open entry is gone and the fresh Filled
+    // entry has been written back to cache by the internal getOrder() call.
+    const cached = await inMemRedis.get(`order:${orderId}`);
+    expect(cached).not.toBeNull();
+    const cachedOrder = JSON.parse(cached!);
+    expect(cachedOrder.status).toBe(OrderStatus.Filled);
+
+    // After eviction, getOrder re-fetches and caches the Filled order.
+    simulateCall.mockImplementation(({ method, args }: { method: string; args: any[] }) => {
+      if (method === 'get_order') return Promise.resolve(rawOrderScVal(Number(scValToNative(args[0])), 2));
+      return Promise.reject(new Error(`unexpected: ${method}`));
+    });
+    const freshOrder = await service.getOrder(orderId);
+    expect(freshOrder.status).toBe(OrderStatus.Filled);
+  });
+
+  it('cancelOrder: individual order:N key is evicted', async () => {
+    const orderId = 3;
+    await inMemRedis.setEx(
+      `order:${orderId}`,
+      60,
+      JSON.stringify({ id: orderId, status: OrderStatus.Open }),
+    );
+
+    invokeContractMethod.mockResolvedValue({ transactionHash: 'tx-cancel', successful: true });
+
+    await service.cancelOrder(orderId, SELLER);
+
+    expect(await inMemRedis.get(`order:${orderId}`)).toBeNull();
+  });
+
+  it('listBondTokens: individual order:N key for the new listing is not stale', async () => {
+    const newOrderId = 9;
+    // Pre-seed a stale cache entry for order 9 (e.g. from a previous failed creation).
+    await inMemRedis.setEx(
+      `order:${newOrderId}`,
+      60,
+      JSON.stringify({ id: newOrderId, status: OrderStatus.Cancelled }),
+    );
+
+    invokeContractMethod.mockResolvedValue({
+      result: nativeToScVal(BigInt(newOrderId), { type: 'u64' }),
+      transactionHash: 'tx-list',
+      successful: true,
+    });
+    simulateCall.mockImplementation(({ method, args }: { method: string; args: any[] }) => {
+      if (method === 'get_order') {
+        return Promise.resolve(rawOrderScVal(Number(scValToNative(args[0])), 0)); // Open
+      }
+      return Promise.reject(new Error(`unexpected: ${method}`));
+    });
+
+    const result = await service.listBondTokens(
+      { bondId: 1, amount: 100, pricePerToken: 10, quoteAsset: 'USDC' } as any,
+      SELLER,
+    );
+
+    // The returned order must be the fresh Open one, not the stale Cancelled entry.
+    expect(result.status).toBe(OrderStatus.Open);
   });
 });

--- a/api/src/marketplace/dex.service.ts
+++ b/api/src/marketplace/dex.service.ts
@@ -100,7 +100,8 @@ export class DexService {
     );
 
     const orderId = Number(scValToNative(result));
-    await this.redis.del(`orders:*`);
+    await this.redis.delPattern(`orders:*`);
+    await this.redis.del(`order:${orderId}`);
     return this.getOrder(orderId);
   }
 
@@ -134,7 +135,8 @@ export class DexService {
       throw this.mapDexError(error);
     }
 
-    await this.redis.del(`orders:*`);
+    await this.redis.delPattern(`orders:*`);
+    await this.redis.del(`order:${dto.orderId}`);
     return this.getOrder(dto.orderId);
   }
 
@@ -151,7 +153,8 @@ export class DexService {
       nonce,
     );
 
-    await this.redis.del(`orders:*`);
+    await this.redis.delPattern(`orders:*`);
+    await this.redis.del(`order:${orderId}`);
   }
 
   async getOrder(orderId: number): Promise<OrderResponse> {


### PR DESCRIPTION
Closes #20

---

## Description

<!-- Briefly describe the change and why it's needed -->
 1. **Fixed cache invalidation**: Replaced the 3 broken `redis.del('orders:*')` no-ops in
    dex.service.ts (listBondTokens L103, buyBondTokens L137, cancelOrder L154) with
    `redis.delPattern('orders:*')` (using SCAN+DEL in a cursor loop) plus `redis.del('order:${id}')` for
    the specific order key. Added `delPattern(pattern)` to RedisService. Verified by reading the updated
    files.
    
    2. **Added tests**: Added 9 new tests across two new describe blocks in dex.service.spec.ts — 3
    mock-based tests asserting `delPattern` is called with correct args on each mutation, and 6
    integration tests using an in-memory Redis stub that prove stale `orders:*` cache entries are
    actually evicted and the next `listOrders()` returns fresh contract data. All 19 tests in
    dex.service.spec.ts pass (npx jest --testPathPattern=dex.service: 19 passed, 0 failed).
    
    3. **Audit of other services**: Grepped all *.ts files for `redis.del(.*\*)` — the anti-pattern only
    appeared in dex.service.ts (3 occurrences). bonds.service.ts and projects.service.ts only del exact
    keys like `bond:${id}` and `project:${id}`, which are correct. No other services have the glob-del
    bug.
    
    The 2 pre-existing failures in oracle.service.spec.ts / oracle.monitoring.service.spec.ts are
    unrelated to this change (those specs were already broken before my edits — they were missing a
    RedisService provider in their test modules due to a prior OracleService change).


## Type of Change

- [ x] Bug fix
- [ ] New feature
- [x ] Documentation update
- [ ] Refactor / chore
- [ ] Security fix

## Area

- [ ] Smart Contracts (Rust / Soroban)
- [ ] API (NestJS)
- [ ] Frontend (Angular)
- [ ] Oracle / Adapters
- [ ] DevOps / CI
- [ ] Docs

## Checklist

- [ ] `cargo test` passes
- [ ] `cargo clippy --all-targets -- -D warnings` is clean
- [ ] `npm run test` passes (API + Frontend)
- [ ] `npm run build` succeeds (API + Frontend)
- [ ] New code is tested
- [ ] New types / endpoints are documented
- [ ] PR description explains the change and motivation

## Related Issues

<!-- Link any related issues using #issue_number -->
