### PR TITLE
Fix issues #30, #59, #60: Auth guards and network passphrase

### DIFF
--- a/api/src/bonds/bonds.controller.ts
+++ b/api/src/bonds/bonds.controller.ts
@@ -11,6 +11,7 @@ import { TransferBondDto } from './dto/transfer-bond.dto';
 import { PaginationDto } from '../common/dto/pagination.dto';
 import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
 import { AdminGuard } from '../common/guards/admin.guard';
+import { KycGuard } from '../common/guards/kyc.guard';
 import {
   BondResponse,
   SubscriptionResponse,
@@ -28,6 +29,7 @@ export class BondsController {
   constructor(private readonly bondsService: BondsService) {}
 
   @Post()
+  @UseGuards(JwtAuthGuard, AdminGuard)
   @HttpCode(HttpStatus.CREATED)
   async create(@Body() dto: CreateBondDto): Promise<BondResponse> {
     return this.bondsService.create(dto);
@@ -51,6 +53,7 @@ export class BondsController {
   }
 
   @Post(':id/subscribe')
+  @UseGuards(JwtAuthGuard, KycGuard)
   @HttpCode(HttpStatus.OK)
   async subscribe(
     @Param('id', ParseIntPipe) id: number,
@@ -67,6 +70,7 @@ export class BondsController {
   }
 
   @Post(':id/coupon')
+  @UseGuards(JwtAuthGuard, AdminGuard)
   @HttpCode(HttpStatus.OK)
   async distributeCoupon(
     @Param('id', ParseIntPipe) id: number,
@@ -76,6 +80,7 @@ export class BondsController {
   }
 
   @Post(':id/claim')
+  @UseGuards(JwtAuthGuard, KycGuard)
   @HttpCode(HttpStatus.OK)
   async claimCredits(
     @Param('id', ParseIntPipe) id: number,
@@ -101,6 +106,7 @@ export class BondsController {
   }
 
   @Post(':id/transfer')
+  @UseGuards(JwtAuthGuard, KycGuard)
   @HttpCode(HttpStatus.OK)
   async transfer(
     @Param('id', ParseIntPipe) id: number,
@@ -110,6 +116,7 @@ export class BondsController {
   }
 
   @Post(':id/mature')
+  @UseGuards(JwtAuthGuard, AdminGuard)
   @HttpCode(HttpStatus.OK)
   async mature(
     @Param('id', ParseIntPipe) id: number,

--- a/api/src/marketplace/marketplace.controller.ts
+++ b/api/src/marketplace/marketplace.controller.ts
@@ -1,10 +1,11 @@
 import {
   Controller, Get, Post, Delete, Body, Param, Query, Req,
-  HttpCode, HttpStatus, ParseIntPipe,
+  HttpCode, HttpStatus, ParseIntPipe, UseGuards,
 } from '@nestjs/common';
 import { DexService } from './dex.service';
 import { LiquidityService } from './liquidity.service';
 import { StellarService } from '../stellar/stellar.service';
+import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
 import { ListBondDto } from './dto/list-bond.dto';
 import { BuyBondDto } from './dto/buy-bond.dto';
 import { DepositQuoteDto } from './dto/deposit-quote.dto';
@@ -54,72 +55,79 @@ export class MarketplaceController {
   }
 
   @Post('list')
+  @UseGuards(JwtAuthGuard)
   @HttpCode(HttpStatus.CREATED)
   async listBondTokens(
     @Body() dto: ListBondDto,
     @Req() req: any,
   ): Promise<OrderResponse> {
-    const sellerAddress = req.headers['x-wallet-address'] as string || '';
+    const sellerAddress = req.user.walletAddress;
     return this.dexService.listBondTokens(dto, sellerAddress);
   }
 
   @Post('buy')
+  @UseGuards(JwtAuthGuard)
   @HttpCode(HttpStatus.OK)
   async buyBondTokens(
     @Body() dto: BuyBondDto,
     @Req() req: any,
   ): Promise<OrderResponse> {
-    const buyerAddress = req.headers['x-wallet-address'] as string || '';
+    const buyerAddress = req.user.walletAddress;
     return this.dexService.buyBondTokens(dto, buyerAddress);
   }
 
   @Get('quote-balance')
+  @UseGuards(JwtAuthGuard)
   async getQuoteBalance(
     @Query() query: QuoteBalanceQueryDto,
     @Req() req: any,
   ): Promise<QuoteBalanceResponse> {
-    const address = req.headers['x-wallet-address'] as string || '';
+    const address = req.user.walletAddress;
     return this.dexService.getQuoteBalance(address, query.asset ?? 'USDC');
   }
 
   @Get('wallet-balance')
+  @UseGuards(JwtAuthGuard)
   async getWalletBalance(
     @Query() query: QuoteBalanceQueryDto,
     @Req() req: any,
   ): Promise<QuoteBalanceResponse> {
-    const address = req.headers['x-wallet-address'] as string || '';
+    const address = req.user.walletAddress;
     const asset = query.asset ?? 'USDC';
     const balanceStr = await this.stellarService.getBalance(address, asset);
     return { address, asset, balance: balanceStr };
   }
 
   @Post('deposit')
+  @UseGuards(JwtAuthGuard)
   @HttpCode(HttpStatus.OK)
   async depositQuote(
     @Body() dto: DepositQuoteDto,
     @Req() req: any,
   ): Promise<QuoteTransactionResponse> {
-    const address = req.headers['x-wallet-address'] as string || '';
+    const address = req.user.walletAddress;
     return this.dexService.depositQuote(dto, address);
   }
 
   @Post('withdraw')
+  @UseGuards(JwtAuthGuard)
   @HttpCode(HttpStatus.OK)
   async withdrawQuote(
     @Body() dto: WithdrawQuoteDto,
     @Req() req: any,
   ): Promise<QuoteTransactionResponse> {
-    const address = req.headers['x-wallet-address'] as string || '';
+    const address = req.user.walletAddress;
     return this.dexService.withdrawQuote(dto, address);
   }
 
   @Delete('orders/:id')
+  @UseGuards(JwtAuthGuard)
   @HttpCode(HttpStatus.NO_CONTENT)
   async cancelOrder(
     @Param('id', ParseIntPipe) id: number,
     @Req() req: any,
   ): Promise<void> {
-    const callerAddress = req.headers['x-wallet-address'] as string || '';
+    const callerAddress = req.user.walletAddress;
     return this.dexService.cancelOrder(id, callerAddress);
   }
 

--- a/api/src/oracle/oracle.controller.ts
+++ b/api/src/oracle/oracle.controller.ts
@@ -1,9 +1,11 @@
 import {
   Controller, Get, Post, Body, Param, Req,
-  HttpCode, HttpStatus, ParseIntPipe,
+  HttpCode, HttpStatus, ParseIntPipe, UseGuards,
 } from '@nestjs/common';
 import { OracleService } from './oracle.service';
 import { OracleMonitoringService } from './oracle.monitoring.service';
+import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
+import { ProviderGuard } from '../common/guards/provider.guard';
 import { SubmitReportDto } from './dto/submit-report.dto';
 import { ChallengeDto } from './dto/challenge.dto';
 import { RegisterProviderDto } from './dto/register-provider.dto';
@@ -23,12 +25,13 @@ export class OracleController {
   ) {}
 
   @Post('reports')
+  @UseGuards(JwtAuthGuard, ProviderGuard)
   @HttpCode(HttpStatus.CREATED)
   async submitReport(
     @Body() dto: SubmitReportDto,
     @Req() req: any,
   ): Promise<ReportResponse> {
-    const providerAddress = req.headers['x-provider-address'] as string || process.env.DEFAULT_PROVIDER_ADDRESS || '';
+    const providerAddress = req.user.walletAddress;
     return this.oracleService.submitReport(dto, providerAddress);
   }
 
@@ -40,13 +43,14 @@ export class OracleController {
   }
 
   @Post('challenge/:reportId')
+  @UseGuards(JwtAuthGuard)
   @HttpCode(HttpStatus.OK)
   async challengeReport(
     @Param('reportId', ParseIntPipe) reportId: number,
     @Body() dto: ChallengeDto,
     @Req() req: any,
   ): Promise<ChallengeResponse> {
-    const challengerAddress = req.headers['x-wallet-address'] as string || '';
+    const challengerAddress = req.user.walletAddress;
     return this.oracleService.challengeReport(reportId, dto, challengerAddress);
   }
 

--- a/frontend/src/app/auth/wallet.service.ts
+++ b/frontend/src/app/auth/wallet.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, signal } from '@angular/core';
 import { isConnected, getAddress, signTransaction } from '@stellar/freighter-api';
+import { environment } from '../../environments/environment';
 
 @Injectable({ providedIn: 'root' })
 export class WalletService {
@@ -24,7 +25,7 @@ export class WalletService {
 
   async signChallenge(challenge: string): Promise<string> {
     const { signedTxXdr } = await signTransaction(challenge, {
-      networkPassphrase: 'Test SDF Network ; September 2015',
+      networkPassphrase: environment.networkPassphrase,
     });
     return signedTxXdr;
   }


### PR DESCRIPTION
# Pull Request: Fix Authentication Guards and Network Passphrase Configuration

This PR addresses multiple security and configuration issues in the API and frontend, specifically focusing on enforcing correct access control via guards and removing hardcoded network passphrases.

### Resolves
- Fixes #30
- Fixes #59
- Fixes #60

## Tasks and Fixes Made

### 1. Fix Frontend Network Configuration (#30)
- **Task:** Remove hardcoded testnet network passphrase in the wallet service.
- **Fix:** Updated `frontend/src/app/auth/wallet.service.ts` to dynamically use `environment.networkPassphrase` from `src/environments/environment.ts` instead of a hardcoded string. This prevents the application from failing when operating on different networks.

### 2. Protect Public Bond Mutation Endpoints (#59)
- **Task:** Enforce `JwtAuthGuard`, `KycGuard`, and `AdminGuard` on public bond endpoints.
- **Fix:** Applied the necessary authentication and authorization guards to `api/src/bonds/bonds.controller.ts`:
  - Enforced `AdminGuard` for `@Post() create`, `@Post(':id/coupon') distributeCoupon`, and `@Post(':id/mature') mature`.
  - Enforced `KycGuard` for `@Post(':id/subscribe') subscribe`, `@Post(':id/claim') claimCredits`, and `@Post(':id/transfer') transfer`.
  - Applied `JwtAuthGuard` to all of these protected routes.

### 3. Enforce Authenticated Wallet Identity on Marketplace & Oracle (#60)
- **Task:** Prevent endpoints from blindly trusting `x-wallet-address` headers.
- **Fix:** Updated `api/src/marketplace/marketplace.controller.ts` and `api/src/oracle/oracle.controller.ts`:
  - Added `JwtAuthGuard` to marketplace user endpoints (`list`, `buy`, `deposit`, `withdraw`, `cancelOrder`, `quote-balance`, `wallet-balance`).
  - Read the authenticated wallet address securely from `req.user.walletAddress` rather than directly reading unverified headers.
  - Added `JwtAuthGuard` and `ProviderGuard` to `submitReport` in the oracle controller, reading the provider address directly from the authenticated user token.
  - Added `JwtAuthGuard` to `challengeReport` in the oracle controller and updated the logic to securely obtain the challenger's address.

## Status
The changes have been successfully committed to the `fix-auth-network-issues` branch locally. Due to access restrictions, you will need to push this branch to your fork and manually open the Pull Request on GitHub using the description provided above.
