### PR TITLE
fix(#123): resilient dashboard empty/loading/partial-failure states

### DIFF
--- a/frontend/src/app/bonds/bond-detail/bond-detail.component.spec.ts
+++ b/frontend/src/app/bonds/bond-detail/bond-detail.component.spec.ts
@@ -16,13 +16,13 @@ describe('BondDetailComponent', () => {
   const bond = {
     id: 1,
     projectId: 'a1b2',
-    faceValue: 1000,
-    couponSchedule: [1000000, 2000000],
+    faceValue: '1000',
+    couponSchedule: ['1000000', '2000000'],
     creditType: 'Carbon' as const,
     maturityDate: 3000000,
     maturityStatus: 'Active' as const,
-    totalSupply: 10000,
-    totalSubscribed: 5000,
+    totalSupply: '10000',
+    totalSubscribed: '5000',
     status: 'Active' as const,
     createdAt: '2026-01-01T00:00:00.000Z',
   };
@@ -43,10 +43,10 @@ describe('BondDetailComponent', () => {
     ]);
     apiService.getBond.and.returnValue(of(bond));
     apiService.getUndistributedTotal.and.returnValue(
-      of({ bondId: 1, undistributedTotal: 7 }),
+      of({ bondId: 1, undistributedTotal: '7' }),
     );
     apiService.sweepUndistributed.and.returnValue(
-      of({ bondId: 1, swept: 7, transactionHash: '0xabc' }),
+      of({ bondId: 1, swept: '7', transactionHash: '0xabc' }),
     );
 
     await TestBed.configureTestingModule({

--- a/frontend/src/app/bonds/bond-detail/bond-detail.component.ts
+++ b/frontend/src/app/bonds/bond-detail/bond-detail.component.ts
@@ -336,7 +336,7 @@ export class BondDetailComponent implements OnInit, OnDestroy {
     if (b && this.isAdmin() && !this.undistributedLoaded) {
       this.undistributedLoaded = true;
       this.apiService.getUndistributedTotal(b.id).subscribe({
-        next: (res) => this.undistributed.set(res.undistributedTotal),
+        next: (res) => this.undistributed.set(Number(res.undistributedTotal)),
         error: (err) =>
           this.undistributedError.set(
             err.error?.detail || err.message || 'Failed to load undistributed total',
@@ -351,8 +351,8 @@ export class BondDetailComponent implements OnInit, OnDestroy {
 
   subscribeProgress(): number {
     const b = this.bond();
-    if (!b || b.totalSupply === 0) return 0;
-    return Math.round((b.totalSubscribed / b.totalSupply) * 100);
+    if (!b || Number(b.totalSupply) === 0) return 0;
+    return Math.round((Number(b.totalSubscribed) / Number(b.totalSupply)) * 100);
   }
 
   formatCountdown(ms: number): string {
@@ -430,7 +430,7 @@ export class BondDetailComponent implements OnInit, OnDestroy {
     this.apiService.claimCredits(b.id).subscribe({
       next: (res) => {
         this.claimSuccess.set(true);
-        this.claimCredits.set(res.credits);
+        this.claimCredits.set(Number(res.credits));
         this.claimTx.set(res.transactionHash);
         this.claimSubmitting.set(false);
       },
@@ -480,7 +480,7 @@ export class BondDetailComponent implements OnInit, OnDestroy {
     this.apiService.sweepUndistributed(b.id).subscribe({
       next: (res) => {
         this.sweepSuccess.set(true);
-        this.sweepSwept.set(res.swept);
+        this.sweepSwept.set(Number(res.swept));
         this.sweepTx.set(res.transactionHash);
         this.sweepSubmitting.set(false);
         this.undistributed.set(0);

--- a/frontend/src/app/dashboard/dashboard.component.spec.ts
+++ b/frontend/src/app/dashboard/dashboard.component.spec.ts
@@ -1,0 +1,338 @@
+import { TestBed, ComponentFixture, fakeAsync, tick } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { HttpErrorResponse } from '@angular/common/http';
+import { of, throwError, Subject, Observable } from 'rxjs';
+import {
+  DashboardComponent,
+  DASHBOARD_RETRY_BASE_DELAY_MS,
+} from './dashboard.component';
+import { ApiService } from '../shared/services/api.service';
+import { AuthService } from '../auth/auth.service';
+import { WalletService } from '../auth/wallet.service';
+import { Bond, Project, PaginatedResponse } from '../shared/interfaces/bond.interface';
+
+const BOND: Bond = {
+  id: 1,
+  projectId: 'p1',
+  faceValue: '1000',
+  couponSchedule: ['2026-01-01'],
+  creditType: 'Carbon',
+  maturityDate: 1800000000,
+  maturityStatus: 'Active',
+  totalSupply: '1000',
+  totalSubscribed: '500',
+  status: 'Active',
+  createdAt: new Date().toISOString(),
+};
+
+const PROJECT: Project = {
+  id: 1,
+  name: 'Amazon Reforestation',
+  status: 'Approved',
+  methodology: 'VERRA-VCS',
+  country: 'Brazil',
+  metadataIpfsHash: 'QmHash',
+  ownerAddress: 'GBOB',
+  totalAreaHa: 5000,
+  carbonSequestrationEstimate: 25000,
+  createdAt: new Date().toISOString(),
+};
+
+const BONDS_META = { page: 1, limit: 5, total: 1, totalPages: 1 };
+const EMPTY_BONDS: PaginatedResponse<Bond> = { data: [], meta: { ...BONDS_META, total: 0 } };
+const FULL_BONDS: PaginatedResponse<Bond> = { data: [BOND], meta: BONDS_META };
+const EMPTY_PROJECTS: PaginatedResponse<Project> = { data: [], meta: { ...BONDS_META, total: 0 } };
+const FULL_PROJECTS: PaginatedResponse<Project> = { data: [PROJECT], meta: BONDS_META };
+
+describe('DashboardComponent', () => {
+  let component: DashboardComponent;
+  let fixture: ComponentFixture<DashboardComponent>;
+  let apiService: {
+    getBonds: jasmine.Spy;
+    getProjects: jasmine.Spy;
+  };
+
+  beforeEach(async () => {
+    apiService = {
+      getBonds: jasmine.createSpy('getBonds').and.returnValue(of(FULL_BONDS)),
+      getProjects: jasmine.createSpy('getProjects').and.returnValue(of(FULL_PROJECTS)),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [DashboardComponent],
+      providers: [
+        provideRouter([]),
+        { provide: ApiService, useValue: apiService },
+        { provide: AuthService, useValue: { token: () => null } },
+        { provide: WalletService, useValue: { address: () => null, isConnected: () => false } },
+      ],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DashboardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('creates the component', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('loads bonds and projects on init', () => {
+    expect(apiService.getBonds).toHaveBeenCalledWith(1, 5);
+    expect(apiService.getProjects).toHaveBeenCalledWith(1, 5);
+  });
+
+  it('renders data when both sections load successfully', () => {
+    fixture.detectChanges();
+    const el: HTMLElement = fixture.nativeElement;
+    expect(el.textContent).toContain('Recent Bonds');
+    expect(el.textContent).toContain('Recent Projects');
+    expect(el.textContent).toContain('Amazon Reforestation');
+    expect(el.textContent).toContain('Total Bonds');
+    expect(component.bondsState()).toBe('ready');
+    expect(component.projectsState()).toBe('ready');
+    expect(component.overviewState()).toBe('ready');
+  });
+
+  describe('all-loading state', () => {
+    it('shows skeletons before any response arrives', () => {
+      apiService.getBonds.calls.reset();
+      apiService.getProjects.calls.reset();
+      apiService.getBonds.and.returnValue(new Subject<PaginatedResponse<Bond>>());
+      apiService.getProjects.and.returnValue(new Subject<PaginatedResponse<Project>>());
+
+      component.retryBonds();
+      component.retryProjects();
+      fixture.detectChanges();
+
+      expect(component.bondsState()).toBe('loading');
+      expect(component.projectsState()).toBe('loading');
+      expect(component.overviewState()).toBe('loading');
+      const el: HTMLElement = fixture.nativeElement;
+      expect(el.querySelectorAll('.skeleton').length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('all-empty state', () => {
+    it('renders empty state when no data exists', () => {
+      apiService.getBonds.calls.reset();
+      apiService.getProjects.calls.reset();
+      apiService.getBonds.and.returnValue(of(EMPTY_BONDS));
+      apiService.getProjects.and.returnValue(of(EMPTY_PROJECTS));
+
+      component.retryBonds();
+      component.retryProjects();
+      fixture.detectChanges();
+
+      expect(component.bondsState()).toBe('empty');
+      expect(component.projectsState()).toBe('empty');
+      expect(component.overviewState()).toBe('empty');
+      const el: HTMLElement = fixture.nativeElement;
+      expect(el.textContent).toContain('No bonds found.');
+      expect(el.textContent).toContain('No projects found.');
+    });
+  });
+
+  describe('partial-failure state', () => {
+    it('preserves a successful section when the other request fails', () => {
+      apiService.getBonds.calls.reset();
+      apiService.getProjects.calls.reset();
+      component.projects.set([]); // no prior projects so the error state is reachable
+      apiService.getBonds.and.returnValue(of(FULL_BONDS));
+      apiService.getProjects.and.returnValue(throwError(() => new HttpErrorResponse({ status: 400, statusText: 'Bad Request' })));
+
+      component.retryBonds();
+      component.retryProjects();
+      fixture.detectChanges();
+
+      // Bonds succeed; projects fail (400 = non-transient, resolves synchronously to error).
+      expect(apiService.getBonds).toHaveBeenCalled();
+      expect(component.bonds().length).toBe(1);
+      expect(component.projectsState()).toBe('error');
+      expect(component.bondsState()).toBe('ready');
+    });
+
+    it('does not blank the entire dashboard when one of two requests fails', () => {
+      apiService.getBonds.calls.reset();
+      apiService.getProjects.calls.reset();
+      component.projects.set([]);
+      apiService.getBonds.and.returnValue(of(FULL_BONDS));
+      apiService.getProjects.and.returnValue(throwError(() => new HttpErrorResponse({ status: 400, statusText: 'Bad Request' })));
+
+      component.retryBonds();
+      component.retryProjects();
+      fixture.detectChanges();
+
+      const el: HTMLElement = fixture.nativeElement;
+      // The successful bonds section is still rendered.
+      expect(el.textContent).toContain('Recent Bonds');
+      expect(el.textContent).toContain('Recent Projects'); // section header still present
+      expect(component.projectsState()).toBe('error');
+      expect(component.overviewState()).not.toBe('error');
+    });
+
+    it('targets retry controls at the failed section only', () => {
+      apiService.getBonds.calls.reset();
+      apiService.getProjects.calls.reset();
+      component.projects.set([]);
+      apiService.getBonds.and.returnValue(of(FULL_BONDS));
+      apiService.getProjects.and.returnValue(throwError(() => new HttpErrorResponse({ status: 400, statusText: 'Bad Request' })));
+
+      component.retryBonds();
+      component.retryProjects();
+      fixture.detectChanges();
+
+      const buttons: Element[] = Array.from(fixture.nativeElement.querySelectorAll('button'));
+      const projectRetry = buttons.find((b) => b.textContent?.trim() === 'Try Again');
+      expect(projectRetry).toBeTruthy();
+    });
+
+    it('recovers the failed section via its retry button', () => {
+      apiService.getBonds.calls.reset();
+      apiService.getProjects.calls.reset();
+      component.projects.set([]);
+      apiService.getBonds.and.returnValue(of(FULL_BONDS));
+      apiService.getProjects.and.returnValues(
+        throwError(() => new HttpErrorResponse({ status: 400, statusText: 'Bad Request' })),
+        of(FULL_PROJECTS),
+      );
+
+      component.retryBonds();
+      component.retryProjects();
+      fixture.detectChanges();
+      expect(component.projectsState()).toBe('error');
+
+      component.retryProjects();
+      fixture.detectChanges();
+      expect(component.projectsState()).toBe('ready');
+      expect(component.projects().length).toBe(1);
+    });
+  });
+
+  describe('retry with backoff', () => {
+    it('retries a transient failure only after the backoff delay', fakeAsync(() => {
+      apiService.getBonds.calls.reset();
+      apiService.getBonds.and.returnValues(
+        throwError(() => new Error('network down')),
+        of(FULL_BONDS),
+      );
+
+      component.retryBonds();
+      expect(apiService.getBonds).toHaveBeenCalledTimes(1);
+
+      tick(DASHBOARD_RETRY_BASE_DELAY_MS - 1);
+      expect(apiService.getBonds).toHaveBeenCalledTimes(1);
+
+      tick(1);
+      expect(apiService.getBonds).toHaveBeenCalledTimes(2);
+      expect(component.bonds()[0].id).toBe(BOND.id);
+      expect(component.bondsState()).toBe('ready');
+    }));
+
+    it('does not retry client errors (4xx)', fakeAsync(() => {
+      apiService.getBonds.calls.reset();
+      apiService.getProjects.calls.reset();
+      // Start with no prior data so the error path is exercised.
+      component.bonds.set([]);
+      component.totalBonds.set(0);
+      apiService.getBonds.and.returnValue(
+        throwError(() => new HttpErrorResponse({ status: 400, statusText: 'Bad Request' })),
+      );
+
+      component.retryBonds();
+      tick(10000);
+
+      expect(apiService.getBonds).toHaveBeenCalledTimes(1);
+      expect(component.bondsState()).toBe('error');
+    }));
+
+    it('recovers when a retry eventually succeeds', fakeAsync(() => {
+      apiService.getBonds.calls.reset();
+      apiService.getBonds.and.returnValues(
+        throwError(() => new Error('network down')),
+        throwError(() => new Error('network down')),
+        throwError(() => new Error('network down')),
+        of(FULL_BONDS),
+      );
+
+      component.retryBonds();
+      tick(DASHBOARD_RETRY_BASE_DELAY_MS);
+      tick(DASHBOARD_RETRY_BASE_DELAY_MS * 2);
+      tick(DASHBOARD_RETRY_BASE_DELAY_MS * 4);
+
+      expect(apiService.getBonds).toHaveBeenCalledTimes(4);
+      expect(component.bonds()[0].id).toBe(BOND.id);
+      expect(component.bondsState()).toBe('ready');
+    }));
+
+    it('handles persistent failures cleanly after retries are exhausted', fakeAsync(() => {
+      apiService.getBonds.calls.reset();
+      component.bonds.set([]);
+      component.totalBonds.set(0);
+      apiService.getBonds.and.returnValue(throwError(() => new Error('still down')));
+
+      component.retryBonds();
+      expect(component.bondsState()).toBe('loading');
+
+      tick(DASHBOARD_RETRY_BASE_DELAY_MS);
+      tick(DASHBOARD_RETRY_BASE_DELAY_MS * 2);
+      tick(DASHBOARD_RETRY_BASE_DELAY_MS * 4);
+      tick(DASHBOARD_RETRY_BASE_DELAY_MS * 8);
+
+      expect(apiService.getBonds).toHaveBeenCalledTimes(4);
+      expect(component.bondsState()).toBe('error');
+      expect(component.bondsError()).toBeTruthy();
+      expect(component.bonds()).toEqual([]);
+    }));
+  });
+
+  describe('refresh concurrency', () => {
+    it('does not stack duplicate subscriptions across repeated refreshes', () => {
+      let active = 0;
+      let maxActive = 0;
+      apiService.getBonds.calls.reset();
+      apiService.getBonds.and.callFake(() => new Observable(() => {
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        return () => { active -= 1; };
+      }));
+
+      component.retryBonds();
+      component.retryBonds();
+      component.retryBonds();
+
+      expect(apiService.getBonds).toHaveBeenCalledTimes(3);
+      expect(maxActive).toBe(1);
+    });
+
+    it('ignores a stale in-flight response superseded by a newer refresh', () => {
+      const first = new Subject<PaginatedResponse<Bond>>();
+      const second = new Subject<PaginatedResponse<Bond>>();
+      apiService.getBonds.calls.reset();
+      apiService.getBonds.and.returnValues(first, second);
+
+      component.retryBonds();
+      component.retryBonds();
+
+      first.next({ data: [{ ...BOND, id: 99 }], meta: BONDS_META });
+      expect(component.bonds().map(b => b.id)).toEqual([1]);
+
+      second.next(FULL_BONDS);
+      second.complete();
+      expect(component.bonds()[0].id).toBe(1);
+      expect(component.bondsState()).toBe('ready');
+    });
+  });
+
+  describe('metrics', () => {
+    it('computes total, active, and carbon totals from loaded data', () => {
+      fixture.detectChanges();
+      expect(component.totalBonds()).toBe(1);
+      expect(component.activeBonds()).toBe(1);
+      expect(component.totalProjects()).toBe(1);
+      expect(component.carbonTotal()).toBe(25000);
+    });
+  });
+});

--- a/frontend/src/app/dashboard/dashboard.component.ts
+++ b/frontend/src/app/dashboard/dashboard.component.ts
@@ -1,11 +1,20 @@
-import { Component, inject, OnInit, ChangeDetectionStrategy, signal } from '@angular/core';
+import { Component, inject, OnInit, OnDestroy, ChangeDetectionStrategy, signal, computed } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule, Router } from '@angular/router';
+import { HttpErrorResponse } from '@angular/common/http';
+import { Observable, EMPTY, defer, timer, Subject, switchMap, takeUntil, retry, tap, finalize, catchError, throwError } from 'rxjs';
 import { ApiService } from '../shared/services/api.service';
 import { BondCardComponent } from '../shared/components/bond-card/bond-card.component';
 import { ProjectCardComponent } from '../shared/components/project-card/project-card.component';
 import { LoadingSpinnerComponent } from '../shared/components/loading-spinner/loading-spinner.component';
-import { Bond, Project } from '../shared/interfaces/bond.interface';
+import { Bond, Project, PaginatedResponse } from '../shared/interfaces/bond.interface';
+import { appErrorMessage } from '../shared/errors/api-error';
+
+export const DASHBOARD_RETRY_COUNT = 3;
+export const DASHBOARD_RETRY_BASE_DELAY_MS = 1000;
+export const DASHBOARD_RETRY_MAX_DELAY_MS = 8000;
+
+type SectionState = 'loading' | 'error' | 'empty' | 'ready';
 
 @Component({
   selector: 'app-dashboard',
@@ -15,145 +24,339 @@ import { Bond, Project } from '../shared/interfaces/bond.interface';
     <div class="dashboard">
       <h1 class="page-title">Dashboard</h1>
 
-      @if (error()) {
-        <div class="error-banner">{{ error() }}</div>
+      @if (overallError()) {
+        <div class="error-banner">
+          <span>{{ overallError() }}</span>
+          <button class="btn btn-sm btn-outline" (click)="retryAll()">Retry All</button>
+        </div>
       }
 
-      <div class="stats-grid">
-        <div class="stat-card">
-          <span class="stat-label">Total Bonds</span>
-          <span class="stat-value">{{ totalBonds() }}</span>
+      <section class="section">
+        <div class="section-header">
+          <h2>Overview</h2>
+          @if (overviewState() === 'error') {
+            <button class="btn btn-sm btn-outline" (click)="retryOverview()">Retry</button>
+          }
         </div>
-        <div class="stat-card">
-          <span class="stat-label">Active Bonds</span>
-          <span class="stat-value">{{ activeBonds() }}</span>
-        </div>
-        <div class="stat-card">
-          <span class="stat-label">Total Projects</span>
-          <span class="stat-value">{{ totalProjects() }}</span>
-        </div>
-        <div class="stat-card">
-          <span class="stat-label">Carbon Sequestration</span>
-          <span class="stat-value">{{ carbonTotal() | number }} tCO₂e</span>
-        </div>
-      </div>
 
-      @if (loading()) {
-        <div class="loading-section">
-          <app-loading-spinner size="lg" />
-        </div>
-      } @else if (bonds().length === 0 && projects().length === 0) {
-        <div class="empty-section">
-          <p>No bonds or projects yet.</p>
-          <div class="quick-actions">
-            <a class="btn btn-primary" routerLink="/projects/new">Register a Project</a>
-            <a class="btn btn-secondary" routerLink="/bonds">View Bonds</a>
-          </div>
-        </div>
-      } @else {
-        <section class="section">
-          <div class="section-header">
-            <h2>Recent Bonds</h2>
+        @switch (overviewState()) {
+          @case ('loading') {
+            <div class="stats-grid stats-skeleton" aria-busy="true" aria-label="Loading overview">
+              @for (s of [1, 2, 3, 4]; track s) {
+                <div class="stat-card skeleton"><span class="skeleton-block"></span><span class="skeleton-block short"></span></div>
+              }
+            </div>
+          }
+          @case ('error') {
+            <div class="section-error">
+              <p>{{ overviewError() }}</p>
+              <button class="btn btn-sm btn-outline" (click)="retryOverview()">Try Again</button>
+            </div>
+          }
+          @case ('empty') {
+            <div class="empty-section">
+              <p>No data available yet. The dashboard is waiting for on-chain activity.</p>
+            </div>
+          }
+          @case ('ready') {
+            <div class="stats-grid">
+              <div class="stat-card">
+                <span class="stat-label">Total Bonds</span>
+                <span class="stat-value">{{ totalBonds() }}</span>
+              </div>
+              <div class="stat-card">
+                <span class="stat-label">Active Bonds</span>
+                <span class="stat-value">{{ activeBonds() }}</span>
+              </div>
+              <div class="stat-card">
+                <span class="stat-label">Total Projects</span>
+                <span class="stat-value">{{ totalProjects() }}</span>
+              </div>
+              <div class="stat-card">
+                <span class="stat-label">Carbon Sequestration</span>
+                <span class="stat-value">{{ carbonTotal() | number }} tCO₂e</span>
+              </div>
+            </div>
+          }
+        }
+      </section>
+
+      <section class="section">
+        <div class="section-header">
+          <h2>Recent Bonds</h2>
+          <div class="header-actions">
+            @if (bondsState() === 'error') {
+              <button class="btn btn-sm btn-outline" (click)="retryBonds()">Retry</button>
+            }
             <a class="section-link" routerLink="/bonds">View All</a>
           </div>
-          @if (bonds().length > 0) {
+        </div>
+
+        @switch (bondsState()) {
+          @case ('loading') {
+            <div class="card-grid cards-skeleton" aria-busy="true" aria-label="Loading recent bonds">
+              @for (s of [1, 2, 3]; track s) {
+                <div class="card skeleton"><span class="skeleton-block"></span><span class="skeleton-block short"></span></div>
+              }
+            </div>
+          }
+          @case ('error') {
+            <div class="section-error">
+              <p>{{ bondsError() }}</p>
+              <button class="btn btn-sm btn-outline" (click)="retryBonds()">Try Again</button>
+            </div>
+          }
+          @case ('empty') {
+            <p class="section-empty">No bonds found.</p>
+          }
+          @case ('ready') {
             <div class="card-grid">
               @for (bond of bonds(); track bond.id) {
                 <app-bond-card [bond]="bond" (subscribe)="onSubscribe($event)" />
               }
             </div>
-          } @else {
-            <p class="section-empty">No bonds found.</p>
           }
-        </section>
+        }
+      </section>
 
-        <section class="section">
-          <div class="section-header">
-            <h2>Recent Projects</h2>
+      <section class="section">
+        <div class="section-header">
+          <h2>Recent Projects</h2>
+          <div class="header-actions">
+            @if (projectsState() === 'error') {
+              <button class="btn btn-sm btn-outline" (click)="retryProjects()">Retry</button>
+            }
             <a class="section-link" routerLink="/projects">View All</a>
           </div>
-          @if (projects().length > 0) {
+        </div>
+
+        @switch (projectsState()) {
+          @case ('loading') {
+            <div class="card-grid cards-skeleton" aria-busy="true" aria-label="Loading recent projects">
+              @for (s of [1, 2, 3]; track s) {
+                <div class="card skeleton"><span class="skeleton-block"></span><span class="skeleton-block short"></span></div>
+              }
+            </div>
+          }
+          @case ('error') {
+            <div class="section-error">
+              <p>{{ projectsError() }}</p>
+              <button class="btn btn-sm btn-outline" (click)="retryProjects()">Try Again</button>
+            </div>
+          }
+          @case ('empty') {
+            <p class="section-empty">No projects found.</p>
+          }
+          @case ('ready') {
             <div class="card-grid">
               @for (project of projects(); track project.id) {
                 <app-project-card [project]="project" />
               }
             </div>
-          } @else {
-            <p class="section-empty">No projects found.</p>
           }
-        </section>
-      }
+        }
+      </section>
     </div>
   `,
   styles: [`
     .dashboard { max-width: 1200px; }
     .page-title { font-size: 1.5rem; font-weight: 700; margin-bottom: 24px; }
-    .error-banner { background: #fef2f2; color: #ef4444; padding: 12px 16px; border-radius: 8px; margin-bottom: 16px; font-size: 0.875rem; }
+    .error-banner { background: #fef2f2; color: #ef4444; padding: 12px 16px; border-radius: 8px; margin-bottom: 16px; font-size: 0.875rem; display: flex; justify-content: space-between; align-items: center; gap: 12px; }
     .stats-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 16px; margin-bottom: 32px; }
     .stat-card { background: #fff; border-radius: 12px; padding: 20px; box-shadow: 0 1px 4px rgba(0,0,0,0.08); }
     .stat-label { display: block; font-size: 0.75rem; color: #6b7280; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 4px; }
     .stat-value { display: block; font-size: 1.75rem; font-weight: 700; color: #1a1a2e; }
-    .loading-section { display: flex; justify-content: center; padding: 48px 0; }
-    .empty-section { text-align: center; padding: 48px 0; color: #6b7280; }
-    .quick-actions { display: flex; gap: 12px; justify-content: center; margin-top: 16px; }
     .section { margin-bottom: 32px; }
     .section-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 16px; }
     .section-header h2 { font-size: 1.125rem; font-weight: 600; }
+    .header-actions { display: flex; align-items: center; gap: 12px; }
     .section-link { font-size: 0.875rem; color: #3b82f6; text-decoration: none; }
     .section-link:hover { text-decoration: underline; }
     .section-empty { color: #6b7280; font-size: 0.875rem; padding: 16px 0; }
     .card-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: 16px; }
+    .cards-skeleton { margin-bottom: 32px; }
+    .skeleton { min-height: 120px; display: flex; flex-direction: column; gap: 12px; }
+    .skeleton-block { background: #e5e7eb; border-radius: 6px; height: 18px; width: 100%; }
+    .skeleton-block.short { width: 55%; }
+    .stats-skeleton { }
+    .section-error { background: #fef2f2; color: #ef4444; padding: 16px; border-radius: 8px; font-size: 0.875rem; display: flex; flex-direction: column; gap: 12px; align-items: flex-start; }
+    .empty-section { text-align: center; padding: 48px 0; color: #6b7280; }
     .btn { display: inline-block; padding: 10px 20px; border-radius: 8px; font-size: 0.875rem; font-weight: 500; text-decoration: none; cursor: pointer; border: none; }
+    .btn-sm { padding: 6px 12px; font-size: 0.8125rem; }
     .btn-primary { background: #1a1a2e; color: #fff; }
     .btn-primary:hover { background: #2a2a4e; }
-    .btn-secondary { background: #fff; color: #1a1a2e; border: 1px solid #d1d5db; }
-    .btn-secondary:hover { background: #f0f2f5; }
+    .btn-outline { background: #fff; color: #1a1a2e; border: 1px solid #d1d5db; }
+    .btn-outline:hover { background: #f0f2f5; }
   `],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class DashboardComponent implements OnInit {
+export class DashboardComponent implements OnInit, OnDestroy {
   private readonly apiService = inject(ApiService);
   private readonly router = inject(Router);
 
   readonly bonds = signal<Bond[]>([]);
   readonly projects = signal<Project[]>([]);
-  readonly loading = signal(true);
-  readonly error = signal('');
 
   readonly totalBonds = signal(0);
   readonly activeBonds = signal(0);
   readonly totalProjects = signal(0);
   readonly carbonTotal = signal(0);
 
+  readonly bondsState = signal<SectionState>('loading');
+  readonly projectsState = signal<SectionState>('loading');
+  readonly overviewState = signal<SectionState>('loading');
+
+  readonly bondsError = signal('');
+  readonly projectsError = signal('');
+  readonly overviewError = signal('');
+
+  private readonly bondsRefresh$ = new Subject<void>();
+  private readonly projectsRefresh$ = new Subject<void>();
+  private readonly destroy$ = new Subject<void>();
+
+  readonly overallError = computed(() => {
+    if (this.bondsState() === 'error' && this.projectsState() === 'error') {
+      return 'Failed to load dashboard data.';
+    }
+    return '';
+  });
+
   ngOnInit(): void {
-    this.loadData();
+    this.bondsRefresh$
+      .pipe(takeUntil(this.destroy$), switchMap(() => this.fetchBonds()))
+      .subscribe();
+    this.projectsRefresh$
+      .pipe(takeUntil(this.destroy$), switchMap(() => this.fetchProjects()))
+      .subscribe();
+    this.loadBonds();
+    this.loadProjects();
   }
 
-  private loadData(): void {
-    this.loading.set(true);
-    this.error.set('');
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
 
-    this.apiService.getBonds(1, 5).subscribe({
-      next: (res) => {
-        this.bonds.set(res.data);
-        this.totalBonds.set(res.meta.total);
-        this.activeBonds.set(res.data.filter((b: Bond) => b.status === 'Active').length);
-      },
-      error: () => this.error.set('Failed to load dashboard data'),
-    });
+  retryBonds(): void {
+    this.loadBonds();
+  }
 
-    this.apiService.getProjects(1, 5).subscribe({
-      next: (res) => {
-        this.projects.set(res.data);
-        this.totalProjects.set(res.meta.total);
-        this.carbonTotal.set(res.data.reduce((sum: number, p: Project) => sum + p.carbonSequestrationEstimate, 0));
-        this.loading.set(false);
-      },
-      error: () => {
-        this.error.set('Failed to load dashboard data');
-        this.loading.set(false);
+  retryProjects(): void {
+    this.loadProjects();
+  }
+
+  retryOverview(): void {
+    // Overview derives from both feeds; retrying both restores it.
+    this.loadBonds();
+    this.loadProjects();
+  }
+
+  retryAll(): void {
+    this.retryOverview();
+  }
+
+  private loadBonds(): void {
+    this.bondsRefresh$.next();
+  }
+
+  private loadProjects(): void {
+    this.projectsRefresh$.next();
+  }
+
+  private fetchBonds(): Observable<PaginatedResponse<Bond>> {
+    this.bondsState.set('loading');
+    this.overviewState.set('loading');
+    this.bondsError.set('');
+    return defer(() => this.apiService.getBonds(1, 5)).pipe(
+      this.withRetry(),
+      tap({
+        next: (res) => {
+          this.bonds.set(res.data);
+          this.totalBonds.set(res.meta.total);
+          this.activeBonds.set(res.data.filter((b: Bond) => b.status === 'Active').length);
+          this.overviewState.update((st) => (st === 'error' ? 'loading' : st));
+          this.bondsState.set(res.data.length > 0 ? 'ready' : 'empty');
+        },
+        error: () => {
+          this.bondsError.set(appErrorMessage(this.lastError, 'Failed to load bonds'));
+          this.bondsState.set(this.bonds().length > 0 ? 'ready' : 'error');
+        },
+      }),
+      finalize(() => {
+        if (this.bondsState() !== 'error') {
+          this.computeOverview();
+        }
+      }),
+      catchError(() => EMPTY),
+    );
+  }
+
+  private fetchProjects(): Observable<PaginatedResponse<Project>> {
+    this.projectsState.set('loading');
+    this.overviewState.set('loading');
+    this.projectsError.set('');
+    return defer(() => this.apiService.getProjects(1, 5)).pipe(
+      this.withRetry(),
+      tap({
+        next: (res) => {
+          this.projects.set(res.data);
+          this.totalProjects.set(res.meta.total);
+          this.carbonTotal.set(res.data.reduce((sum: number, p: Project) => sum + p.carbonSequestrationEstimate, 0));
+          this.projectsState.set(res.data.length > 0 ? 'ready' : 'empty');
+        },
+        error: () => {
+          this.projectsError.set(appErrorMessage(this.lastError, 'Failed to load projects'));
+          this.projectsState.set(this.projects().length > 0 ? 'ready' : 'error');
+        },
+      }),
+      finalize(() => {
+        if (this.projectsState() !== 'error') {
+          this.computeOverview();
+        }
+      }),
+      catchError(() => EMPTY),
+    );
+  }
+
+  private computeOverview(): void {
+    const bondsOk = this.bondsState() === 'ready' || this.bondsState() === 'empty';
+    const projectsOk = this.projectsState() === 'ready' || this.projectsState() === 'empty';
+    if (bondsOk && projectsOk) {
+      this.overviewState.set(this.bonds().length === 0 && this.projects().length === 0 ? 'empty' : 'ready');
+    } else if (this.bondsState() === 'error' && this.projectsState() === 'error') {
+      this.overviewState.set('error');
+    } else if (this.bondsState() === 'loading' || this.projectsState() === 'loading') {
+      this.overviewState.set('loading');
+    } else if (bondsOk) {
+      this.overviewState.set(this.bonds().length === 0 && this.projects().length === 0 ? 'empty' : 'ready');
+    } else if (projectsOk) {
+      this.overviewState.set(this.bonds().length === 0 && this.projects().length === 0 ? 'empty' : 'ready');
+    } else {
+      this.overviewState.set('error');
+    }
+  }
+
+  private lastError: unknown = undefined;
+
+  private withRetry<T>() {
+    return retry<T>({
+      count: DASHBOARD_RETRY_COUNT,
+      delay: (error, attempt) => {
+        this.lastError = error;
+        return this.isTransientError(error) ? timer(this.retryDelayMs(attempt)) : throwError(() => error);
       },
     });
+  }
+
+  private retryDelayMs(attempt: number): number {
+    return Math.min(DASHBOARD_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1), DASHBOARD_RETRY_MAX_DELAY_MS);
+  }
+
+  private isTransientError(error: unknown): boolean {
+    if (error instanceof HttpErrorResponse) {
+      return error.status === 0 || error.status >= 500;
+    }
+    return true;
   }
 
   onSubscribe(bondId: string): void {

--- a/frontend/src/app/marketplace/marketplace-list/marketplace-list.component.spec.ts
+++ b/frontend/src/app/marketplace/marketplace-list/marketplace-list.component.spec.ts
@@ -13,8 +13,8 @@ const ORDER: Order = {
   id: 1,
   seller: 'GBOB',
   bondId: 3,
-  amount: 20,
-  pricePerToken: 10,
+  amount: '20',
+  pricePerToken: '10',
   quoteAsset: 'USDC',
   status: 'Open',
   createdAt: new Date().toISOString(),
@@ -22,7 +22,7 @@ const ORDER: Order = {
 
 const META = { page: 1, limit: 20, total: 1, totalPages: 1 };
 
-const FRESH_ORDER: Order = { ...ORDER, status: 'Filled', amount: 5 };
+const FRESH_ORDER: Order = { ...ORDER, status: 'Filled', amount: '5' };
 
 describe('MarketplaceListComponent', () => {
   let component: MarketplaceListComponent;
@@ -32,6 +32,7 @@ describe('MarketplaceListComponent', () => {
     getOrders: jasmine.Spy;
     buyBondTokens: jasmine.Spy;
     getQuoteBalance: jasmine.Spy;
+    getWalletBalance: jasmine.Spy;
   };
   let walletService: {
     isConnected: ReturnType<typeof signal<boolean>>;
@@ -45,6 +46,11 @@ describe('MarketplaceListComponent', () => {
       buyBondTokens: jasmine.createSpy('buyBondTokens').and.returnValue(of(undefined)),
       getQuoteBalance: jasmine
         .createSpy('getQuoteBalance')
+        .and.callFake((asset: string) =>
+          of({ address: 'GALICE', asset, balance: asset === 'USDC' ? 100 : 0 }),
+        ),
+      getWalletBalance: jasmine
+        .createSpy('getWalletBalance')
         .and.callFake((asset: string) =>
           of({ address: 'GALICE', asset, balance: asset === 'USDC' ? 100 : 0 }),
         ),
@@ -148,7 +154,7 @@ describe('MarketplaceListComponent', () => {
 
       component.refreshOrders();
       expect(component.orders()[0].status).toBe('Filled');
-      expect(component.orders()[0].amount).toBe(5);
+      expect(component.orders()[0].amount).toBe('5');
     });
 
     it('updates the UI with fresh order data after a refresh', () => {

--- a/frontend/src/app/marketplace/marketplace-list/marketplace-list.component.ts
+++ b/frontend/src/app/marketplace/marketplace-list/marketplace-list.component.ts
@@ -10,8 +10,12 @@ import { WalletService } from '../../auth/wallet.service';
 import { StatusBadgeComponent } from '../../shared/components/status-badge/status-badge.component';
 import { LoadingSpinnerComponent } from '../../shared/components/loading-spinner/loading-spinner.component';
 import { QuoteBalanceComponent, QuoteBalances } from '../../shared/components/quote-balance/quote-balance.component';
-import { Order, Bond, QuoteAsset } from '../../shared/interfaces/bond.interface';
+import { Order, Bond, QuoteAsset, PaginatedResponse } from '../../shared/interfaces/bond.interface';
 import { appErrorMessage } from '../../shared/errors/api-error';
+
+export const ORDERS_RETRY_COUNT = 3;
+export const ORDERS_RETRY_BASE_DELAY_MS = 1000;
+export const ORDERS_RETRY_MAX_DELAY_MS = 8000;
 
 @Component({
   selector: 'app-marketplace-list',
@@ -264,7 +268,7 @@ export class MarketplaceListComponent implements OnInit, OnDestroy {
     });
     const result: Record<number, { best: number; average: number }> = {};
     grouped.forEach((list, bondId) => {
-      const prices = list.map(o => o.pricePerToken);
+      const prices = list.map(o => Number(o.pricePerToken));
       result[bondId] = {
         best: Math.min(...prices),
         average: prices.reduce((a, b) => a + b, 0) / prices.length,
@@ -389,7 +393,7 @@ export class MarketplaceListComponent implements OnInit, OnDestroy {
     if (!this.buyAmount || this.buyAmount < 1 || !this.buyMaxPrice || this.buyMaxPrice <= 0) return null;
 
     const asset = order.quoteAsset;
-    const required = this.buyAmount * order.pricePerToken;
+    const required = this.buyAmount * Number(order.pricePerToken);
     const available = this.balances()[asset] ?? 0;
     return {
       required,

--- a/frontend/src/app/marketplace/marketplace-sell/marketplace-sell.component.spec.ts
+++ b/frontend/src/app/marketplace/marketplace-sell/marketplace-sell.component.spec.ts
@@ -13,10 +13,20 @@ describe('MarketplaceSellComponent', () => {
   beforeEach(async () => {
     const apiService = {
       getHeldBonds: jasmine.createSpy('getHeldBonds').and.returnValue(of([
-        { id: 1, creditType: 'Carbon', balance: 25 },
-        { id: 2, creditType: 'BlueCarbon', balance: 10 },
+        { id: 1, creditType: 'Carbon', balance: '25' },
+        { id: 2, creditType: 'BlueCarbon', balance: '10' },
       ])),
       listBondTokens: jasmine.createSpy('listBondTokens').and.returnValue(of({ id: 1 })),
+      getQuoteBalance: jasmine
+        .createSpy('getQuoteBalance')
+        .and.callFake((asset: string) =>
+          of({ address: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF', asset, balance: '50' }),
+        ),
+      getWalletBalance: jasmine
+        .createSpy('getWalletBalance')
+        .and.callFake((asset: string) =>
+          of({ address: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF', asset, balance: '50' }),
+        ),
     };
 
     await TestBed.configureTestingModule({

--- a/frontend/src/app/marketplace/marketplace-sell/marketplace-sell.component.ts
+++ b/frontend/src/app/marketplace/marketplace-sell/marketplace-sell.component.ts
@@ -5,7 +5,7 @@ import { AbstractControl, FormBuilder, FormGroup, ReactiveFormsModule, Validatio
 import { ApiService } from '../../shared/services/api.service';
 import { WalletService } from '../../auth/wallet.service';
 import { QuoteBalanceComponent } from '../../shared/components/quote-balance/quote-balance.component';
-import { Bond } from '../../shared/interfaces/bond.interface';
+import { HeldBond } from '../../shared/interfaces/bond.interface';
 import { appErrorMessage } from '../../shared/errors/api-error';
 
 @Component({
@@ -163,7 +163,7 @@ export class MarketplaceSellComponent implements OnInit {
 
   private updateSelectedBalance(bondId: unknown): void {
     const heldBond = this.bonds().find((bond) => bond.id === Number(bondId));
-    this.selectedBalance.set(heldBond?.balance ?? null);
+    this.selectedBalance.set(heldBond?.balance != null ? Number(heldBond.balance) : null);
   }
 
   onSubmit(): void {

--- a/frontend/src/app/shared/components/quote-balance/quote-balance.component.ts
+++ b/frontend/src/app/shared/components/quote-balance/quote-balance.component.ts
@@ -173,8 +173,8 @@ export class QuoteBalanceComponent implements OnInit {
       xlmWallet: this.apiService.getWalletBalance('XLM').pipe(catchError(() => of({ balance: 0 }))),
     }).subscribe({
       next: (res) => {
-        this.balances.set({ USDC: res.usdcEscrow.balance, XLM: res.xlmEscrow.balance });
-        this.walletBalances.set({ USDC: res.usdcWallet.balance, XLM: res.xlmWallet.balance });
+        this.balances.set({ USDC: Number(res.usdcEscrow.balance), XLM: Number(res.xlmEscrow.balance) });
+        this.walletBalances.set({ USDC: Number(res.usdcWallet.balance), XLM: Number(res.xlmWallet.balance) });
         this.loading.set(false);
         this.balanceChange.emit(this.balances());
       },


### PR DESCRIPTION
Closes #123

## Summary
Rework the dashboard so each section (Overview, Recent Bonds, Recent Projects) tracks its own loading / empty / error / ready state independently.

- **Loading**: per-section skeleton placeholders.
- **Empty**: helpful empty state per section (no longer a single blanket "no bonds or projects").
- **Partial failure**: one failed upstream request no longer blanks the whole dashboard. Successful sections are preserved, each with its own **Retry** control. An "Overview" row uses the same global API problem-detail model for rendering errors.
- **Retries**: transient failures (network / 5xx) retry with exponential backoff (same pattern as the marketplace); 4xx fail fast.

## Tests
Adds `src/app/dashboard/dashboard.component.spec.ts` covering all-loading, all-empty, partial-error (preserve successful section + not blanking), section-targeted retry, recovery via retry, retry backoff, and refresh concurrency (no stacked subscriptions, stale-response guard). All 54 frontend tests pass; lint + production build clean.

## Also fixes pre-existing frontend breakage (blocked the whole suite from compiling)
A prior interface migration changed amounts to `string`, but consumers were not updated. Fixed:
- **marketplace-list**: declare/export missing `ORDERS_RETRY_*` constants, import `PaginatedResponse`, coerce `pricePerToken`.
- **marketplace-sell**: import `HeldBond`, coerce held balance, stub quote-balance API mocks in spec.
- **bond-detail**: coerce string amounts to numeric signals; align spec fixtures to string types.
- **quote-balance**: coerce string balances to the numeric `QuoteBalances` type.

## Verification
- `ng test --watch=false --browsers=ChromeHeadless`: **54 SUCCESS**
- `ng lint`: All files pass
- `ng build`: succeeds