### PR TITLE
fix(oracle): replace regex cadence matching with lookup table; add BLUE-CARBON cadence

### DIFF
--- a/docs/runbook-degraded-providers.md
+++ b/docs/runbook-degraded-providers.md
@@ -52,8 +52,8 @@ curl http://localhost:3000/oracle/monitoring/staleness
 ## Staleness metric definition
 
 - **Cadence**: expected seconds between verified reports, per methodology
-  (`VERRA-VCS` = 365d, `REMOTE-SENSING` = 90d, `IOT-SENSORS` = 30d; override
-  via `ORACLE_CADENCE_SECONDS`).
+  (`VERRA-VCS` = 365d, `REMOTE-SENSING` = 90d, `IOT-SENSORS` = 30d,
+  `BLUE-CARBON` = 90d; override via `ORACLE_CADENCE_SECONDS`).
 - **Grace**: additional slack before alerting (`ORACLE_GRACE_SECONDS`, default 30d).
 - `expectedNextReportAt = lastVerifiedAt + cadence + grace`.
 - A project with no verified report falls back to its `createdAt` as baseline.

--- a/oracle/staleness.spec.ts
+++ b/oracle/staleness.spec.ts
@@ -86,4 +86,8 @@ describe('cadenceForMethodology', () => {
   it('uses monthly cadence for IoT sensors', () => {
     expect(cadenceForMethodology('IOT-SENSORS')).toBe(30 * 24 * 60 * 60);
   });
+
+  it('uses seasonal (90-day) cadence for BLUE-CARBON methodology', () => {
+    expect(cadenceForMethodology('BLUE-CARBON')).toBe(90 * 24 * 60 * 60);
+  });
 });

--- a/oracle/staleness.ts
+++ b/oracle/staleness.ts
@@ -1,17 +1,18 @@
 export const DEFAULT_CADENCE_SECONDS = 365 * 24 * 60 * 60;
 export const DEFAULT_GRACE_SECONDS = 30 * 24 * 60 * 60;
 
-const CADENCE_OVERRIDES: Array<{ pattern: RegExp; seconds: number }> = [
-  { pattern: /REMOTE.?SENSING|SATELLITE/i, seconds: 90 * 24 * 60 * 60 },
-  { pattern: /IOT|SENSOR/i, seconds: 30 * 24 * 60 * 60 },
-];
+/** Explicit cadence overrides keyed by methodology constants from contracts/shared/src/types.rs. */
+const METHODOLOGY_CADENCES: Record<string, number> = {
+  'REMOTE-SENSING': 90 * 24 * 60 * 60,
+  'SATELLITE': 90 * 24 * 60 * 60,
+  'IOT': 30 * 24 * 60 * 60,
+  'IOT-SENSORS': 30 * 24 * 60 * 60,
+  'BLUE-CARBON': 90 * 24 * 60 * 60,
+};
 
 /** Expected reporting cadence for a methodology (seconds between reports). */
 export function cadenceForMethodology(methodology: string): number {
-  for (const override of CADENCE_OVERRIDES) {
-    if (override.pattern.test(methodology)) return override.seconds;
-  }
-  return DEFAULT_CADENCE_SECONDS;
+  return METHODOLOGY_CADENCES[methodology.toUpperCase()] ?? DEFAULT_CADENCE_SECONDS;
 }
 
 export interface StalenessInput {


### PR DESCRIPTION
Fixes #39

- Replace regex-based CADENCE_OVERRIDES with explicit METHODOLOGY_CADENCES lookup table
- Add BLUE-CARBON → 90 days cadence (was silently falling back to 365-day default)
- Add unit test asserting BLUE-CARBON gets correct non-default cadence
- Update docs/runbook-degraded-providers.md with BLUE-CARBON cadence