### PR TITLE
fix: allow challenging Verified reports and add cross-contract coupon escrow test

### DIFF
--- a/contracts/oracle-consumer/src/lib.rs
+++ b/contracts/oracle-consumer/src/lib.rs
@@ -426,7 +426,7 @@ impl OracleConsumer {
             .get(&DataKey::Report(report_id))
             .ok_or(OracleError::ReportNotFound)?;
 
-        if report.status != ReportStatus::Pending {
+        if report.status != ReportStatus::Pending && report.status != ReportStatus::Verified {
             return Err(OracleError::ReportAlreadyVerified);
         }
 
@@ -436,7 +436,12 @@ impl OracleConsumer {
             .instance()
             .get(&DataKey::ChallengeWindow)
             .unwrap_or(CHALLENGE_WINDOW_SECONDS);
-        if now.saturating_sub(report.submitted_at) > window {
+        let reference_time = if report.status == ReportStatus::Verified {
+            report.verified_at
+        } else {
+            report.submitted_at
+        };
+        if now.saturating_sub(reference_time) > window {
             return Err(OracleError::ChallengeWindowExpired);
         }
 
@@ -1227,9 +1232,22 @@ mod test {
 
         client.verify_report(&admin, &report_id, &2);
 
-        let result =
-            client.try_challenge_report(&challenger, &report_id, &make_ipfs_hash(&env, 2), &0);
-        assert_eq!(result, Err(Ok(OracleError::ReportAlreadyVerified)));
+        let verified = client.get_report(&report_id);
+        assert_eq!(verified.status, ReportStatus::Verified);
+
+        client.challenge_report(&challenger, &report_id, &make_ipfs_hash(&env, 3), &0);
+
+        let challenged = client.get_report(&report_id);
+        assert_eq!(challenged.status, ReportStatus::Challenged);
+
+        let challenge = client.get_challenge(&report_id);
+        assert_eq!(challenge.challenger, challenger);
+        assert!(!challenge.resolved);
+
+        client.resolve_challenge(&admin, &report_id, &ReportStatus::Verified, &3);
+
+        let resolved = client.get_report(&report_id);
+        assert_eq!(resolved.status, ReportStatus::Verified);
     }
 
     #[test]

--- a/contracts/tests/src/lib.rs
+++ b/contracts/tests/src/lib.rs
@@ -594,6 +594,127 @@ mod integration {
         }
     }
 
+    mod challenge_coupon_escrow {
+        use super::*;
+
+        #[test]
+        fn test_coupon_distribution_blocked_during_active_challenge() {
+            let env = Env::default();
+            env.mock_all_auths_allowing_non_root_auth();
+
+            let admin = Address::generate(&env);
+            let alice = Address::generate(&env);
+            let bob = Address::generate(&env);
+            let oracle = Address::generate(&env);
+            let challenger = Address::generate(&env);
+            let contracts = deploy_contracts(&env, &admin);
+
+            let project_id = make_project_id(&env, 1);
+
+            let pid = contracts.pr_client.register_project(
+                &alice,
+                &make_ipfs_hash(&env, 1),
+                &Symbol::new(&env, "VCS"),
+                &Symbol::new(&env, "US"),
+                &0,
+            );
+            contracts.pr_client.approve_project(&admin, &pid, &0);
+
+            let config = make_bond_config(&env, project_id.clone(), 10_000);
+            let bond_id = contracts.bi_client.issue_bond(&admin, &config, &0);
+            contracts.bi_client.subscribe(&bob, &bond_id, &1_000, &0);
+
+            contracts.oc_client.register_provider(
+                &admin,
+                &oracle,
+                &Symbol::new(&env, "verra_vcs"),
+                &0,
+            );
+            contracts.oc_client.set_signature_threshold(&admin, &1u32, &1);
+            contracts.oc_client.add_stake(&oracle, &100_000i128, &0);
+
+            let report_id = contracts.oc_client.submit_report(
+                &oracle,
+                &project_id,
+                &1000u64,
+                &2000u64,
+                &100_000i128,
+                &BiodiversityMetrics::Absent,
+                &Symbol::new(&env, "verra_vcs"),
+                &make_ipfs_hash(&env, 1),
+                &1,
+            );
+
+            contracts.oc_client.verify_report(&admin, &report_id, &2);
+            assert_eq!(
+                contracts.oc_client.get_report(&report_id).status,
+                ReportStatus::Verified
+            );
+
+            contracts
+                .ce_client
+                .register_bond(&admin, &bond_id, &project_id, &0);
+
+            let holders = soroban_sdk::vec![&env, bob.clone()];
+
+            let ok = contracts.ce_client.distribute_coupon(
+                &admin,
+                &bond_id,
+                &0,
+                &holders,
+                &report_id,
+                &1,
+            );
+            assert!(ok.total_credits > 0);
+
+            contracts.oc_client.challenge_report(
+                &challenger,
+                &report_id,
+                &make_ipfs_hash(&env, 2),
+                &0,
+            );
+            assert_eq!(
+                contracts.oc_client.get_report(&report_id).status,
+                ReportStatus::Challenged
+            );
+
+            let blocked = contracts.ce_client.try_distribute_coupon(
+                &admin,
+                &bond_id,
+                &1,
+                &holders,
+                &report_id,
+                &2,
+            );
+            assert_eq!(blocked, Err(Ok(BondError::ReportNotVerified)));
+
+            contracts.oc_client.resolve_challenge(
+                &admin,
+                &report_id,
+                &ReportStatus::Verified,
+                &3,
+            );
+            assert_eq!(
+                contracts.oc_client.get_report(&report_id).status,
+                ReportStatus::Verified
+            );
+
+            let retry = contracts.ce_client.distribute_coupon(
+                &admin,
+                &bond_id,
+                &1,
+                &holders,
+                &report_id,
+                &2,
+            );
+            assert!(retry.total_credits > 0);
+
+            let provider = contracts.oc_client.get_provider(&oracle);
+            assert_eq!(provider.stake, 100_000);
+            assert!(provider.active);
+        }
+    }
+
     mod dex {
         use super::*;
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -104,6 +104,35 @@ DEXRouter ──► BondIssuer (settle purchase via transfer, debiting seller / 
 CreditRetirement ──► CouponEngine (verify credit ownership)
 ```
 
+## Oracle Report Status Machine
+
+Reports follow a strict status lifecycle managed by `OracleConsumer`:
+
+```
+                   ┌──────────┐
+                   │ Pending  │
+                   └────┬─────┘
+                        │
+          ┌─────────────┼─────────────┐
+          ▼                           ▼
+   ┌──────────┐                ┌────────────┐
+   │ Verified │◄───────────────│ Challenged │
+   └──────────┘  (exonerated)  └─────┬──────┘
+          ▲                           │
+          │                 (overturned)
+          │                           ▼
+          │                    ┌──────────┐
+          └────────────────────│ Rejected │
+                               └──────────┘
+```
+
+- **Pending → Verified**: report accumulates independent verifier signatures up to the configured `SignatureThreshold`.
+- **Pending → Challenged**: any address submits counter-evidence within the challenge window.
+- **Verified → Challenged**: any address disputes a verified report within the challenge window (measured from `verified_at`).
+- **Challenged → Verified**: admin resolves the challenge in favour of the provider (report exonerated, no slash).
+- **Challenged → Rejected**: admin overturns the report; the provider is slashed 10% of stake.
+- **CouponEngine coupling**: `distribute_coupon` only accepts reports in `Verified` status. While a report is `Challenged`, coupons for the associated bond period are held in escrow until the dispute is resolved.
+
 ## Bond Maturity
 
 - A bond matures when the ledger timestamp reaches its `maturity_date` — `mature_bond` rejects calls made before that instant (`BondError::Overflow`).
@@ -119,7 +148,7 @@ CreditRetirement ──► CouponEngine (verify credit ownership)
 ## Coupon Integrity
 
 - `CouponEngine.distribute_coupon` accepts an **on-chain `report_id`** instead of a caller-supplied report, eliminating fabricated distributions.
-- It reads the report from the `OracleConsumer` contract and rejects any report whose status is not `Verified` (`ReportNotVerified`).
+- It reads the report from the `OracleConsumer` contract and rejects any report whose status is not `Verified` (`ReportNotVerified`). Reports in `Challenged` status are rejected, effectively holding coupons in escrow while a dispute is active.
 - The report's `project_id` must match the bond's registered project, otherwise distribution is rejected.
 - The verified report id is persisted in `PeriodInfo`, making every distribution auditable back to its evidence.
 - Integer-division remainder that cannot be allocated to holders is recorded as `undistributed` per period and aggregated in `UndistributedTotal`; the admin can recover it via `sweep_undistributed`, preventing value from being silently lost.

--- a/docs/oracle-design.md
+++ b/docs/oracle-design.md
@@ -6,6 +6,21 @@ Multi-source, multi-layer: Auditors + Satellite + IoT → OracleConsumer contrac
 ## Provider Lifecycle
 Register → Whitelisted → Submit Reports → Challenge Window → Verify/Reject
 
+## Report Status Machine
+
+```
+Pending ──(threshold met)──► Verified
+Pending ──(challenged)─────► Challenged
+Verified ──(challenged)────► Challenged
+Challenged ──(admin: Verified)──► Verified  (exonerated, no slash)
+Challenged ──(admin: Rejected)──► Rejected  (provider slashed 10%)
+```
+
+Key invariants:
+- Only `Pending` and `Verified` reports can be challenged.
+- The challenge window is measured from `submitted_at` for `Pending` reports, and from `verified_at` for `Verified` reports.
+- `CouponEngine.distribute_coupon` only accepts `Verified` reports. Reports in `Challenged` status block coupon distribution, holding coupons in escrow until the dispute is resolved.
+
 ## Report Format
 ```
 {
@@ -33,9 +48,10 @@ A report only reaches `Verified` status after **independent verifications** meet
 The admin can verify a report and it counts toward the threshold, but the submitting provider's own signature never does. Low-stake providers are rejected before their verification is recorded, so a self-registered provider cannot cheaply satisfy consensus for a colluding report.
 
 ## Challenge Mechanism
-- 72-hour window from submission
-- Any address can challenge with counter-evidence (IPFS hash)
+- 72-hour window from submission (for `Pending` reports) or from verification (for `Verified` reports)
+- Any address can challenge with counter-evidence (IPFS hash) while the report is `Pending` or `Verified`
 - Admin resolves via on-chain vote (`resolve_challenge`), settling the report to `Rejected` or `Verified`
+- While a report is `Challenged`, `CouponEngine.distribute_coupon` rejects it, holding coupons in escrow
 
 ## Staking & Slashing
 Providers stake collateral that is at risk if their reports are overturned:
@@ -72,5 +88,5 @@ log-based staleness alerting described in
 - Provider staking: committed collateral underwrites report quality; `add_stake` / `withdraw_stake` manage exposure
 - Slashing: a `Rejected` challenge resolution slashes 10% of stake; zero stake deactivates the provider
 - Signature threshold defaults to two independent qualifying sources, with minimum verifier stake required for provider votes
-- Coupon distributions consume only `Verified` reports (enforced by `CouponEngine`)
+- Coupon distributions consume only `Verified` reports (enforced by `CouponEngine`); reports in `Challenged` status are rejected, holding coupons in escrow during disputes
 - Multi-sig for high-value reports


### PR DESCRIPTION
Fixes #40

- Allow challenging Verified reports (not just Pending)
- Add cross-contract integration test: submit → verify → challenge → distribute_coupon fails → resolve → distribute_coupon succeeds
- Update docs/architecture.md and docs/oracle-design.md with status machine documentation