### PR TITLE
fix: add separate refresh tokens

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,7 +37,9 @@ IOT_API_URL=https://api.iot-sensor-network.io/v1
 
 # ── Authentication ───────────────────────────────────────────────
 JWT_SECRET=your_very_long_jwt_secret_here
-JWT_EXPIRY=7d
+JWT_EXPIRY=15m
+JWT_REFRESH_SECRET=your_very_long_refresh_jwt_secret_here
+JWT_REFRESH_EXPIRY=7d
 KYC_PROVIDER_URL=https://kyc.your-provider.com
 KYC_API_KEY=your_kyc_api_key
 

--- a/README.md
+++ b/README.md
@@ -771,7 +771,9 @@ DEFAULT_PROVIDER_ADDRESS=G...                  # Default provider used by the sc
 
 # ── Authentication ───────────────────────────────────────────────
 JWT_SECRET=your_very_long_jwt_secret_here
-JWT_EXPIRY=7d
+JWT_EXPIRY=15m
+JWT_REFRESH_SECRET=your_very_long_refresh_jwt_secret_here
+JWT_REFRESH_EXPIRY=7d
 KYC_PROVIDER_URL=https://kyc.your-provider.com
 KYC_API_KEY=your_kyc_api_key
 

--- a/api/src/auth/auth.controller.ts
+++ b/api/src/auth/auth.controller.ts
@@ -31,10 +31,9 @@ export class AuthController {
   }
 
   @Post('refresh')
-  @UseGuards(JwtAuthGuard)
   @HttpCode(HttpStatus.OK)
   async refresh(@Body() dto: RefreshTokenDto): Promise<AuthTokenResponse> {
-    return this.authService.refreshToken(dto.accessToken);
+    return this.authService.refreshToken(dto.refreshToken);
   }
 
   @Get('profile')

--- a/api/src/auth/auth.module.ts
+++ b/api/src/auth/auth.module.ts
@@ -11,7 +11,7 @@ import { KycService } from './kyc.service';
     PassportModule.register({ defaultStrategy: 'jwt' }),
     JwtModule.register({
       secret: process.env.JWT_SECRET || 'dev-secret-change-in-production',
-      signOptions: { expiresIn: process.env.JWT_EXPIRY || '7d' },
+      signOptions: { expiresIn: process.env.JWT_EXPIRY || '15m' },
     }),
   ],
   controllers: [AuthController],

--- a/api/src/auth/auth.service.spec.ts
+++ b/api/src/auth/auth.service.spec.ts
@@ -1,0 +1,60 @@
+import { JwtService } from '@nestjs/jwt';
+import { UnauthorizedException } from '@nestjs/common';
+import { AuthService } from './auth.service';
+
+describe('AuthService', () => {
+  let service: AuthService;
+  let jwtService: JwtService;
+
+  beforeEach(() => {
+    process.env.JWT_SECRET = 'access-secret';
+    process.env.JWT_REFRESH_SECRET = 'refresh-secret';
+    process.env.JWT_EXPIRY = '15m';
+    process.env.JWT_REFRESH_EXPIRY = '7d';
+    jwtService = new JwtService({ secret: process.env.JWT_SECRET });
+    service = new AuthService(
+      jwtService,
+      {} as any,
+      {} as any,
+      {} as any,
+    );
+  });
+
+  it('refreshes an access token after the access token has expired', async () => {
+    const expiredAccessToken = jwtService.sign(
+      { sub: 'GUSER', kycStatus: 'verified' },
+      { expiresIn: -1 },
+    );
+    const refreshToken = jwtService.sign(
+      { sub: 'GUSER', kycStatus: 'verified', tokenType: 'refresh' },
+      { secret: 'refresh-secret', expiresIn: '7d' },
+    );
+
+    await expect(service.refreshToken(expiredAccessToken)).rejects.toThrow(
+      UnauthorizedException,
+    );
+    await expect(service.refreshToken(refreshToken)).resolves.toMatchObject({
+      tokenType: 'Bearer',
+      expiresIn: '15m',
+    });
+  });
+
+  it('rejects an expired refresh token', async () => {
+    const expiredRefreshToken = jwtService.sign(
+      { sub: 'GUSER', kycStatus: 'verified', tokenType: 'refresh' },
+      { secret: 'refresh-secret', expiresIn: -1 },
+    );
+
+    await expect(service.refreshToken(expiredRefreshToken)).rejects.toThrow(
+      UnauthorizedException,
+    );
+  });
+
+  it('rejects an access token presented as a refresh token', async () => {
+    const accessToken = jwtService.sign({ sub: 'GUSER', kycStatus: 'verified' });
+
+    await expect(service.refreshToken(accessToken)).rejects.toThrow(
+      UnauthorizedException,
+    );
+  });
+});

