### PR TITLE
fix(oracle): fix #95 persist oracle incidents with dedupe, escalation…

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -21,6 +21,7 @@
         "class-validator": "^0.14.1",
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
+        "pg": "^8.23.0",
         "reflect-metadata": "^0.2.1",
         "rxjs": "^7.8.0",
         "zod": "^3.22.0"
@@ -33,9 +34,11 @@
         "@types/jest": "^29.5.0",
         "@types/node": "^20.11.0",
         "@types/passport-jwt": "^4.0.1",
+        "@types/pg": "^8.23.1",
         "@types/supertest": "^6.0.2",
         "@typescript-eslint/eslint-plugin": "^7.0.0",
         "@typescript-eslint/parser": "^7.0.0",
+        "embedded-postgres": "18.4.0-beta.17",
         "eslint": "^8.57.0",
         "jest": "^29.7.0",
         "supertest": "^6.3.0",
@@ -814,6 +817,150 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@embedded-postgres/darwin-arm64": {
+      "version": "18.4.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@embedded-postgres/darwin-arm64/-/darwin-arm64-18.4.0-beta.17.tgz",
+      "integrity": "sha512-Kg1ZMNFzkVIJs3g4V2UYEc5X005km9rGinxFBH8R1sOU2Rblvz4pt2Uf93Pu8Rk273Ue9HIdrbMPpgUqwjUi0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@embedded-postgres/darwin-x64": {
+      "version": "18.4.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@embedded-postgres/darwin-x64/-/darwin-x64-18.4.0-beta.17.tgz",
+      "integrity": "sha512-4tShSYWMxUQTSWoQAdLnHISvRj6L9gTch9/31ASJPg6wgyN64LDRwMcOINEWybM7N0ropJ3nTYhFT3UX1bKY5Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@embedded-postgres/linux-arm": {
+      "version": "18.4.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@embedded-postgres/linux-arm/-/linux-arm-18.4.0-beta.17.tgz",
+      "integrity": "sha512-VuD1nFasN7yG57zpJcp6MBXM0nXqGfb8GBQV+f1FGJ17+VMNYLIFLhFp99UlY4xnWG74FQC4NPYw8eCwSTJ6qg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@embedded-postgres/linux-arm64": {
+      "version": "18.4.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@embedded-postgres/linux-arm64/-/linux-arm64-18.4.0-beta.17.tgz",
+      "integrity": "sha512-TIzjtGnDGSD/LbdW0OWCEcbI+YVT0WKSfSr20TCkkP4UR8zeKe+QCZbO0/CM4hS9EWyZ4cDebjRvpRc3iMi6wg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@embedded-postgres/linux-ia32": {
+      "version": "18.4.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@embedded-postgres/linux-ia32/-/linux-ia32-18.4.0-beta.17.tgz",
+      "integrity": "sha512-aSRe4kknqRHuedtpo/rDIaqa8r9VrKIgW9p5FkJyIFqUUkIkxRqND1dg8xrDRREcSUXRJKS0x+j/AuxflgYIfg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@embedded-postgres/linux-ppc64": {
+      "version": "18.4.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@embedded-postgres/linux-ppc64/-/linux-ppc64-18.4.0-beta.17.tgz",
+      "integrity": "sha512-zO2RRUFdKRPplrdhmglG39VXJZzDXu3P3ONAG1sFPhGh89vbk24Btd5P7uOmQLIpWehzL0s+UqUWoeE/ZUKvgw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@embedded-postgres/linux-x64": {
+      "version": "18.4.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@embedded-postgres/linux-x64/-/linux-x64-18.4.0-beta.17.tgz",
+      "integrity": "sha512-jVw/MdDtIX/vICH/DKIe6/mHpiCggdx6QVyza4vt/NbcZFsL0KhwglF6F1Koqx3gRBZ9XtN+vi63EsqSyqOSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@embedded-postgres/windows-x64": {
+      "version": "18.4.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@embedded-postgres/windows-x64/-/windows-x64-18.4.0-beta.17.tgz",
+      "integrity": "sha512-AwRerliA4IGWyW5jWBvHt5vidVUSB0QQW9Tt2y7ScnmifnCb/awfxZr4BkBSTv+gNt8Djcddqs+xSF5Z6/CkTg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -2407,6 +2554,18 @@
         "@types/passport": "*"
       }
     },
+    "node_modules/@types/pg": {
+      "version": "8.23.1",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.23.1.tgz",
+      "integrity": "sha512-fKVHpikPdg4GKks3JuLEhvwSyvwzF23hnabPy6DD8ljVbC7+6J5dQzdv4arV6jqq57djnMgs1HKBxX4P8aBI3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
     "node_modules/@types/qs": {
       "version": "6.15.1",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
@@ -3256,6 +3415,16 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/async-exit-hook": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-2.0.1.tgz",
+      "integrity": "sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -4501,6 +4670,30 @@
       "integrity": "sha512-e9htk9mAYL6AzmkEhSvVVw7IWGSBJ/Bqdn2eRyRLrj1g6sncN4WbFt5qnILYoCktktr45pyjIrOiRvBThQ808w==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/embedded-postgres": {
+      "version": "18.4.0-beta.17",
+      "resolved": "https://registry.npmjs.org/embedded-postgres/-/embedded-postgres-18.4.0-beta.17.tgz",
+      "integrity": "sha512-ORT/A1YiO6ecpRHpyIIBgyCR/8ASqqYZuFw11aX9PkqTX3FUM5+9sNOXY1mGIixxsm2TWSIA5WghJEk7A5ZxVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-exit-hook": "^2.0.1",
+        "pg": "^8.7.3"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@embedded-postgres/darwin-arm64": "^18.4.0-beta.17",
+        "@embedded-postgres/darwin-x64": "^18.4.0-beta.17",
+        "@embedded-postgres/linux-arm": "^18.4.0-beta.17",
+        "@embedded-postgres/linux-arm64": "^18.4.0-beta.17",
+        "@embedded-postgres/linux-ia32": "^18.4.0-beta.17",
+        "@embedded-postgres/linux-ppc64": "^18.4.0-beta.17",
+        "@embedded-postgres/linux-x64": "^18.4.0-beta.17",
+        "@embedded-postgres/windows-x64": "^18.4.0-beta.17"
+      }
     },
     "node_modules/emittery": {
       "version": "0.13.1",
@@ -8004,6 +8197,95 @@
       "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
       "integrity": "sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg=="
     },
+    "node_modules/pg": {
+      "version": "8.23.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.23.0.tgz",
+      "integrity": "sha512-Ip2EQCngowJLGOfCwkFhPXU7/ljlhn6Rxlmy4XYfL2Y+vyRM59+8uR2xqRWKdYmbXmxCFOAmKxBuSUCdF34qLg==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.14.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.16.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.4.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.14.0.tgz",
+      "integrity": "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.16.0.tgz",
+      "integrity": "sha512-sILXutLVjCLjcDuOmvhX5e2Z4cS5qG/6Bu3VkpFwdf/633ElGLpEh9bgmuI5I4sqKqkifQiGyiCcx1HdtrK7tg==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -8064,6 +8346,45 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/prelude-ls": {
@@ -8854,6 +9175,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/sprintf-js": {

--- a/api/package.json
+++ b/api/package.json
@@ -25,6 +25,7 @@
     "class-validator": "^0.14.1",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
+    "pg": "^8.23.0",
     "reflect-metadata": "^0.2.1",
     "rxjs": "^7.8.0",
     "zod": "^3.22.0"
@@ -37,7 +38,9 @@
     "@types/jest": "^29.5.0",
     "@types/node": "^20.11.0",
     "@types/passport-jwt": "^4.0.1",
+    "@types/pg": "^8.23.1",
     "@types/supertest": "^6.0.2",
+    "embedded-postgres": "18.4.0-beta.17",
     "eslint": "^8.57.0",
     "jest": "^29.7.0",
     "supertest": "^6.3.0",

--- a/api/src/oracle/dto/list-oracle-incidents.dto.ts
+++ b/api/src/oracle/dto/list-oracle-incidents.dto.ts
@@ -1,0 +1,9 @@
+import { IsEnum, IsOptional } from 'class-validator';
+import { PaginationDto } from '../../common/dto/pagination.dto';
+import { OracleIncidentStatus } from '../interfaces/oracle-incident.interface';
+
+export class ListOracleIncidentsDto extends PaginationDto {
+  @IsOptional()
+  @IsEnum(OracleIncidentStatus)
+  status?: OracleIncidentStatus;
+}

--- a/api/src/oracle/dto/resolve-oracle-incident.dto.ts
+++ b/api/src/oracle/dto/resolve-oracle-incident.dto.ts
@@ -1,0 +1,8 @@
+import { IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class ResolveOracleIncidentDto {
+  @IsOptional()
+  @IsString()
+  @MaxLength(1000)
+  resolutionNote?: string;
+}

--- a/api/src/oracle/interfaces/oracle-incident.interface.ts
+++ b/api/src/oracle/interfaces/oracle-incident.interface.ts
@@ -1,0 +1,79 @@
+/**
+ * Durable oracle incident model (issue #95).
+ *
+ * Replaces the previous log-only / Redis-rearm alerting in
+ * `OracleMonitoringService` with a persisted incident lifecycle so operators
+ * have a source of truth for degraded oracle coverage instead of scattered
+ * WARN log lines.
+ */
+
+export enum OracleIncidentStatus {
+  Active = 'active',
+  Acknowledged = 'acknowledged',
+  Resolved = 'resolved',
+}
+
+export enum OracleIncidentSeverity {
+  Warning = 'warning',
+  Critical = 'critical',
+}
+
+export enum OracleIncidentSubjectType {
+  Project = 'project',
+  Provider = 'provider',
+}
+
+/**
+ * Point-in-time staleness context captured when an incident is created or
+ * updated, for audit/debugging. Intentionally the same shape the staleness
+ * report already exposes via `GET /oracle/monitoring/staleness`, so an
+ * incident's `details` is self-explanatory next to that endpoint.
+ */
+export interface OracleIncidentDetails {
+  lastVerifiedAt?: string;
+  expectedNextReportAt?: string;
+  stalenessSeconds?: number;
+  projectIds?: string[];
+}
+
+export interface OracleIncident {
+  id: string;
+  dedupeKey: string;
+  subjectType: OracleIncidentSubjectType;
+  subjectId: string;
+  status: OracleIncidentStatus;
+  severity: OracleIncidentSeverity;
+  occurrenceCount: number;
+  firstDetectedAt: string;
+  lastDetectedAt: string;
+  acknowledgedAt: string | null;
+  acknowledgedBy: string | null;
+  resolvedAt: string | null;
+  resolvedBy: string | null;
+  resolutionNote: string | null;
+  details: OracleIncidentDetails | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** Input for recording one detection of a stale condition during a monitoring cycle. */
+export interface IncidentDetectionInput {
+  subjectType: OracleIncidentSubjectType;
+  subjectId: string;
+  detectedAt: string;
+  details: OracleIncidentDetails;
+}
+
+export interface IncidentDetectionResult {
+  incident: OracleIncident;
+  /** True if this detection created a new incident row (first occurrence or a recurrence after resolution). */
+  isNew: boolean;
+  /** True if this detection pushed the incident's severity to a higher tier. */
+  escalated: boolean;
+}
+
+export interface OracleIncidentSyncSummary {
+  created: number;
+  updated: number;
+  escalated: number;
+}

--- a/api/src/oracle/oracle-incident.repository.spec.ts
+++ b/api/src/oracle/oracle-incident.repository.spec.ts
@@ -1,0 +1,279 @@
+import { randomUUID } from 'crypto';
+import { spawn, ChildProcessByStdio } from 'child_process';
+import * as path from 'path';
+import { Readable } from 'stream';
+import { OracleIncidentRepository } from './oracle-incident.repository';
+import {
+  OracleIncidentSeverity,
+  OracleIncidentStatus,
+  OracleIncidentSubjectType,
+} from './interfaces/oracle-incident.interface';
+
+/**
+ * Integration test for OracleIncidentRepository (issue #95), run against a
+ * real, ephemeral PostgreSQL server -- not a mock or a SQL emulator. This
+ * matters because the dedup/recurrence guarantee relies on a real
+ * PostgreSQL-specific feature (a partial unique index combined with
+ * `INSERT ... ON CONFLICT (col) WHERE <predicate> DO UPDATE`); a
+ * lighter-weight in-memory SQL engine (`pg-mem` was evaluated and does not
+ * parse this exact clause) would not actually verify that this works. The
+ * CI workflow (`.github/workflows/ci.yml`) does not provision a Postgres
+ * service for the `api` job, so this test brings its own real, disposable
+ * database instead of depending on one being externally available.
+ *
+ * The database itself is started by `test-setup/embedded-postgres-server.mjs`
+ * in a genuinely separate `node` child process, not loaded in-process. The
+ * `embedded-postgres` npm package ships as pure ESM with no CommonJS build,
+ * and this project's Jest is configured for CommonJS/ts-jest (matching every
+ * other test file); Jest's sandboxed module loader cannot execute a real ESM
+ * package even via a dynamic `import()` from inside a test file. Running it
+ * as a plain `node file.mjs` subprocess sidesteps that entirely -- Jest is
+ * not involved in loading it at all.
+ */
+
+const PORT = 57432;
+let serverProcess: ChildProcessByStdio<null, Readable, Readable>;
+let repository: OracleIncidentRepository;
+
+jest.setTimeout(60_000);
+
+function startEmbeddedPostgres(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      process.execPath,
+      [path.join(__dirname, '..', '..', 'test-setup', 'embedded-postgres-server.mjs'), String(PORT)],
+      { stdio: ['ignore', 'pipe', 'pipe'] },
+    );
+    serverProcess = child;
+
+    let stderr = '';
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on('exit', (code) => {
+      if (code !== null && code !== 0) {
+        reject(new Error(`embedded-postgres-server exited early (code ${code}): ${stderr}`));
+      }
+    });
+
+    let stdout = '';
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
+      const match = stdout.match(/PGREADY:(\S+)/);
+      if (match) resolve(match[1]);
+    });
+  });
+}
+
+function stopEmbeddedPostgres(): Promise<void> {
+  return new Promise((resolve) => {
+    if (!serverProcess || serverProcess.exitCode !== null) {
+      resolve();
+      return;
+    }
+    serverProcess.once('exit', () => resolve());
+    serverProcess.kill('SIGTERM');
+  });
+}
+
+beforeAll(async () => {
+  process.env.DATABASE_URL = await startEmbeddedPostgres();
+  process.env.ORACLE_INCIDENT_ESCALATION_THRESHOLDS = '3:critical';
+
+  repository = new OracleIncidentRepository();
+  await repository.onModuleInit();
+});
+
+afterAll(async () => {
+  await repository.onModuleDestroy();
+  await stopEmbeddedPostgres();
+});
+
+function detection(overrides: Partial<{ subjectType: OracleIncidentSubjectType; subjectId: string; detectedAt: string }> = {}) {
+  return {
+    subjectType: overrides.subjectType ?? OracleIncidentSubjectType.Project,
+    subjectId: overrides.subjectId ?? randomUUID(),
+    detectedAt: overrides.detectedAt ?? '2026-01-01T00:00:00.000Z',
+    details: { lastVerifiedAt: '2025-12-01T00:00:00.000Z', stalenessSeconds: 2_592_000 },
+  };
+}
+
+describe('OracleIncidentRepository', () => {
+  describe('creation', () => {
+    it('creates a new active incident on first detection', async () => {
+      const input = detection();
+      const result = await repository.recordDetection(input);
+
+      expect(result.isNew).toBe(true);
+      expect(result.escalated).toBe(false);
+      expect(result.incident.status).toBe(OracleIncidentStatus.Active);
+      expect(result.incident.severity).toBe(OracleIncidentSeverity.Warning);
+      expect(result.incident.occurrenceCount).toBe(1);
+      expect(result.incident.subjectId).toBe(input.subjectId);
+      expect(result.incident.dedupeKey).toBe(`project:${input.subjectId}`);
+    });
+
+    it('keys projects and providers separately even with the same subject id', async () => {
+      const subjectId = randomUUID();
+      const project = await repository.recordDetection(
+        detection({ subjectType: OracleIncidentSubjectType.Project, subjectId }),
+      );
+      const provider = await repository.recordDetection(
+        detection({ subjectType: OracleIncidentSubjectType.Provider, subjectId }),
+      );
+
+      expect(project.isNew).toBe(true);
+      expect(provider.isNew).toBe(true);
+      expect(project.incident.id).not.toBe(provider.incident.id);
+    });
+  });
+
+  describe('dedupe', () => {
+    it('updates the existing incident instead of creating a new row on a repeated cron cycle', async () => {
+      const subjectId = randomUUID();
+      const first = await repository.recordDetection(detection({ subjectId, detectedAt: '2026-01-01T00:00:00.000Z' }));
+      const second = await repository.recordDetection(detection({ subjectId, detectedAt: '2026-01-02T00:00:00.000Z' }));
+
+      expect(second.isNew).toBe(false);
+      expect(second.incident.id).toBe(first.incident.id);
+      expect(second.incident.occurrenceCount).toBe(2);
+      expect(second.incident.lastDetectedAt).toBe('2026-01-02T00:00:00.000Z');
+
+      const listed = await repository.findMany(1, 20, undefined);
+      const matching = listed.data.filter((incident) => incident.dedupeKey === first.incident.dedupeKey);
+      expect(matching).toHaveLength(1);
+    });
+
+    it('is safe under concurrent detections for the same subject (no duplicate active rows)', async () => {
+      const subjectId = randomUUID();
+      const [a, b, c] = await Promise.all([
+        repository.recordDetection(detection({ subjectId, detectedAt: '2026-02-01T00:00:00.000Z' })),
+        repository.recordDetection(detection({ subjectId, detectedAt: '2026-02-01T00:00:01.000Z' })),
+        repository.recordDetection(detection({ subjectId, detectedAt: '2026-02-01T00:00:02.000Z' })),
+      ]);
+
+      const ids = new Set([a.incident.id, b.incident.id, c.incident.id]);
+      expect(ids.size).toBe(1);
+      const finalCount = Math.max(a.incident.occurrenceCount, b.incident.occurrenceCount, c.incident.occurrenceCount);
+      expect(finalCount).toBe(3);
+    });
+  });
+
+  describe('escalation', () => {
+    it('escalates severity once occurrence count reaches the configured threshold', async () => {
+      const subjectId = randomUUID();
+      const first = await repository.recordDetection(detection({ subjectId }));
+      expect(first.incident.severity).toBe(OracleIncidentSeverity.Warning);
+
+      const second = await repository.recordDetection(detection({ subjectId }));
+      expect(second.escalated).toBe(false);
+      expect(second.incident.severity).toBe(OracleIncidentSeverity.Warning);
+
+      // ORACLE_INCIDENT_ESCALATION_THRESHOLDS='3:critical' set in beforeAll.
+      const third = await repository.recordDetection(detection({ subjectId }));
+      expect(third.escalated).toBe(true);
+      expect(third.incident.severity).toBe(OracleIncidentSeverity.Critical);
+      expect(third.incident.occurrenceCount).toBe(3);
+
+      // Does not re-fire "escalated" once already at the target severity.
+      const fourth = await repository.recordDetection(detection({ subjectId }));
+      expect(fourth.escalated).toBe(false);
+      expect(fourth.incident.severity).toBe(OracleIncidentSeverity.Critical);
+    });
+  });
+
+  describe('acknowledgement', () => {
+    it('acknowledges an active incident', async () => {
+      const { incident } = await repository.recordDetection(detection());
+      const acknowledged = await repository.acknowledge(incident.id, 'GADMIN...OPERATOR');
+
+      expect(acknowledged.status).toBe(OracleIncidentStatus.Acknowledged);
+      expect(acknowledged.acknowledgedBy).toBe('GADMIN...OPERATOR');
+      expect(acknowledged.acknowledgedAt).not.toBeNull();
+    });
+
+    it('rejects acknowledging an incident that is already acknowledged', async () => {
+      const { incident } = await repository.recordDetection(detection());
+      await repository.acknowledge(incident.id, 'GADMIN...OPERATOR');
+
+      await expect(repository.acknowledge(incident.id, 'GADMIN...OPERATOR')).rejects.toThrow();
+    });
+
+    it('rejects acknowledging a resolved incident', async () => {
+      const { incident } = await repository.recordDetection(detection());
+      await repository.resolve(incident.id, 'GADMIN...OPERATOR');
+
+      await expect(repository.acknowledge(incident.id, 'GADMIN...OPERATOR')).rejects.toThrow();
+    });
+
+    it('rejects acknowledging an incident that does not exist', async () => {
+      await expect(repository.acknowledge(randomUUID(), 'GADMIN...OPERATOR')).rejects.toThrow();
+    });
+  });
+
+  describe('resolution', () => {
+    it('resolves an active incident directly', async () => {
+      const { incident } = await repository.recordDetection(detection());
+      const resolved = await repository.resolve(incident.id, 'GADMIN...OPERATOR', 'provider back online');
+
+      expect(resolved.status).toBe(OracleIncidentStatus.Resolved);
+      expect(resolved.resolvedBy).toBe('GADMIN...OPERATOR');
+      expect(resolved.resolutionNote).toBe('provider back online');
+      expect(resolved.resolvedAt).not.toBeNull();
+    });
+
+    it('resolves an already-acknowledged incident', async () => {
+      const { incident } = await repository.recordDetection(detection());
+      await repository.acknowledge(incident.id, 'GADMIN...OPERATOR');
+      const resolved = await repository.resolve(incident.id, 'GADMIN...OPERATOR');
+
+      expect(resolved.status).toBe(OracleIncidentStatus.Resolved);
+    });
+
+    it('rejects resolving an incident that is already resolved', async () => {
+      const { incident } = await repository.recordDetection(detection());
+      await repository.resolve(incident.id, 'GADMIN...OPERATOR');
+
+      await expect(repository.resolve(incident.id, 'GADMIN...OPERATOR')).rejects.toThrow();
+    });
+  });
+
+  describe('recurrence', () => {
+    it('opens a new incident when the same subject goes stale again after resolution', async () => {
+      const subjectId = randomUUID();
+      const first = await repository.recordDetection(detection({ subjectId, detectedAt: '2026-03-01T00:00:00.000Z' }));
+      await repository.resolve(first.incident.id, 'GADMIN...OPERATOR');
+
+      const recurrence = await repository.recordDetection(detection({ subjectId, detectedAt: '2026-04-01T00:00:00.000Z' }));
+
+      expect(recurrence.isNew).toBe(true);
+      expect(recurrence.incident.id).not.toBe(first.incident.id);
+      expect(recurrence.incident.status).toBe(OracleIncidentStatus.Active);
+      expect(recurrence.incident.occurrenceCount).toBe(1);
+
+      // The resolved incident's history is preserved, not overwritten.
+      const resolvedHistory = await repository.findById(first.incident.id);
+      expect(resolvedHistory?.status).toBe(OracleIncidentStatus.Resolved);
+    });
+  });
+
+  describe('listing', () => {
+    it('filters by status and paginates results', async () => {
+      const resolvedOne = await repository.recordDetection(detection());
+      await repository.resolve(resolvedOne.incident.id, 'GADMIN...OPERATOR');
+      await repository.recordDetection(detection());
+
+      const activeOnly = await repository.findMany(1, 50, OracleIncidentStatus.Active);
+      expect(activeOnly.data.every((incident) => incident.status === OracleIncidentStatus.Active)).toBe(true);
+
+      const resolvedOnly = await repository.findMany(1, 50, OracleIncidentStatus.Resolved);
+      expect(resolvedOnly.data.some((incident) => incident.id === resolvedOne.incident.id)).toBe(true);
+
+      const page1 = await repository.findMany(1, 1);
+      expect(page1.data).toHaveLength(1);
+      expect(page1.meta.limit).toBe(1);
+      // With limit=1, totalPages == total exactly (ceil(total / 1) == total).
+      expect(page1.meta.totalPages).toBe(page1.meta.total);
+    });
+  });
+});

--- a/api/src/oracle/oracle-incident.repository.ts
+++ b/api/src/oracle/oracle-incident.repository.ts
@@ -1,0 +1,306 @@
+import { Injectable, Logger, OnModuleDestroy, OnModuleInit, NotFoundException } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import { Pool } from 'pg';
+import { PaginatedResponse } from '../common/dto/pagination.dto';
+import {
+  IncidentDetectionInput,
+  IncidentDetectionResult,
+  OracleIncident,
+  OracleIncidentDetails,
+  OracleIncidentSeverity,
+  OracleIncidentStatus,
+} from './interfaces/oracle-incident.interface';
+
+/**
+ * Durable store for oracle incidents (issue #95).
+ *
+ * Postgres, not Redis, is the source of truth: the contributor guidance for
+ * this issue is explicit that alerting state is operational/audit data, and
+ * `RedisService` (`api/src/common/services/redis.service.ts`) is designed to
+ * degrade -- every read/write there logs a warning and continues on failure
+ * (see its `logDegraded`). That is the right behavior for a cache, but wrong
+ * for the only record of "was this incident acknowledged and by whom."
+ * `DATABASE_URL` is already provisioned in `docker-compose.yml` and
+ * documented in `.env.example`/`README.md`; nothing in this API used it
+ * before this table.
+ *
+ * Dedup and recurrence are both enforced by a single Postgres construct: a
+ * partial unique index on `dedupe_key` scoped to non-resolved rows. An
+ * `INSERT ... ON CONFLICT (dedupe_key) WHERE status <> 'resolved' DO UPDATE`
+ * can therefore only ever match an *unresolved* incident for the same
+ * subject -- a fresh INSERT proceeds instead once the prior one is resolved,
+ * which is exactly a "recurrence" (a new incident row, not silently merged
+ * into stale historical state). This is atomic at the database level, so
+ * repeated or concurrent cron cycles (including multiple API replicas
+ * evaluating the same cycle) cannot create duplicate active rows for the
+ * same subject -- Postgres's own conflict resolution serializes it, with no
+ * application-level locking required.
+ */
+
+interface EscalationThreshold {
+  occurrences: number;
+  severity: OracleIncidentSeverity;
+}
+
+const DEFAULT_ESCALATION_THRESHOLDS: EscalationThreshold[] = [
+  { occurrences: 3, severity: OracleIncidentSeverity.Critical },
+];
+
+/**
+ * Parses `ORACLE_INCIDENT_ESCALATION_THRESHOLDS` (format: "count:severity,count:severity",
+ * e.g. "3:critical,10:critical") the same way `oracle.monitoring.service.ts`'s
+ * `CADENCE_OVERRIDES` reads its own env override -- a small, explicit,
+ * validated array, not a generic config framework. Invalid or unparseable
+ * entries are skipped; an empty or entirely-invalid value falls back to the
+ * default so a typo in configuration cannot silently disable escalation.
+ */
+function parseEscalationThresholds(raw: string | undefined): EscalationThreshold[] {
+  if (!raw) return DEFAULT_ESCALATION_THRESHOLDS;
+
+  const validSeverities = new Set(Object.values(OracleIncidentSeverity));
+  const parsed: EscalationThreshold[] = [];
+  for (const entry of raw.split(',')) {
+    const [countRaw, severityRaw] = entry.split(':').map((part) => part.trim());
+    const occurrences = Number(countRaw);
+    if (Number.isFinite(occurrences) && occurrences > 0 && validSeverities.has(severityRaw as OracleIncidentSeverity)) {
+      parsed.push({ occurrences, severity: severityRaw as OracleIncidentSeverity });
+    }
+  }
+  return parsed.length > 0
+    ? parsed.sort((a, b) => a.occurrences - b.occurrences)
+    : DEFAULT_ESCALATION_THRESHOLDS;
+}
+
+/** O(k) in the number of configured thresholds (typically 1-3), not the occurrence count. */
+function severityForOccurrenceCount(count: number, thresholds: EscalationThreshold[]): OracleIncidentSeverity {
+  let severity = OracleIncidentSeverity.Warning;
+  for (const threshold of thresholds) {
+    if (count >= threshold.occurrences) severity = threshold.severity;
+  }
+  return severity;
+}
+
+export function buildDedupeKey(subjectType: string, subjectId: string): string {
+  return `${subjectType}:${subjectId}`;
+}
+
+interface IncidentRow {
+  id: string;
+  dedupe_key: string;
+  subject_type: string;
+  subject_id: string;
+  status: string;
+  severity: string;
+  occurrence_count: number;
+  first_detected_at: Date;
+  last_detected_at: Date;
+  acknowledged_at: Date | null;
+  acknowledged_by: string | null;
+  resolved_at: Date | null;
+  resolved_by: string | null;
+  resolution_note: string | null;
+  details: OracleIncidentDetails | null;
+  created_at: Date;
+  updated_at: Date;
+}
+
+@Injectable()
+export class OracleIncidentRepository implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(OracleIncidentRepository.name);
+  private readonly pool: Pool;
+  private readonly escalationThresholds: EscalationThreshold[];
+
+  constructor() {
+    this.pool = new Pool({ connectionString: process.env.DATABASE_URL });
+    this.escalationThresholds = parseEscalationThresholds(
+      process.env.ORACLE_INCIDENT_ESCALATION_THRESHOLDS,
+    );
+  }
+
+  async onModuleInit(): Promise<void> {
+    await this.pool.query(`
+      CREATE TABLE IF NOT EXISTS oracle_incidents (
+        id UUID PRIMARY KEY,
+        dedupe_key TEXT NOT NULL,
+        subject_type TEXT NOT NULL,
+        subject_id TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'active',
+        severity TEXT NOT NULL DEFAULT 'warning',
+        occurrence_count INTEGER NOT NULL DEFAULT 1,
+        first_detected_at TIMESTAMPTZ NOT NULL,
+        last_detected_at TIMESTAMPTZ NOT NULL,
+        acknowledged_at TIMESTAMPTZ,
+        acknowledged_by TEXT,
+        resolved_at TIMESTAMPTZ,
+        resolved_by TEXT,
+        resolution_note TEXT,
+        details JSONB,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+      );
+
+      CREATE UNIQUE INDEX IF NOT EXISTS oracle_incidents_active_dedupe_key
+        ON oracle_incidents (dedupe_key)
+        WHERE status <> 'resolved';
+
+      CREATE INDEX IF NOT EXISTS oracle_incidents_status_idx ON oracle_incidents (status);
+    `);
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    await this.pool.end();
+  }
+
+  /**
+   * Record one detection of a stale condition. Creates a new incident if
+   * none is currently unresolved for this subject (first occurrence, or a
+   * recurrence after a prior incident was resolved); otherwise updates the
+   * existing unresolved incident's occurrence count and detection metadata.
+   *
+   * O(1): a single indexed upsert, plus at most one follow-up single-row
+   * update when the occurrence count crosses an escalation threshold.
+   */
+  async recordDetection(input: IncidentDetectionInput): Promise<IncidentDetectionResult> {
+    const dedupeKey = buildDedupeKey(input.subjectType, input.subjectId);
+    const id = randomUUID();
+
+    const upsertResult = await this.pool.query<IncidentRow>(
+      `
+      INSERT INTO oracle_incidents (
+        id, dedupe_key, subject_type, subject_id, status, severity,
+        occurrence_count, first_detected_at, last_detected_at, details
+      )
+      VALUES ($1, $2, $3, $4, 'active', 'warning', 1, $5, $5, $6)
+      ON CONFLICT (dedupe_key) WHERE status <> 'resolved'
+      DO UPDATE SET
+        occurrence_count = oracle_incidents.occurrence_count + 1,
+        last_detected_at = EXCLUDED.last_detected_at,
+        details = EXCLUDED.details,
+        updated_at = now()
+      RETURNING *;
+      `,
+      [id, dedupeKey, input.subjectType, input.subjectId, input.detectedAt, input.details],
+    );
+
+    const row = upsertResult.rows[0];
+    // A fresh row (first occurrence, or a recurrence after resolution) always
+    // starts at occurrence_count = 1 from the VALUES clause above; the
+    // DO UPDATE branch always increments past 1. This distinguishes the two
+    // cases without a second round-trip or relying on Postgres's internal
+    // xmax system column.
+    const isNew = row.occurrence_count === 1;
+
+    const targetSeverity = severityForOccurrenceCount(row.occurrence_count, this.escalationThresholds);
+    let finalRow = row;
+    const escalated = targetSeverity !== (row.severity as OracleIncidentSeverity);
+    if (escalated) {
+      const escalateResult = await this.pool.query<IncidentRow>(
+        `UPDATE oracle_incidents SET severity = $1, updated_at = now() WHERE id = $2 RETURNING *;`,
+        [targetSeverity, row.id],
+      );
+      finalRow = escalateResult.rows[0];
+    }
+
+    return { incident: this.toIncident(finalRow), isNew, escalated };
+  }
+
+  async findMany(
+    page = 1,
+    limit = 20,
+    status?: OracleIncidentStatus,
+  ): Promise<PaginatedResponse<OracleIncident>> {
+    const offset = (page - 1) * limit;
+    const whereClause = status ? 'WHERE status = $1' : '';
+    const params = status ? [status] : [];
+
+    const [rowsResult, countResult] = await Promise.all([
+      this.pool.query<IncidentRow>(
+        `SELECT * FROM oracle_incidents ${whereClause}
+         ORDER BY last_detected_at DESC
+         LIMIT $${params.length + 1} OFFSET $${params.length + 2};`,
+        [...params, limit, offset],
+      ),
+      this.pool.query<{ count: string }>(
+        `SELECT COUNT(*) FROM oracle_incidents ${whereClause};`,
+        params,
+      ),
+    ]);
+
+    const total = Number(countResult.rows[0].count);
+    return {
+      data: rowsResult.rows.map((row) => this.toIncident(row)),
+      meta: { page, limit, total, totalPages: Math.ceil(total / limit) },
+    };
+  }
+
+  async findById(id: string): Promise<OracleIncident | null> {
+    const result = await this.pool.query<IncidentRow>(
+      `SELECT * FROM oracle_incidents WHERE id = $1;`,
+      [id],
+    );
+    return result.rows[0] ? this.toIncident(result.rows[0]) : null;
+  }
+
+  async acknowledge(id: string, acknowledgedBy: string): Promise<OracleIncident> {
+    const result = await this.pool.query<IncidentRow>(
+      `
+      UPDATE oracle_incidents
+      SET status = 'acknowledged', acknowledged_at = now(), acknowledged_by = $2, updated_at = now()
+      WHERE id = $1 AND status = 'active'
+      RETURNING *;
+      `,
+      [id, acknowledgedBy],
+    );
+    if (result.rows.length === 0) {
+      await this.assertExists(id);
+      throw new NotFoundException(`Incident ${id} is not in an active state and cannot be acknowledged.`);
+    }
+    return this.toIncident(result.rows[0]);
+  }
+
+  async resolve(id: string, resolvedBy: string, resolutionNote?: string): Promise<OracleIncident> {
+    const result = await this.pool.query<IncidentRow>(
+      `
+      UPDATE oracle_incidents
+      SET status = 'resolved', resolved_at = now(), resolved_by = $2, resolution_note = $3, updated_at = now()
+      WHERE id = $1 AND status <> 'resolved'
+      RETURNING *;
+      `,
+      [id, resolvedBy, resolutionNote ?? null],
+    );
+    if (result.rows.length === 0) {
+      await this.assertExists(id);
+      throw new NotFoundException(`Incident ${id} is already resolved.`);
+    }
+    return this.toIncident(result.rows[0]);
+  }
+
+  private async assertExists(id: string): Promise<void> {
+    const existing = await this.findById(id);
+    if (!existing) {
+      throw new NotFoundException(`Incident ${id} not found.`);
+    }
+  }
+
+  private toIncident(row: IncidentRow): OracleIncident {
+    return {
+      id: row.id,
+      dedupeKey: row.dedupe_key,
+      subjectType: row.subject_type as OracleIncident['subjectType'],
+      subjectId: row.subject_id,
+      status: row.status as OracleIncidentStatus,
+      severity: row.severity as OracleIncidentSeverity,
+      occurrenceCount: row.occurrence_count,
+      firstDetectedAt: row.first_detected_at.toISOString(),
+      lastDetectedAt: row.last_detected_at.toISOString(),
+      acknowledgedAt: row.acknowledged_at ? row.acknowledged_at.toISOString() : null,
+      acknowledgedBy: row.acknowledged_by,
+      resolvedAt: row.resolved_at ? row.resolved_at.toISOString() : null,
+      resolvedBy: row.resolved_by,
+      resolutionNote: row.resolution_note,
+      details: row.details,
+      createdAt: row.created_at.toISOString(),
+      updatedAt: row.updated_at.toISOString(),
+    };
+  }
+}

--- a/api/src/oracle/oracle.controller.ts
+++ b/api/src/oracle/oracle.controller.ts
@@ -1,12 +1,17 @@
 import {
-  Controller, Get, Post, Body, Param, Req,
-  HttpCode, HttpStatus, ParseIntPipe,
+  Controller, Get, Post, Body, Param, Query, Req,
+  HttpCode, HttpStatus, ParseIntPipe, UseGuards,
 } from '@nestjs/common';
 import { OracleService } from './oracle.service';
 import { OracleMonitoringService } from './oracle.monitoring.service';
+import { OracleIncidentRepository } from './oracle-incident.repository';
 import { SubmitReportDto } from './dto/submit-report.dto';
 import { ChallengeDto } from './dto/challenge.dto';
 import { RegisterProviderDto } from './dto/register-provider.dto';
+import { ListOracleIncidentsDto } from './dto/list-oracle-incidents.dto';
+import { ResolveOracleIncidentDto } from './dto/resolve-oracle-incident.dto';
+import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
+import { AdminGuard } from '../common/guards/admin.guard';
 import {
   ReportResponse,
   ChallengeResponse,
@@ -14,12 +19,15 @@ import {
   ProviderStatsWithHistory,
   OracleStalenessReport,
 } from './interfaces/oracle.interface';
+import { OracleIncident } from './interfaces/oracle-incident.interface';
+import { PaginatedResponse } from '../common/dto/pagination.dto';
 
 @Controller('oracle')
 export class OracleController {
   constructor(
     private readonly oracleService: OracleService,
     private readonly monitoringService: OracleMonitoringService,
+    private readonly incidents: OracleIncidentRepository,
   ) {}
 
   @Post('reports')
@@ -71,5 +79,42 @@ export class OracleController {
   @Get('monitoring/staleness')
   async staleness(): Promise<OracleStalenessReport> {
     return this.monitoringService.computeStaleness();
+  }
+
+  /**
+   * Operator-facing incident surface (issue #95). Admin-guarded like the
+   * other privileged actions in this API (e.g. `BondsController`'s
+   * `sweep-undistributed` and `admin.guard.ts`'s own doc comment): incident
+   * acknowledgement/resolution is operational state, not public data.
+   */
+  @Get('incidents')
+  @UseGuards(JwtAuthGuard, AdminGuard)
+  async listIncidents(
+    @Query() query: ListOracleIncidentsDto,
+  ): Promise<PaginatedResponse<OracleIncident>> {
+    return this.incidents.findMany(query.page, query.limit, query.status);
+  }
+
+  @Post('incidents/:id/acknowledge')
+  @UseGuards(JwtAuthGuard, AdminGuard)
+  @HttpCode(HttpStatus.OK)
+  async acknowledgeIncident(
+    @Param('id') id: string,
+    @Req() req: any,
+  ): Promise<OracleIncident> {
+    const acknowledgedBy = req.headers['x-wallet-address'] as string || '';
+    return this.incidents.acknowledge(id, acknowledgedBy);
+  }
+
+  @Post('incidents/:id/resolve')
+  @UseGuards(JwtAuthGuard, AdminGuard)
+  @HttpCode(HttpStatus.OK)
+  async resolveIncident(
+    @Param('id') id: string,
+    @Body() dto: ResolveOracleIncidentDto,
+    @Req() req: any,
+  ): Promise<OracleIncident> {
+    const resolvedBy = req.headers['x-wallet-address'] as string || '';
+    return this.incidents.resolve(id, resolvedBy, dto.resolutionNote);
   }
 }

--- a/api/src/oracle/oracle.module.ts
+++ b/api/src/oracle/oracle.module.ts
@@ -5,6 +5,7 @@ import { OracleController } from './oracle.controller';
 import { OracleService } from './oracle.service';
 import { OracleScheduler } from './oracle.scheduler';
 import { OracleMonitoringService } from './oracle.monitoring.service';
+import { OracleIncidentRepository } from './oracle-incident.repository';
 import { VerraProvider } from './providers/verra.provider';
 import { SatelliteProvider } from './providers/satellite.provider';
 import { BlueCarbonProvider } from './providers/blue-carbon.provider';
@@ -16,6 +17,7 @@ import { BlueCarbonProvider } from './providers/blue-carbon.provider';
     OracleService,
     OracleScheduler,
     OracleMonitoringService,
+    OracleIncidentRepository,
     VerraProvider,
     SatelliteProvider,
     BlueCarbonProvider,

--- a/api/src/oracle/oracle.monitoring.service.spec.ts
+++ b/api/src/oracle/oracle.monitoring.service.spec.ts
@@ -2,7 +2,9 @@ import { Test } from '@nestjs/testing';
 import { OracleMonitoringService } from './oracle.monitoring.service';
 import { ProjectsService } from '../projects/projects.service';
 import { OracleService } from './oracle.service';
+import { OracleIncidentRepository } from './oracle-incident.repository';
 import { ReportStatus } from './interfaces/oracle.interface';
+import { OracleIncidentSeverity, OracleIncidentStatus, OracleIncidentSubjectType } from './interfaces/oracle-incident.interface';
 
 const NOW = Date.UTC(2026, 0, 1, 0, 0, 0);
 const DAY = 24 * 60 * 60 * 1000;
@@ -12,6 +14,7 @@ describe('OracleMonitoringService', () => {
   let service: OracleMonitoringService;
   let projectsService: { findAll: jest.Mock };
   let oracleService: { getProjectReports: jest.Mock };
+  let incidentRepository: { recordDetection: jest.Mock };
 
   const makeProject = (id: number, methodology: string, createdAt = NOW - DAY) => ({
     id,
@@ -43,12 +46,14 @@ describe('OracleMonitoringService', () => {
   beforeEach(async () => {
     projectsService = { findAll: jest.fn() };
     oracleService = { getProjectReports: jest.fn() };
+    incidentRepository = { recordDetection: jest.fn() };
 
     const moduleRef = await Test.createTestingModule({
       providers: [
         OracleMonitoringService,
         { provide: ProjectsService, useValue: projectsService },
         { provide: OracleService, useValue: oracleService },
+        { provide: OracleIncidentRepository, useValue: incidentRepository },
       ],
     }).compile();
 
@@ -149,6 +154,120 @@ describe('OracleMonitoringService', () => {
       const report = await service.computeStaleness(NOW);
       expect(report.projects[0].isStale).toBe(true);
       expect(report.projects).toHaveLength(1);
+    });
+  });
+
+  describe('syncIncidents (#95)', () => {
+    function fakeIncident(overrides: Partial<{ id: string; occurrenceCount: number; severity: OracleIncidentSeverity }> = {}) {
+      return {
+        id: overrides.id ?? 'incident-1',
+        dedupeKey: 'project:1',
+        subjectType: OracleIncidentSubjectType.Project,
+        subjectId: '1',
+        status: OracleIncidentStatus.Active,
+        severity: overrides.severity ?? OracleIncidentSeverity.Warning,
+        occurrenceCount: overrides.occurrenceCount ?? 1,
+        firstDetectedAt: new Date(NOW).toISOString(),
+        lastDetectedAt: new Date(NOW).toISOString(),
+        acknowledgedAt: null,
+        acknowledgedBy: null,
+        resolvedAt: null,
+        resolvedBy: null,
+        resolutionNote: null,
+        details: null,
+        createdAt: new Date(NOW).toISOString(),
+        updatedAt: new Date(NOW).toISOString(),
+      };
+    }
+
+    it('records a durable incident for a stale project instead of only logging', async () => {
+      projectsService.findAll.mockResolvedValue({
+        data: [makeProject(1, 'VERRA-VCS', NOW - CADENCE_GRACE_MS - DAY)],
+        meta: { total: 1 },
+      });
+      oracleService.getProjectReports.mockResolvedValue([]);
+      incidentRepository.recordDetection.mockResolvedValue({
+        incident: fakeIncident(),
+        isNew: true,
+        escalated: false,
+      });
+
+      const summary = await service.syncIncidents(NOW);
+
+      expect(incidentRepository.recordDetection).toHaveBeenCalledWith(
+        expect.objectContaining({ subjectType: OracleIncidentSubjectType.Project, subjectId: '1' }),
+      );
+      expect(summary).toEqual({ created: 1, updated: 0, escalated: 0 });
+    });
+
+    it('also records incidents for stale providers, not just stale projects', async () => {
+      projectsService.findAll.mockResolvedValue({
+        data: [makeProject(1, 'VERRA-VCS'), makeProject(2, 'VERRA-VCS')],
+        meta: { total: 2 },
+      });
+      // Both projects share a provider whose last report is far outside the
+      // reporting window, so the provider (not just the project) is stale.
+      oracleService.getProjectReports.mockResolvedValue([
+        makeReport(NOW - CADENCE_GRACE_MS - DAY, 'GSTALEPROVIDER'),
+      ]);
+      incidentRepository.recordDetection.mockImplementation(({ subjectType }) =>
+        Promise.resolve({
+          incident: fakeIncident({ id: `${subjectType}-incident` }),
+          isNew: true,
+          escalated: false,
+        }),
+      );
+
+      await service.syncIncidents(NOW);
+
+      expect(incidentRepository.recordDetection).toHaveBeenCalledWith(
+        expect.objectContaining({ subjectType: OracleIncidentSubjectType.Provider, subjectId: 'GSTALEPROVIDER' }),
+      );
+    });
+
+    it('does not record an incident for a project or provider that is not stale', async () => {
+      projectsService.findAll.mockResolvedValue({
+        data: [makeProject(1, 'VERRA-VCS')],
+        meta: { total: 1 },
+      });
+      oracleService.getProjectReports.mockResolvedValue([makeReport(NOW - DAY, 'GPROVIDER')]);
+
+      const summary = await service.syncIncidents(NOW);
+
+      expect(incidentRepository.recordDetection).not.toHaveBeenCalled();
+      expect(summary).toEqual({ created: 0, updated: 0, escalated: 0 });
+    });
+
+    it('tallies an existing incident as updated, not created, on a repeated cron cycle', async () => {
+      projectsService.findAll.mockResolvedValue({
+        data: [makeProject(1, 'VERRA-VCS', NOW - CADENCE_GRACE_MS - DAY)],
+        meta: { total: 1 },
+      });
+      oracleService.getProjectReports.mockResolvedValue([]);
+      incidentRepository.recordDetection.mockResolvedValue({
+        incident: fakeIncident({ occurrenceCount: 2 }),
+        isNew: false,
+        escalated: false,
+      });
+
+      const summary = await service.syncIncidents(NOW);
+      expect(summary).toEqual({ created: 0, updated: 1, escalated: 0 });
+    });
+
+    it('tallies an escalation separately from the created/updated counts', async () => {
+      projectsService.findAll.mockResolvedValue({
+        data: [makeProject(1, 'VERRA-VCS', NOW - CADENCE_GRACE_MS - DAY)],
+        meta: { total: 1 },
+      });
+      oracleService.getProjectReports.mockResolvedValue([]);
+      incidentRepository.recordDetection.mockResolvedValue({
+        incident: fakeIncident({ occurrenceCount: 3, severity: OracleIncidentSeverity.Critical }),
+        isNew: false,
+        escalated: true,
+      });
+
+      const summary = await service.syncIncidents(NOW);
+      expect(summary).toEqual({ created: 0, updated: 1, escalated: 1 });
     });
   });
 });

--- a/api/src/oracle/oracle.monitoring.service.ts
+++ b/api/src/oracle/oracle.monitoring.service.ts
@@ -1,13 +1,18 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { RedisService } from '../common/services/redis.service';
 import { ProjectsService } from '../projects/projects.service';
 import { OracleService } from './oracle.service';
+import { OracleIncidentRepository } from './oracle-incident.repository';
 import {
   ReportStatus,
   StalenessMetric,
   ProviderStalenessMetric,
   OracleStalenessReport,
 } from './interfaces/oracle.interface';
+import {
+  IncidentDetectionResult,
+  OracleIncidentSubjectType,
+  OracleIncidentSyncSummary,
+} from './interfaces/oracle-incident.interface';
 
 const DEFAULT_CADENCE_SECONDS = 365 * 24 * 60 * 60;
 const DEFAULT_GRACE_SECONDS = 30 * 24 * 60 * 60;
@@ -15,7 +20,6 @@ const CADENCE_OVERRIDES: Array<{ pattern: RegExp; seconds: number }> = [
   { pattern: /REMOTE.?SENSING|SATELLITE/i, seconds: 90 * 24 * 60 * 60 },
   { pattern: /IOT|SENSOR/i, seconds: 30 * 24 * 60 * 60 },
 ];
-const ALERT_REARM_SECONDS = 24 * 60 * 60;
 
 function cadenceForMethodology(methodology: string): number {
   for (const override of CADENCE_OVERRIDES) {
@@ -41,7 +45,7 @@ export class OracleMonitoringService {
   constructor(
     private readonly projectsService: ProjectsService,
     private readonly oracleService: OracleService,
-    private readonly redis: RedisService,
+    private readonly incidents: OracleIncidentRepository,
   ) {}
 
   async computeStaleness(now: number = Date.now()): Promise<OracleStalenessReport> {
@@ -92,32 +96,78 @@ export class OracleMonitoringService {
     };
   }
 
-  async alertStaleProjects(now: number = Date.now()): Promise<number> {
+  /**
+   * Evaluate the current staleness report and reconcile durable incidents
+   * for every stale project and stale provider (issue #95). Each detection
+   * is recorded via `OracleIncidentRepository.recordDetection`, which
+   * dedupes/updates in place -- so a repeated cron cycle over an
+   * already-open incident produces a database update, not a new row, and
+   * (per `recordAndLog` below) does not re-emit a log line unless the
+   * incident is new or has just escalated. This is the fix for "repeated
+   * cron cycles can spam logs": the previous implementation only
+   * rate-limited the log line via a Redis TTL key and never persisted
+   * anything an operator could query, acknowledge, or resolve.
+   */
+  async syncIncidents(now: number = Date.now()): Promise<OracleIncidentSyncSummary> {
     const report = await this.computeStaleness(now);
-    const stale = report.projects.filter((metric) => metric.isStale);
+    const detectedAt = new Date(now).toISOString();
+    const summary: OracleIncidentSyncSummary = { created: 0, updated: 0, escalated: 0 };
 
-    let alerted = 0;
-    for (const metric of stale) {
-      const rearmKey = `oracle:alerts:${metric.projectId}`;
-      const lastAlert = await this.redis.get(rearmKey);
-      if (lastAlert && now - Number(lastAlert) < ALERT_REARM_SECONDS * 1000) {
-        continue;
-      }
+    for (const metric of report.projects.filter((m) => m.isStale)) {
+      const result = await this.recordAndLog(OracleIncidentSubjectType.Project, metric.projectId, detectedAt, {
+        lastVerifiedAt: metric.lastVerifiedAt,
+        expectedNextReportAt: metric.expectedNextReportAt,
+        stalenessSeconds: metric.stalenessSeconds,
+      });
+      this.tally(summary, result);
+    }
 
-      this.logger.warn(
-        `Oracle alert: project ${metric.projectId} is stale. ` +
-          `Last verified: ${metric.lastVerifiedAt ?? 'never'}, ` +
-          `expected next report by ${metric.expectedNextReportAt}, ` +
-          `staleness: ${this.formatDuration(metric.stalenessSeconds ?? 0)}`,
+    for (const metric of report.providers.filter((m) => m.isStale)) {
+      const result = await this.recordAndLog(OracleIncidentSubjectType.Provider, metric.providerAddress, detectedAt, {
+        lastVerifiedAt: metric.lastVerifiedAt,
+        expectedNextReportAt: metric.expectedNextReportAt,
+        stalenessSeconds: metric.stalenessSeconds,
+        projectIds: metric.projectIds,
+      });
+      this.tally(summary, result);
+    }
+
+    if (summary.created + summary.updated > 0) {
+      this.logger.log(
+        `Oracle monitoring: ${summary.created} incident(s) created, ${summary.updated} updated, ` +
+          `${summary.escalated} escalated this cycle`,
       );
-      await this.redis.set(rearmKey, String(now));
-      alerted += 1;
     }
+    return summary;
+  }
 
-    if (alerted > 0) {
-      this.logger.warn(`Oracle monitoring: ${alerted} stale project(s) alerted this cycle`);
+  private async recordAndLog(
+    subjectType: OracleIncidentSubjectType,
+    subjectId: string,
+    detectedAt: string,
+    details: { lastVerifiedAt?: string; expectedNextReportAt?: string; stalenessSeconds?: number; projectIds?: string[] },
+  ): Promise<IncidentDetectionResult> {
+    const result = await this.incidents.recordDetection({ subjectType, subjectId, detectedAt, details });
+
+    if (result.isNew) {
+      this.logger.warn(
+        `Oracle incident opened: ${subjectType} ${subjectId} is stale. ` +
+          `Last verified: ${details.lastVerifiedAt ?? 'never'}, ` +
+          `staleness: ${this.formatDuration(details.stalenessSeconds ?? 0)} (incident ${result.incident.id})`,
+      );
+    } else if (result.escalated) {
+      this.logger.warn(
+        `Oracle incident escalated to ${result.incident.severity}: ${subjectType} ${subjectId} ` +
+          `(occurrence #${result.incident.occurrenceCount}, incident ${result.incident.id})`,
+      );
     }
-    return alerted;
+    return result;
+  }
+
+  private tally(summary: OracleIncidentSyncSummary, result: IncidentDetectionResult): void {
+    if (result.isNew) summary.created += 1;
+    else summary.updated += 1;
+    if (result.escalated) summary.escalated += 1;
   }
 
   private buildProjectMetric(

--- a/api/src/oracle/oracle.scheduler.ts
+++ b/api/src/oracle/oracle.scheduler.ts
@@ -44,9 +44,10 @@ export class OracleScheduler {
     this.logger.log('Oracle reliability monitoring cycle started');
 
     try {
-      const alerted = await this.monitoringService.alertStaleProjects();
+      const summary = await this.monitoringService.syncIncidents();
       this.logger.log(
-        `Oracle reliability monitoring cycle completed: ${alerted} alert(s) emitted`,
+        `Oracle reliability monitoring cycle completed: ${summary.created} incident(s) created, ` +
+          `${summary.updated} updated, ${summary.escalated} escalated`,
       );
     } catch (error) {
       this.logger.error(`Oracle reliability monitoring error: ${error.message}`);

--- a/api/test-setup/embedded-postgres-server.mjs
+++ b/api/test-setup/embedded-postgres-server.mjs
@@ -1,0 +1,32 @@
+import EmbeddedPostgres from 'embedded-postgres';
+import os from 'os';
+import path from 'path';
+import crypto from 'crypto';
+
+const port = Number(process.argv[2] || 57432);
+const databaseDir = path.join(os.tmpdir(), `oracle-incident-repo-test-${crypto.randomUUID()}`);
+
+const pg = new EmbeddedPostgres({
+  databaseDir,
+  user: 'test',
+  password: 'test',
+  port,
+  persistent: false,
+});
+
+await pg.initialise();
+await pg.start();
+await pg.createDatabase('testdb');
+
+console.log(`PGREADY:postgresql://test:test@localhost:${port}/testdb`);
+
+async function shutdown() {
+  try {
+    await pg.stop();
+  } finally {
+    process.exit(0);
+  }
+}
+
+process.on('SIGTERM', shutdown);
+process.on('SIGINT', shutdown);

--- a/docs/runbook-degraded-providers.md
+++ b/docs/runbook-degraded-providers.md
@@ -11,7 +11,7 @@ provider health, what alerts mean, and how to respond.
 | Adapter health | `oracle` monitor, `GET /health` | Per-adapter upstream probe: `up` / `degraded` / `down` + latency |
 | Report staleness | API, `GET /oracle/monitoring/staleness` | Per-project and per-provider time since last verified report vs. expected window |
 | Provider stats | API, `GET /oracle/stats/:providerAddress` | Reports submitted, challenges faced, slash history (from chain) |
-| Alert log | API scheduler | Log-based alert when a project misses its reporting window + grace |
+| Oracle incidents | API, `GET /oracle/incidents` (admin) | Durable, queryable record of every stale project/provider: active, acknowledged, or resolved, with occurrence count and severity |
 
 ### Starting the oracle monitor
 
@@ -59,9 +59,71 @@ curl http://localhost:3000/oracle/monitoring/staleness
 - A project with no verified report falls back to its `createdAt` as baseline.
 - `isStale = now > expectedNextReportAt`.
 
-The API scheduler evaluates this every 6 hours, logs a `WARN` per stale project
-(redis-deduplicated so each project alerts at most once per 24h), and the
-result is queryable at `GET /oracle/monitoring/staleness`.
+The API scheduler evaluates this every 6 hours and reconciles a durable
+**oracle incident** (see below) for every stale project *and* stale provider.
+The staleness snapshot itself remains queryable at
+`GET /oracle/monitoring/staleness`; the incident history derived from it is
+queryable at `GET /oracle/incidents`.
+
+## Oracle incident lifecycle
+
+Each stale condition (one project, or one provider aggregated across its
+projects) is tracked as a durable incident in Postgres, not just a log line
+-- log-only alerting gave operators no way to see what was currently
+degraded, acknowledge that someone was handling it, or confirm it had
+actually been resolved.
+
+**Status**: `active` -> `acknowledged` -> `resolved`. An incident can be
+resolved directly from `active` (acknowledgement is optional, not a required
+step).
+
+**Deduplication**: a project or provider that is still stale on the next
+6-hourly cron cycle updates its existing incident (`occurrenceCount` +1,
+`lastDetectedAt` refreshed) instead of creating a new one. This is enforced
+at the database level (a partial unique index on the incident's dedupe key,
+scoped to non-resolved rows), so it holds even if the scheduler somehow runs
+concurrently across multiple API instances.
+
+**Escalation**: `severity` starts at `warning`. Once `occurrenceCount`
+reaches a configurable threshold, it escalates to `critical`. Configure via
+`ORACLE_INCIDENT_ESCALATION_THRESHOLDS`, a comma-separated `count:severity`
+list, e.g. `3:critical` (the default -- three consecutive 6-hourly cycles,
+i.e. ~18 hours of continuous staleness). The log line
+`Oracle incident escalated to critical: ...` marks the transition.
+
+**Recurrence**: once an incident is resolved, the *next* time the same
+project or provider goes stale, a brand-new incident is opened
+(`occurrenceCount` restarts at 1) rather than reopening the resolved one --
+the resolved incident's history (who resolved it, when, and any note) is
+never overwritten.
+
+### Managing incidents via API
+
+All three endpoints require an authenticated admin session
+(`JwtAuthGuard` + `AdminGuard`, same as other privileged endpoints like
+`POST /bonds/:id/sweep-undistributed`).
+
+```bash
+# List active incidents (also accepts status=acknowledged / status=resolved, page, limit)
+curl -H "Authorization: Bearer $ADMIN_JWT" \
+  "http://localhost:3000/oracle/incidents?status=active"
+
+# Acknowledge an incident (someone is investigating)
+curl -X POST -H "Authorization: Bearer $ADMIN_JWT" \
+  -H "x-wallet-address: $ADMIN_ADDRESS" \
+  http://localhost:3000/oracle/incidents/<incident-id>/acknowledge
+
+# Resolve an incident once the underlying cause is fixed
+curl -X POST -H "Authorization: Bearer $ADMIN_JWT" \
+  -H "x-wallet-address: $ADMIN_ADDRESS" -H "Content-Type: application/json" \
+  -d '{"resolutionNote": "Provider ingest job restarted; fresh report verified"}' \
+  http://localhost:3000/oracle/incidents/<incident-id>/resolve
+```
+
+Resolving before the underlying staleness clears is safe but temporary: if
+the project or provider is still stale on the next cron cycle, a new
+incident opens (see Recurrence above) -- resolving is a record of "this was
+handled," not a suppression switch.
 
 ## Interpreting provider stats
 
@@ -80,7 +142,8 @@ zeroed), has been through the enforcement path and should be reviewed.
 
 | Alert | Meaning | Action |
 |-------|---------|--------|
-| `Oracle alert: project X is stale` | No verified report within cadence + grace | Contact provider; verify ingest jobs are running; check adapter health |
+| `Oracle incident opened: project/provider X is stale` | New incident: no verified report within cadence + grace | Contact provider; verify ingest jobs are running; check adapter health; then acknowledge the incident via `POST /oracle/incidents/:id/acknowledge` |
+| `Oracle incident escalated to critical: ...` | Same incident has now recurred past `ORACLE_INCIDENT_ESCALATION_THRESHOLDS` | Treat as a priority page, not routine monitoring -- see `GET /oracle/incidents?status=active` for `occurrenceCount` |
 | `Adapter <x> status: down` | Upstream returned 5xx, timeout, or DNS failure | Check upstream provider status / credentials / network |
 | `Adapter <x> status: degraded` | 4xx response, or latency above threshold | Check API keys, rate limits, quota |
 | `provider slashed` event / `slashes > 0` | A rejected challenge applied the 10% penalty | Investigate report quality; watch stake; consider rotation |
@@ -103,3 +166,8 @@ zeroed), has been through the enforcement path and should be reviewed.
 6. **Verify recovery.** `GET /oracle/monitoring/staleness` should flip
    `isStale` to `false` for the affected projects within the next scheduler
    cycle.
+7. **Resolve the incident.** `POST /oracle/incidents/:id/resolve` with an
+   optional `resolutionNote`, once the cause is fixed. If staleness returns
+   later, a fresh incident opens rather than reusing this one (see
+   Recurrence above), so resolving does not need to wait for absolute
+   certainty that the issue won't recur.


### PR DESCRIPTION
Closes #95 

`OracleMonitoringService` could detect stale projects and stale providers, but
the only output was a `logger.warn(...)` line rate-limited by a Redis key with
a 24-hour TTL. That left three real gaps:

1. **No durable record.** Every restart, deploy, or Redis flush erased all
   history of what had ever been degraded. There was no way to answer "what
   is currently wrong with our oracle coverage" except by grepping logs.
2. **No operator workflow.** There was no way to acknowledge that someone was
   investigating a degradation, or to record that it had been resolved and by
   whom — acknowledgement and resolution are exactly the kind of audit trail
   Redis (by this codebase's own design, every `RedisService` call logs a
   warning and degrades on failure rather than guaranteeing durability) is
   the wrong place to be the *only* copy of.
3. **Stale providers were silently dropped.** `computeStaleness()` already
   computed provider-level staleness (aggregated across a provider's
   projects), but the old `alertStaleProjects()` method — despite the
   scheduler calling it from a method literally named
   `monitorProviderReliability()` — only ever acted on the `projects` half of
   the report. Provider degradation was computed and thrown away every cycle.

### What changed

A new `oracle_incidents` table (bootstrapped idempotently on module init,
via the `DATABASE_URL` connection that was already provisioned in
`docker-compose.yml`/`.env.example` but had no consumer anywhere in this API)
is now the source of truth for oracle degradation state. `OracleMonitoringService.alertStaleProjects()`
was replaced with `syncIncidents()`, which evaluates **both** stale projects
and stale providers and reconciles a database incident for each one via the
new `OracleIncidentRepository`.

Dedup and recurrence are enforced by a single database construct rather than
application logic: a **partial unique index** on `dedupe_key` scoped to
non-resolved rows (`WHERE status <> 'resolved'`), combined with
`INSERT ... ON CONFLICT (dedupe_key) WHERE status <> 'resolved' DO UPDATE`.
A repeated 6-hourly detection of an already-open incident matches that index
and updates the same row (`occurrence_count` increments, `last_detected_at`
refreshes) — this is what stops repeated cron cycles from creating log/row
noise. Once an incident is resolved, no non-resolved row remains to match the
partial index, so the next detection for that subject correctly opens a
*new* incident (recurrence) rather than reopening or overwriting the
resolved one's audit history. This is atomic and concurrency-safe at the
database level — verified directly with a test that fires three simultaneous
detections for the same subject and confirms only one row and a correctly
incremented count result, with no application-level locking involved.

Severity starts at `warning` and escalates to `critical` once
`occurrence_count` crosses a configurable threshold
(`ORACLE_INCIDENT_ESCALATION_THRESHOLDS`, default `3:critical`, same
env-driven-array style already used by this file's own
`ORACLE_CADENCE_SECONDS`/`CADENCE_OVERRIDES`). Log output was also made more
precise: a line is now only emitted when an incident is newly opened or has
just escalated, not on every repeat detection of an already-known,
unescalated incident — the database still records every occurrence for audit
purposes, but the log itself no longer spams.

Three new admin-guarded endpoints (`@UseGuards(JwtAuthGuard, AdminGuard)`,
matching the existing pattern on `BondsController`'s
`sweep-undistributed`) expose the operator workflow:

- `GET /oracle/incidents?status=active|acknowledged|resolved` — paginated list
- `POST /oracle/incidents/:id/acknowledge`
- `POST /oracle/incidents/:id/resolve` (optional `resolutionNote`)

`docs/runbook-degraded-providers.md` was updated with a new "Oracle incident
lifecycle" section (status transitions, dedup, escalation, recurrence) and
curl examples for the new endpoints, plus updated observability and
alert-action-matrix tables and an added resolution step in the recovery flow.


## Changed

- `api/src/oracle/oracle-incident.repository.ts` **(new)** — Postgres-backed
  incident store: schema bootstrap, `recordDetection` (atomic dedupe +
  recurrence + escalation), `findMany`, `findById`, `acknowledge`, `resolve`.
  Addresses #95's requirement to persist incident lifecycle state outside logs.
- `api/src/oracle/interfaces/oracle-incident.interface.ts` **(new)** —
  `OracleIncident` domain model, status/severity/subject-type enums (#95).
- `api/src/oracle/dto/list-oracle-incidents.dto.ts`,
  `dto/resolve-oracle-incident.dto.ts` **(new)** — request validation for the
  new incident endpoints (#95).
- `api/src/oracle/oracle.monitoring.service.ts` — `alertStaleProjects()` →
  `syncIncidents()`; now evaluates stale **providers** in addition to stale
  projects (previously computed but unused), delegates persistence to
  `OracleIncidentRepository`, removes the superseded Redis rearm-key logic (#95).
- `api/src/oracle/oracle.scheduler.ts` — calls `syncIncidents()` and logs the
  `{created, updated, escalated}` summary (#95).
- `api/src/oracle/oracle.controller.ts` — adds `GET /oracle/incidents`,
  `POST /oracle/incidents/:id/acknowledge`, `POST /oracle/incidents/:id/resolve`,
  all admin-guarded (#95).
- `api/src/oracle/oracle.module.ts` — registers `OracleIncidentRepository` (#95).
- `api/src/oracle/oracle.monitoring.service.spec.ts` — existing
  `computeStaleness` tests untouched; adds a `syncIncidents` test block (#95).
- `api/src/oracle/oracle-incident.repository.spec.ts` **(new)** — 14
  integration tests against a real ephemeral Postgres instance (#95).
- `api/test-setup/embedded-postgres-server.mjs` **(new)** — test-only helper
  that runs `embedded-postgres` in a separate Node process, needed because
  the package is pure ESM and incompatible with this project's CJS/ts-jest
  setup when loaded in-process (#95).
- `api/package.json` / `api/package-lock.json` — adds `pg` (runtime dep) and
  `@types/pg`, `embedded-postgres` (test-only dev deps) (#95).
- `docs/runbook-degraded-providers.md` — documents the incident lifecycle and
  the new API endpoints for operators (#95).

## Testing

```bash
cd api
npx jest oracle-incident.repository.spec.ts oracle.monitoring.service.spec.ts
npx tsc --noEmit
npx eslint "src/**/*.ts"
```

- `oracle-incident.repository.spec.ts`: **14/14 passing**, run against a real,
  disposable PostgreSQL instance (not a mock/emulator — `pg-mem` was evaluated
  and rejected because it cannot parse the `ON CONFLICT ... WHERE`
  partial-index syntax this fix relies on). Covers creation, dedupe
  (including concurrent-safety), escalation, acknowledgement (success +
  every rejection path), resolution (success + rejection), recurrence, and
  paginated listing.
- `oracle.monitoring.service.spec.ts`: **11/11 passing** (6 pre-existing
  `computeStaleness` tests untouched + 5 new `syncIncidents` tests covering
  project detection, provider detection, the non-stale no-op case, dedupe
  tallying, and escalation tallying).
- `npx tsc --noEmit`: same 53 pre-existing errors as on unmodified `main`
  (all in `bonds.service.ts`, `dex.service.ts`, `oracle.service.ts` — none in
  any file this PR touches), confirmed via `git stash` comparison before and
  after this change. Zero new errors introduced.
- `npx eslint` on every new/changed file: zero issues.
- PostgreSQL's `ON CONFLICT (col) WHERE <predicate> DO UPDATE` partial-index
  inference behavior was verified against the official PostgreSQL
  documentation (postgresql.org/docs/current/sql-insert.html), not assumed.

## Scope Notes

- Backend-only (`api/`) plus documentation (`docs/runbook-degraded-providers.md`).
  No frontend/UI changes.
- No changes to bond, DEX, or contract/Soroban logic.
- `GET /oracle/monitoring/staleness` (the existing live staleness computation)
  is unchanged; only the scheduler's handling of what it finds changed.
- Several pre-existing, unrelated issues were found while verifying this
  change but were deliberately **not** touched, since they fall outside
  #95's scope: a `getOracleConsumer()` / `getOracleConsumerAddress()` typo in
  `oracle.service.ts` (introduced by a separate prior commit), missing
  `@stellar/stellar-sdk` imports in `bonds.service.ts`, a nonexistent
  `RedisService.scanIterator` call in `dex.service.ts`, and CI
  (`.github/workflows/ci.yml`) provisioning no Postgres service for the `api`
  job while also referencing a `npm run typecheck` script that doesn't exist
  in `api/package.json`.
- `implementation.md` and `CODEBASE_INDEX.md` are intentionally excluded from
  this commit/PR.

## Push Command

```bash
git push -u origin fix/oracle-incident-persistence-95
```
