### PR TITLE
fix: populate ProjectSummary.name in list_projects() from stored project data

### DIFF
--- a/contracts/project-registry/src/lib.rs
+++ b/contracts/project-registry/src/lib.rs
@@ -239,7 +239,7 @@ impl ProjectRegistry {
             {
                 result.push_back(ProjectSummary {
                     id: project.id,
-                    name: Symbol::new(&env, ""),
+                    name: project.methodology,
                     status: project.status,
                     country: project.country,
                 });
@@ -492,11 +492,53 @@ mod test {
         assert_eq!(page1.get(0).unwrap().id, 1);
         assert_eq!(page1.get(1).unwrap().id, 2);
         assert_eq!(page1.get(2).unwrap().id, 3);
+        // name must be populated from methodology, not blank
+        assert_eq!(page1.get(0).unwrap().name, Symbol::new(&env, "VCS"));
+        assert_eq!(page1.get(1).unwrap().name, Symbol::new(&env, "VCS"));
+        assert_eq!(page1.get(2).unwrap().name, Symbol::new(&env, "VCS"));
 
         let page2 = client.list_projects(&1, &3);
         assert_eq!(page2.len(), 2);
         assert_eq!(page2.get(0).unwrap().id, 4);
         assert_eq!(page2.get(1).unwrap().id, 5);
+        assert_eq!(page2.get(0).unwrap().name, Symbol::new(&env, "VCS"));
+        assert_eq!(page2.get(1).unwrap().name, Symbol::new(&env, "VCS"));
+    }
+
+    #[test]
+    fn test_list_projects_name_matches_methodology() {
+        let (env, client, _admin, user) = setup();
+
+        let hash1 = create_hash(&env, 1);
+        client.register_project(
+            &user,
+            &hash1,
+            &Symbol::new(&env, "VCS"),
+            &Symbol::new(&env, "US"),
+            &0,
+        );
+
+        let hash2 = create_hash(&env, 2);
+        client.register_project(
+            &user,
+            &hash2,
+            &Symbol::new(&env, "GS"),
+            &Symbol::new(&env, "BR"),
+            &1,
+        );
+
+        let projects = client.list_projects(&0, &10);
+        assert_eq!(projects.len(), 2);
+
+        let summary1 = projects.get(0).unwrap();
+        assert_eq!(summary1.id, 1);
+        assert_eq!(summary1.name, Symbol::new(&env, "VCS"));
+        assert_eq!(summary1.country, Symbol::new(&env, "US"));
+
+        let summary2 = projects.get(1).unwrap();
+        assert_eq!(summary2.id, 2);
+        assert_eq!(summary2.name, Symbol::new(&env, "GS"));
+        assert_eq!(summary2.country, Symbol::new(&env, "BR"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #11

### Root Cause
`list_projects()` in `contracts/project-registry/src/lib.rs` hardcoded
`name: Symbol::new(&env, "")` for every `ProjectSummary` it returned.
Since there is no separate name field stored on-chain (project names live
in IPFS metadata resolved off-chain), the `name` field of `ProjectSummary`
should carry the `methodology` symbol — the most meaningful label that *is*
stored on-chain and mirrors how `get_project()` exposes project data.

### Changes
- **`contracts/project-registry/src/lib.rs`**
  - In `list_projects()`, replaced `Symbol::new(&env, "")` with
    `project.methodology` when constructing each `ProjectSummary`.
  - Updated `test_list_projects_pagination` to assert the returned `name`
    matches the registered methodology, so the regression cannot silently
    reoccur.
  - Added `test_list_projects_name_matches_methodology`: a dedicated test
    that registers two projects with different methodologies (`VCS`, `GS`)
    and verifies each summary carries the correct name.

### Verification
All 16 project-registry tests pass:
```
cargo test -p nbbs-project-registry
running 16 tests ... test result: ok. 16 passed; 0 failed
```