--- a/api/src/auth/auth.service.ts
+++ b/api/src/auth/auth.service.ts
@@ -10,6 +10,11 @@ import { ChallengeResponse, AuthTokenResponse, UserProfileResponse } from './int
 
 @Injectable()
 export class AuthService {
+  private readonly accessTokenExpiry = process.env.JWT_EXPIRY || '15m';
+  private readonly refreshTokenExpiry = process.env.JWT_REFRESH_EXPIRY || '7d';
+  private readonly refreshTokenSecret =
+    process.env.JWT_REFRESH_SECRET || `${process.env.JWT_SECRET || 'dev-secret-change-in-production'}:refresh`;
+
   constructor(
     private readonly jwtService: JwtService,
     private readonly kycService: KycService,
@@ -52,16 +57,32 @@ export class AuthService {
 
     const payload = { sub: dto.address, kycStatus };
     const accessToken = this.jwtService.sign(payload);
+    const refreshToken = this.jwtService.sign(
+      { ...payload, tokenType: 'refresh' },
+      { secret: this.refreshTokenSecret, expiresIn: this.refreshTokenExpiry },
+    );
 
-    return { accessToken, tokenType: 'Bearer', expiresIn: '7d' };
+    return {
+      accessToken,
+      refreshToken,
+      tokenType: 'Bearer',
+      expiresIn: this.accessTokenExpiry,
+      refreshExpiresIn: this.refreshTokenExpiry,
+    };
   }
 
   async refreshToken(token: string): Promise<AuthTokenResponse> {
     try {
-      const payload = this.jwtService.verify(token) as { sub: string; kycStatus: string };
+      const payload = this.jwtService.verify(token, {
+        secret: this.refreshTokenSecret,
+      }) as { sub: string; kycStatus: string; tokenType: string };
+      if (payload.tokenType !== 'refresh') {
+        throw new UnauthorizedException('Invalid refresh token');
+      }
+
       const newPayload = { sub: payload.sub, kycStatus: payload.kycStatus };
       const accessToken = this.jwtService.sign(newPayload);
-      return { accessToken, tokenType: 'Bearer', expiresIn: '7d' };
+      return { accessToken, tokenType: 'Bearer', expiresIn: this.accessTokenExpiry };
     } catch {
       throw new UnauthorizedException('Invalid or expired token');
     }

--- a/api/src/auth/dto/refresh-token.dto.ts
+++ b/api/src/auth/dto/refresh-token.dto.ts
@@ -3,5 +3,5 @@ import { IsString, IsNotEmpty } from 'class-validator';
 export class RefreshTokenDto {
   @IsString()
   @IsNotEmpty()
-  accessToken: string;
+  refreshToken: string;
 }

--- a/api/src/auth/interfaces/auth.interface.ts
+++ b/api/src/auth/interfaces/auth.interface.ts
@@ -5,8 +5,10 @@ export interface ChallengeResponse {
 
 export interface AuthTokenResponse {
   accessToken: string;
+  refreshToken?: string;
   tokenType: string;
   expiresIn: string;
+  refreshExpiresIn?: string;
 }
 
 export interface UserProfileResponse {

--- a/frontend/src/app/auth/auth.service.ts
+++ b/frontend/src/app/auth/auth.service.ts
@@ -8,7 +8,7 @@ export class AuthService {
   private readonly http = inject(HttpClient);
   private readonly walletService = inject(WalletService);
 
-  readonly token = signal<string | null>(localStorage.getItem('nbs_token'));
+  readonly token = signal<string | null>(localStorage.getItem('nbs_access_token'));
   readonly isAuthenticated = computed(() => this.token() !== null);
 
   async login(): Promise<void> {
@@ -21,20 +21,33 @@ export class AuthService {
 
     const signedChallenge = await this.walletService.signChallenge(challenge);
 
-    const { accessToken } = await firstValueFrom(
-      this.http.post<{ accessToken: string }>('/api/auth/verify', {
+    const { accessToken, refreshToken } = await firstValueFrom(
+      this.http.post<{ accessToken: string; refreshToken: string }>('/api/auth/verify', {
         address,
         signedChallenge,
         originalChallenge: challenge,
       }),
     );
 
-    localStorage.setItem('nbs_token', accessToken);
+    localStorage.setItem('nbs_access_token', accessToken);
+    localStorage.setItem('nbs_refresh_token', refreshToken);
+    this.token.set(accessToken);
+  }
+
+  async refresh(): Promise<void> {
+    const refreshToken = localStorage.getItem('nbs_refresh_token');
+    if (!refreshToken) throw new Error('No refresh token available');
+
+    const { accessToken } = await firstValueFrom(
+      this.http.post<{ accessToken: string }>('/api/auth/refresh', { refreshToken }),
+    );
+    localStorage.setItem('nbs_access_token', accessToken);
     this.token.set(accessToken);
   }
 
   logout(): void {
-    localStorage.removeItem('nbs_token');
+    localStorage.removeItem('nbs_access_token');
+    localStorage.removeItem('nbs_refresh_token');
     this.token.set(null);
     this.walletService.disconnect();
   }


### PR DESCRIPTION
closes #25 
## Description

Fix refresh token handling so users can obtain a new access token after the previous access token expires. The API now issues separate access and refresh JWTs, validates refresh tokens independently, and the Angular frontend stores and uses the refresh token when needed.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / chore
- [ ] Security fix

## Area

- [ ] Smart Contracts (Rust / Soroban)
- [x] API (NestJS)
- [x] Frontend (Angular)
- [ ] Oracle / Adapters
- [ ] DevOps / CI
- [x] Docs

## Checklist

- [ ] `cargo test` passes
- [ ] `cargo clippy --all-targets -- -D warnings` is clean
- [ ] `npm run test` passes (API + Frontend)
- [x] `npm run build` succeeds (API + Frontend)
- [x] New code is tested
- [x] New types / endpoints are documented
- [x] PR description explains the change and motivation

## Related Issues

Closes #25

