### PR TITLE
fix: enforce integer pagination and apply PaginationDto consistently

### DIFF
--- a/api/src/common/dto/pagination.dto.ts
+++ b/api/src/common/dto/pagination.dto.ts
@@ -1,15 +1,16 @@
-import { IsOptional, IsNumber, Min, Max } from 'class-validator';
+import { IsOptional, IsInt, Min, Max } from 'class-validator';
 import { Type } from 'class-transformer';
 
 export class PaginationDto {
   @IsOptional()
-  @IsNumber()
+  @IsInt()
   @Min(1)
+  @Max(10000)
   @Type(() => Number)
   page?: number = 1;
 
   @IsOptional()
-  @IsNumber()
+  @IsInt()
   @Min(1)
   @Max(100)
   @Type(() => Number)

--- a/api/src/marketplace/marketplace.controller.ts
+++ b/api/src/marketplace/marketplace.controller.ts
@@ -18,7 +18,7 @@ import {
   QuoteTransactionResponse,
   SlippageResponse,
 } from './interfaces/marketplace.interface';
-import { PaginatedResponse } from '../common/dto/pagination.dto';
+import { PaginatedResponse, PaginationDto } from '../common/dto/pagination.dto';
 import { toBigIntString } from '../common/utils';
 
 @Controller('marketplace')
@@ -33,14 +33,13 @@ export class MarketplaceController {
   async listOrders(
     @Query('bondId') bondId?: number,
     @Query('status') status?: string,
-    @Query('page') page?: number,
-    @Query('limit') limit?: number,
+    @Query() pagination: PaginationDto = new PaginationDto(),
   ): Promise<PaginatedResponse<OrderResponse>> {
     return this.dexService.listOrders(
       bondId ? Number(bondId) : undefined,
       status,
-      page || 1,
-      limit || 20,
+      pagination.page ?? 1,
+      pagination.limit ?? 20,
     );
   }
 


### PR DESCRIPTION
Closes #102
Closes #103
Closes #104
Closes #105

- Replace `IsNumber` with `IsInt` in `PaginationDto` so non-integer values like `1.5` are rejected at the validation boundary
- Add `@Max(10000)` to `page` to cap unreachable page numbers
- Switch `marketplace.controller.ts#listOrders` from raw `@Query('page')` / `@Query('limit')` params to `@Query() pagination: PaginationDto`, aligning it with how `bonds.controller.ts` already works