### PR TITLE
feat: restrict bond listings to held balances

### DIFF
--- a/api/src/bonds/bonds.controller.ts
+++ b/api/src/bonds/bonds.controller.ts
@@ -15,6 +15,7 @@ import {
   BondResponse,
   SubscriptionResponse,
   HolderListResponse,
+  HeldBondResponse,
   CouponDistributionResponse,
   ClaimCreditsResponse,
   TransferResponse,
@@ -35,6 +36,13 @@ export class BondsController {
   @Get()
   async findAll(@Query() query: PaginationDto) {
     return this.bondsService.findAll(query.page, query.limit);
+  }
+
+  @Get('held/:address')
+  async findHeldByAddress(
+    @Param('address') address: string,
+  ): Promise<HeldBondResponse[]> {
+    return this.bondsService.findHeldByAddress(address);
   }
 
   @Get(':id')

--- a/api/src/bonds/bonds.service.spec.ts
+++ b/api/src/bonds/bonds.service.spec.ts
@@ -22,6 +22,7 @@ import { StellarService } from '../stellar/stellar.service';
 import { NonceService } from '../common/services/nonce.service';
 import { RedisService } from '../common/services/redis.service';
 import { SigningKeyProvider } from '../common/services/signing-key.provider';
+import { BondStatusEnum, BondMaturityStatusEnum, CreditTypeEnum } from './interfaces/bond.interface';
 
 const redisProvider = {
   provide: RedisService,
@@ -168,6 +169,49 @@ describe('BondsService', () => {
       expect(options.method).toBe('get_undistributed_total');
       expect(options.args).toEqual([nativeToScVal(BigInt(3), { type: 'u64' })]);
       expect(result).toEqual({ bondId: 3, undistributedTotal: 42 });
+    });
+  });
+
+  describe('findHeldByAddress', () => {
+    it('returns only bonds with a positive on-chain balance', async () => {
+      const contractService = {
+        simulateCall: jest.fn()
+          .mockResolvedValueOnce(nativeToScVal(BigInt(2), { type: 'u64' }))
+          .mockResolvedValueOnce(nativeToScVal(BigInt(25), { type: 'i128' }))
+          .mockResolvedValueOnce(nativeToScVal(BigInt(0), { type: 'i128' })),
+      };
+      const moduleRef = await Test.createTestingModule({
+        providers: [
+          BondsService,
+          { provide: ContractService, useValue: contractService },
+          { provide: StellarService, useValue: {} },
+          { provide: NonceService, useValue: { next: jest.fn() } },
+          redisProvider,
+          signingProvider,
+        ],
+      }).compile();
+      const svc = moduleRef.get(BondsService);
+      jest.spyOn(svc, 'findOne').mockImplementation(async (id) => ({
+        id,
+        projectId: '',
+        faceValue: 0,
+        couponSchedule: [],
+        creditType: CreditTypeEnum.Carbon,
+        maturityDate: 0,
+        maturityStatus: BondMaturityStatusEnum.Active,
+        totalSupply: 0,
+        totalSubscribed: 0,
+        status: BondStatusEnum.Active,
+        createdAt: '',
+      }));
+
+      const result = await svc.findHeldByAddress(
+        'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe(1);
+      expect(result[0].balance).toBe(25);
     });
   });
 

--- a/api/src/bonds/bonds.service.ts
+++ b/api/src/bonds/bonds.service.ts
@@ -12,6 +12,7 @@ import { ClaimCreditsDto } from './dto/claim-credits.dto';
 import { TransferBondDto } from './dto/transfer-bond.dto';
 import {
   BondResponse,
+  HeldBondResponse,
   SubscriptionResponse,
   HolderListResponse,
   CouponDistributionResponse,
@@ -111,6 +112,40 @@ export class BondsService {
     const bond = await this.buildBondResponse(id);
     await this.redis.setEx(`bond:${id}`, 300, JSON.stringify(bond));
     return bond;
+  }
+
+  async findHeldByAddress(address: string): Promise<HeldBondResponse[]> {
+    try {
+      Address.fromString(address);
+    } catch {
+      throw new BadRequestException('Invalid wallet address');
+    }
+
+    let total = 0;
+    try {
+      const countScVal = await this.contractService.simulateCall({
+        contractAddress: BOND_ISSUER(), method: 'bond_count', args: [],
+      });
+      total = Number(scValToNative(countScVal));
+    } catch {
+      return [];
+    }
+
+    const heldBonds: HeldBondResponse[] = [];
+    for (let id = 1; id <= total; id++) {
+      try {
+        const balanceScVal = await this.contractService.simulateCall({
+          contractAddress: BOND_ISSUER(), method: 'get_holder_balance',
+          args: [nativeToScVal(BigInt(id), { type: 'u64' }), Address.fromString(address).toScVal()],
+        });
+        const balance = Number(scValToNative(balanceScVal));
+        if (balance > 0) {
+          heldBonds.push({ ...(await this.findOne(id)), balance });
+        }
+      } catch {}
+    }
+
+    return heldBonds;
   }
 
   async subscribe(id: number, dto: SubscribeDto): Promise<SubscriptionResponse> {

--- a/api/src/bonds/interfaces/bond.interface.ts
+++ b/api/src/bonds/interfaces/bond.interface.ts
@@ -30,6 +30,10 @@ export interface BondResponse {
   createdAt: string;
 }
 
+export interface HeldBondResponse extends BondResponse {
+  balance: number;
+}
+
 export interface SubscriptionResponse {
   bondId: number;
   investorAddress: string;

--- a/frontend/src/app/marketplace/marketplace-sell/marketplace-sell.component.spec.ts
+++ b/frontend/src/app/marketplace/marketplace-sell/marketplace-sell.component.spec.ts
@@ -12,7 +12,10 @@ describe('MarketplaceSellComponent', () => {
 
   beforeEach(async () => {
     const apiService = {
-      getBonds: jasmine.createSpy('getBonds').and.returnValue(of({ data: [], meta: { page: 1, limit: 100, total: 0, totalPages: 1 } })),
+      getHeldBonds: jasmine.createSpy('getHeldBonds').and.returnValue(of([
+        { id: 1, creditType: 'Carbon', balance: 25 },
+        { id: 2, creditType: 'BlueCarbon', balance: 10 },
+      ])),
       listBondTokens: jasmine.createSpy('listBondTokens').and.returnValue(of({ id: 1 })),
     };
 
@@ -21,7 +24,7 @@ describe('MarketplaceSellComponent', () => {
       providers: [
         provideRouter([]),
         { provide: ApiService, useValue: apiService },
-        { provide: WalletService, useValue: { isConnected: signal(false), address: signal(null) } },
+        { provide: WalletService, useValue: { isConnected: signal(true), address: signal('GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF') } },
       ],
     }).compileComponents();
   });
@@ -36,8 +39,14 @@ describe('MarketplaceSellComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('loads available bonds for the listing form', () => {
-    expect(component.bonds()).toEqual([]);
+  it('loads only bonds held by the connected wallet', () => {
+    expect(component.bonds().map((bond) => bond.id)).toEqual([1, 2]);
+    expect(fixture.nativeElement.querySelectorAll('#bondId option').length).toBe(3);
+  });
+
+  it('rejects an amount above the selected bond balance', () => {
+    component.form.patchValue({ bondId: 1, amount: 26 });
+    expect(component.form.get('amount')?.hasError('exceedsBalance')).toBeTrue();
   });
 
   it('has a valid default listing form', () => {

--- a/frontend/src/app/marketplace/marketplace-sell/marketplace-sell.component.ts
+++ b/frontend/src/app/marketplace/marketplace-sell/marketplace-sell.component.ts
@@ -1,11 +1,11 @@
 import { Component, inject, OnInit, ChangeDetectionStrategy, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule, Router, ActivatedRoute } from '@angular/router';
-import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { AbstractControl, FormBuilder, FormGroup, ReactiveFormsModule, ValidationErrors, ValidatorFn, Validators } from '@angular/forms';
 import { ApiService } from '../../shared/services/api.service';
 import { WalletService } from '../../auth/wallet.service';
 import { QuoteBalanceComponent } from '../../shared/components/quote-balance/quote-balance.component';
-import { Bond } from '../../shared/interfaces/bond.interface';
+import { HeldBond } from '../../shared/interfaces/bond.interface';
 
 @Component({
   selector: 'app-marketplace-sell',
@@ -44,10 +44,15 @@ import { Bond } from '../../shared/interfaces/bond.interface';
           <div class="form-group">
             <label class="form-label" for="amount">Amount</label>
             <input id="amount" type="number" class="form-input" formControlName="amount" placeholder="100" />
-            @if (form.get('amount')?.invalid && form.get('amount')?.touched) {
+            @if (form.get('amount')?.hasError('exceedsBalance')) {
+              <span class="form-error">Amount exceeds your balance of {{ selectedBalance() }}</span>
+            } @else if (form.get('amount')?.invalid && form.get('amount')?.touched) {
               <span class="form-error">Enter a positive amount</span>
             }
           </div>
+          @if (selectedBalance() !== null) {
+            <div class="balance-hint">Available balance: {{ selectedBalance() }}</div>
+          }
           <div class="form-group">
             <label class="form-label" for="pricePerToken">Price per Token</label>
             <input id="pricePerToken" type="number" class="form-input" formControlName="pricePerToken" placeholder="10.50" step="0.01" />
@@ -111,26 +116,53 @@ export class MarketplaceSellComponent implements OnInit {
   private readonly route = inject(ActivatedRoute);
   readonly walletService = inject(WalletService);
 
-  readonly bonds = signal<Bond[]>([]);
+  readonly bonds = signal<HeldBond[]>([]);
+  readonly selectedBalance = signal<number | null>(null);
   readonly submitting = signal(false);
   readonly error = signal('');
 
   form: FormGroup = this.fb.group({
     bondId: [null, Validators.required],
-    amount: [null, [Validators.required, Validators.min(1)]],
+    amount: [null, [Validators.required, Validators.min(1), this.amountWithinBalanceValidator()]],
     pricePerToken: [null, [Validators.required, Validators.min(0.01)]],
     quoteAsset: ['USDC', Validators.required],
     expiresAfterSeconds: [604800],
   });
 
   ngOnInit(): void {
+    this.form.get('bondId')?.valueChanges.subscribe((bondId) => {
+      this.updateSelectedBalance(bondId);
+      this.form.get('amount')?.updateValueAndValidity();
+    });
+
     const bondIdParam = this.route.snapshot.queryParamMap.get('bondId');
     if (bondIdParam) {
       this.form.patchValue({ bondId: Number(bondIdParam) });
     }
-    this.apiService.getBonds(1, 100).subscribe({
-      next: (res) => this.bonds.set(res.data),
+    const walletAddress = this.walletService.address();
+    if (!walletAddress) return;
+    this.apiService.getHeldBonds(walletAddress).subscribe({
+      next: (bonds) => {
+        this.bonds.set(bonds);
+        this.updateSelectedBalance(this.form.get('bondId')?.value);
+        this.form.get('bondId')?.updateValueAndValidity();
+        this.form.get('amount')?.updateValueAndValidity();
+      },
     });
+  }
+
+  private amountWithinBalanceValidator(): ValidatorFn {
+    return (control: AbstractControl): ValidationErrors | null => {
+      const balance = this.selectedBalance();
+      return balance !== null && Number(control.value) > balance
+        ? { exceedsBalance: true }
+        : null;
+    };
+  }
+
+  private updateSelectedBalance(bondId: unknown): void {
+    const heldBond = this.bonds().find((bond) => bond.id === Number(bondId));
+    this.selectedBalance.set(heldBond?.balance ?? null);
   }
 
   onSubmit(): void {

--- a/frontend/src/app/shared/interfaces/bond.interface.ts
+++ b/frontend/src/app/shared/interfaces/bond.interface.ts
@@ -12,6 +12,10 @@ export interface Bond {
   createdAt: string;
 }
 
+export interface HeldBond extends Bond {
+  balance: number;
+}
+
 export interface Project {
   id: number;
   name: string;

--- a/frontend/src/app/shared/services/api.service.ts
+++ b/frontend/src/app/shared/services/api.service.ts
@@ -4,7 +4,7 @@ import { Observable } from 'rxjs';
 import { AuthService } from '../../auth/auth.service';
 import { WalletService } from '../../auth/wallet.service';
 import {
-  Bond, Project, Order, PaginatedResponse,
+  Bond, HeldBond, Project, Order, PaginatedResponse,
   SubscriptionResponse, CreateProjectDto, ListBondDto, BuyBondDto,
   ClaimCreditsResponse, TransferResponse,
   UndistributedTotalResponse, SweepUndistributedResponse,
@@ -39,6 +39,12 @@ export class ApiService {
 
   getBond(id: number): Observable<Bond> {
     return this.http.get<Bond>(`/api/bonds/${id}`, { headers: this.headers() });
+  }
+
+  getHeldBonds(address: string): Observable<HeldBond[]> {
+    return this.http.get<HeldBond[]>(`/api/bonds/held/${address}`, {
+      headers: this.headers(),
+    });
   }
 
   issueBond(data: any): Observable<Bond> {


### PR DESCRIPTION
Closes #33 
## Title

Restrict bond listings to held balances

## Description


### Changes

- Added `GET /api/bonds/held/:address` to return bonds with a positive on-chain balance for a wallet.
- Updated the sell form to load only bonds held by the connected wallet.
- Displayed the available balance for the selected bond.
- Added client-side validation preventing listings above the held balance.
- Added backend and frontend tests for held-bond filtering and amount validation.

### Validation

- API tests: 13 passed
- API build and lint passed
- Frontend build and lint passed
- Angular browser test could not run because Chrome is unavailable in the container.