### PR TITLE
fix(dashboard,ipfs,fixtures,repro): resilient dashboards, IPFS upload policy, seed fixtures, reproducible builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
       - name: Build
         run: cargo build --release
         working-directory: contracts
+      - name: Verify reproducible WASM checksums (skips if soroban CLI unavailable)
+        run: ./scripts/reproducibility/wasm-checksums.sh --verify
       - name: Test
         run: cargo test
         working-directory: contracts
@@ -120,6 +122,18 @@ jobs:
       - name: Test
         run: npm test
         working-directory: oracle
+
+  reproducibility:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Verify reproducible lockfiles and artifacts
+        run: ./scripts/reproducibility/verify.sh
 
   deploy-testnet:
     if: github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch'

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@
 - [API Reference](#-api-reference)
 - [Testing](#-testing)
 - [Deployment](#-deployment)
+- [Reproducible Builds](#reproducible-builds)
 - [Governance](#-governance)
 - [Compliance & KYC](#-compliance--kyc)
 - [Roadmap](#-roadmap)
@@ -789,6 +790,42 @@ cd frontend && ng serve
 open http://localhost:4200
 ```
 
+### Local Development Fixtures (Seeding)
+
+The API serves list/detail pages (dashboard, projects, bonds, marketplace,
+oracle) from a Redis cache that is normally populated by on-chain contract
+calls. To develop without deployed contracts, you can seed the local cache with
+a **deterministic, realistic fixture set** so every page renders meaningful data.
+
+```bash
+# Within the api package:
+cd api
+
+# 1. Ensure Redis is running (see docker-compose.yml).
+# 2. Apply the fixtures (idempotent — skips if already seeded):
+npm run seed
+
+# Re-apply fixtures after changing them (overwrites seed keys):
+npm run seed -- --force
+
+# Clear all seeded keys and the seed marker:
+npm run seed -- --reset
+```
+
+What gets seeded (all values are stable and repeatable across runs):
+
+| Domain          | Fixtures                                                                   |
+| --------------- | -------------------------------------------------------------------------- |
+| Users/roles     | 4 users covering admin, developer, investor, oracle-provider               |
+| Projects        | 6 projects spanning every status and 4 credit methodologies                |
+| Bonds           | 8 bonds across Active/Matured and all credit types                          |
+| Marketplace     | 6 orders covering every order status                                        |
+| Oracle reports  | 10 reports (9 plus a pending/stale case) across all report statuses         |
+
+The seed is idempotent (guarded by a `seed:verdant:marker` Redis key) and never
+duplicates or clobbers unrelated keys. See `api/src/seed/fixtures.ts` for the
+data and `api/scripts/seed.ts` for the CLI entry point.
+
 ---
 
 ## 🔧 Environment Variables
@@ -1084,6 +1121,42 @@ docker-compose up -d
 # View logs
 docker-compose logs -f api
 ```
+
+### Reproducible Builds
+
+Releases must be reproducible: the same commit must yield the same Lockfiles,
+WASM contract artifacts, and Node bundles on any machine or CI runner. A
+committed, in-sync lockfile is the primary guarantee; drifting lockfiles or
+uncommitted dependency resolutions are the leading cause of unreproducible
+builds.
+
+Run the self-contained reproducibility gate:
+
+```bash
+# Validates lockfile presence + sync for api/frontend/oracle, Cargo.lock for
+# contracts, and (when the soroban CLI is available) contract WASM checksums:
+./scripts/reproducibility/verify.sh
+```
+
+What each check enforces, and how to regenerate baselines:
+
+| Check                                                     | Script                                                        | Baseline to commit              |
+| --------------------------------------------------------- | ------------------------------------------------------------- | ------------------------------- |
+| Node lockfiles present & in sync (`npm ci --dry-run`)     | `scripts/reproducibility/lockfiles.sh`                        | `api|frontend|oracle/package-lock.json` |
+| Rust workspace pinned                                     | `scripts/reproducibility/lockfiles.sh`                        | `contracts/Cargo.lock`          |
+| Contract WASM artifact checksums                          | `scripts/reproducibility/wasm-checksums.sh --verify`          | `contracts/checksums.sha256`    |
+
+Regenerating the contract WASM checksum baseline (only when artifacts
+intentionally change):
+
+```bash
+./scripts/reproducibility/wasm-checksums.sh --generate
+```
+
+The CI pipeline runs `verify.sh` on every push/PR, so a commit that breaks
+reproducibility (e.g. an out-of-sync lockfile) is blocked before merge, and
+the `contracts` job re-verifies WASM checksums whenever the soroban CLI is
+available in the build environment.
 
 ---
 

--- a/api/package.json
+++ b/api/package.json
@@ -9,7 +9,10 @@
     "test": "jest",
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "test:cov": "jest --coverage",
-    "lint": "eslint \"{src,test}/**/*.ts\""
+    "lint": "eslint \"{src,test}/**/*.ts\"",
+    "typecheck": "tsc --noEmit",
+    "seed": "ts-node scripts/seed.ts",
+    "seed:reset": "ts-node scripts/seed.ts --reset"
   },
   "dependencies": {
     "@nestjs/common": "^10.4.0",

--- a/api/scripts/seed.ts
+++ b/api/scripts/seed.ts
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+/**
+ * Deterministic local seed data for Verdant Bond Protocol.
+ *
+ * Populates the Redis cache keys the API reads (projects, bonds, orders,
+ * oracle reports) with realistic fixtures so the local frontend shows
+ * meaningful data without deployed contracts.
+ *
+ * Usage:
+ *   npm run seed                 # apply fixtures (idempotent; skips if done)
+ *   npm run seed -- --force      # always re-apply fixtures
+ *   npm run seed -- --reset      # clear all seeded keys
+ */
+import 'reflect-metadata';
+import { Module } from '@nestjs/common';
+import { NestFactory } from '@nestjs/core';
+import { CommonModule } from '../src/common/common.module';
+import { SeedModule } from '../src/seed/seed.module';
+import { SeedService } from '../src/seed/seed.service';
+
+@Module({
+  imports: [CommonModule, SeedModule],
+})
+class SeedContextModule {}
+
+async function main(): Promise<void> {
+  const argv = process.argv.slice(2);
+  const force = argv.includes('--force');
+  const reset = argv.includes('--reset');
+
+  const app = await NestFactory.createApplicationContext(SeedContextModule, {
+    logger: ['error', 'warn', 'log'],
+  });
+  const seedService = app.get(SeedService);
+
+  try {
+    if (reset) {
+      await seedService.reset();
+      console.log('Seed data cleared.');
+    } else {
+      const summary = await seedService.seed(force);
+      if (summary.wasSkipped) {
+        console.log('Already seeded. Run `npm run seed -- --force` to reseed.');
+      } else {
+        console.log(
+          `Seeded ${summary.totals.bonds} bonds, ${summary.totals.projects} projects, ` +
+            `${summary.totals.orders} orders, ${summary.totals.oracleReports} oracle reports, ` +
+            `${summary.totals.cacheKeysWritten} cache keys.`,
+        );
+      }
+    }
+    await app.close();
+  } finally {
+    process.exit(0);
+  }
+}
+
+main().catch(async (error) => {
+  console.error('Seed failed:', error);
+  process.exitCode = 1;
+  process.exit(1);
+});

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -7,18 +7,22 @@ import { OracleModule } from './oracle/oracle.module';
 import { MarketplaceModule } from './marketplace/marketplace.module';
 import { AuthModule } from './auth/auth.module';
 import { StellarModule } from './stellar/stellar.module';
+import { SeedModule } from './seed/seed.module';
+import { ConfigModule } from './config/config.module';
 import { Rfc7807ExceptionFilter } from './common/filters/rfc7807-exception.filter';
 import { RequestLoggingInterceptor } from './common/interceptors/request-logging.interceptor';
 
 @Module({
   imports: [
     CommonModule,
+    ConfigModule,
     BondsModule,
     ProjectsModule,
     OracleModule,
     MarketplaceModule,
     AuthModule,
     StellarModule,
+    SeedModule,
   ],
   providers: [
     { provide: APP_FILTER, useClass: Rfc7807ExceptionFilter },

--- a/api/src/bonds/bonds.service.spec.ts
+++ b/api/src/bonds/bonds.service.spec.ts
@@ -22,7 +22,16 @@ import { StellarService } from '../stellar/stellar.service';
 import { NonceService } from '../common/services/nonce.service';
 import { RedisService } from '../common/services/redis.service';
 import { SigningKeyProvider } from '../common/services/signing-key.provider';
+import { ConfigService } from '../config/config.service';
 import { BondStatusEnum, BondMaturityStatusEnum, CreditTypeEnum } from './interfaces/bond.interface';
+
+const configProvider = {
+  provide: ConfigService,
+  useValue: {
+    getBondIssuerAddress: jest.fn().mockReturnValue(''),
+    getCouponEngineAddress: jest.fn().mockReturnValue(''),
+  },
+};
 
 const redisProvider = {
   provide: RedisService,
@@ -58,6 +67,7 @@ describe('BondsService', () => {
         },
         redisProvider,
         signingProvider,
+        configProvider,
       ],
     }).compile();
 
@@ -119,6 +129,7 @@ describe('BondsService', () => {
           },
           redisProvider,
           signingProvider,
+          configProvider,
         ],
       }).compile();
 
@@ -157,6 +168,7 @@ describe('BondsService', () => {
           },
           redisProvider,
           signingProvider,
+          configProvider,
         ],
       }).compile();
 
@@ -188,6 +200,7 @@ describe('BondsService', () => {
           { provide: NonceService, useValue: { next: jest.fn() } },
           redisProvider,
           signingProvider,
+          configProvider,
         ],
       }).compile();
       const svc = moduleRef.get(BondsService);
@@ -242,6 +255,7 @@ describe('BondsService', () => {
           },
           redisProvider,
           signingProvider,
+          configProvider,
         ],
       }).compile();
 
@@ -284,6 +298,7 @@ describe('BondsService', () => {
           },
           redisProvider,
           signingProvider,
+          configProvider,
         ],
       }).compile();
       return moduleRef.get(BondsService);
@@ -364,6 +379,7 @@ describe('BondsService', () => {
           },
           redisProvider,
           signingProvider,
+          configProvider,
         ],
       }).compile();
       return moduleRef.get(BondsService);

--- a/api/src/bonds/bonds.service.ts
+++ b/api/src/bonds/bonds.service.ts
@@ -25,6 +25,7 @@ import {
 } from './interfaces/bond.interface';
 import { toBigIntString } from '../common/utils';
 import { ConfigService } from '../config/config.service';
+import { Address, nativeToScVal, scValToNative, xdr } from '@stellar/stellar-sdk';
 
 const BOND_ERROR_CODE = {
   NotInitialized: 1,

--- a/api/src/config/config.module.ts
+++ b/api/src/config/config.module.ts
@@ -1,0 +1,9 @@
+import { Global, Module } from '@nestjs/common';
+import { ConfigService } from './config.service';
+
+@Global()
+@Module({
+  providers: [ConfigService],
+  exports: [ConfigService],
+})
+export class ConfigModule {}

--- a/api/src/marketplace/dex.service.spec.ts
+++ b/api/src/marketplace/dex.service.spec.ts
@@ -6,7 +6,16 @@ import { StellarService } from '../stellar/stellar.service';
 import { NonceService } from '../common/services/nonce.service';
 import { RedisService } from '../common/services/redis.service';
 import { SigningKeyProvider } from '../common/services/signing-key.provider';
+import { ConfigService } from '../config/config.service';
 import { OrderStatus } from './interfaces/marketplace.interface';
+
+const configProvider = {
+  provide: ConfigService,
+  useValue: {
+    getDexRouterAddress: jest.fn().mockReturnValue(''),
+  },
+};
+
 
 // ---------------------------------------------------------------------------
 // Minimal in-memory Redis stub used by cache-staleness tests.
@@ -95,6 +104,7 @@ describe('DexService', () => {
           provide: SigningKeyProvider,
           useValue: { adminSecret: jest.fn().mockReturnValue('SADMIN') },
         },
+        configProvider,
       ],
     }).compile();
 
@@ -405,6 +415,7 @@ describe('DexService — cache staleness (in-memory Redis)', () => {
           provide: SigningKeyProvider,
           useValue: { adminSecret: jest.fn().mockReturnValue('SADMIN') },
         },
+        configProvider,
       ],
     }).compile();
 

--- a/api/src/oracle/oracle.monitoring.service.spec.ts
+++ b/api/src/oracle/oracle.monitoring.service.spec.ts
@@ -2,6 +2,7 @@ import { Test } from '@nestjs/testing';
 import { OracleMonitoringService } from './oracle.monitoring.service';
 import { ProjectsService } from '../projects/projects.service';
 import { OracleService } from './oracle.service';
+import { RedisService } from '../common/services/redis.service';
 import { ReportStatus } from './interfaces/oracle.interface';
 
 const NOW = Date.UTC(2026, 0, 1, 0, 0, 0);
@@ -49,6 +50,13 @@ describe('OracleMonitoringService', () => {
         OracleMonitoringService,
         { provide: ProjectsService, useValue: projectsService },
         { provide: OracleService, useValue: oracleService },
+        {
+          provide: RedisService,
+          useValue: {
+            get: jest.fn().mockResolvedValue(null),
+            set: jest.fn().mockResolvedValue(undefined),
+          },
+        },
       ],
     }).compile();
 

--- a/api/src/oracle/oracle.service.spec.ts
+++ b/api/src/oracle/oracle.service.spec.ts
@@ -84,7 +84,7 @@ describe('OracleService', () => {
         projectId: 'a1b2'.padEnd(64, '0'),
         periodStart: 1700000000,
         periodEnd: 1700086400,
-        carbonSequestered: 1200,
+        carbonSequestered: '1200',
         methodology: 'VM0003',
         ipfsHash: 'c3d4'.padEnd(64, '0'),
         status: ReportStatus.Verified,
@@ -143,8 +143,8 @@ describe('OracleService', () => {
 
       expect((service as any).decodeSlashRecord(raw)).toEqual({
         reportId: 7,
-        penalty: 10_000,
-        remainingStake: 90_000,
+        penalty: '10000',
+        remainingStake: '90000',
         timestamp: new Date(1700000000 * 1000).toISOString(),
         activeAfter: true,
       });
@@ -161,8 +161,8 @@ describe('OracleService', () => {
 
       expect((service as any).decodeSlashRecord(raw)).toEqual({
         reportId: 7,
-        penalty: 10_000,
-        remainingStake: 90_000,
+        penalty: '10000',
+        remainingStake: '90000',
         timestamp: new Date(1700000000 * 1000).toISOString(),
         activeAfter: true,
       });

--- a/api/src/projects/ipfs-upload.policy.spec.ts
+++ b/api/src/projects/ipfs-upload.policy.spec.ts
@@ -1,0 +1,110 @@
+import { IpfsUploadPolicy, FileScanHook } from './ipfs-upload.policy';
+
+const PDF = Buffer.concat([
+  Buffer.from('%PDF-1.4\n'),
+  Buffer.alloc(1024, 1),
+]);
+
+const PNG = Buffer.concat([
+  Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+  Buffer.alloc(100, 2),
+]);
+
+const OVERSIZED = Buffer.alloc(10 * 1024 * 1024 + 1, 7);
+
+describe('IpfsUploadPolicy', () => {
+  it('accepts a valid pdf with matching mime and extension', async () => {
+    const policy = new IpfsUploadPolicy();
+    const mime = await policy.validate({ buffer: PDF, mimetype: 'application/pdf', filename: 'report.pdf' });
+    expect(mime).toBe('application/pdf');
+  });
+
+  it('accepts a valid png', async () => {
+    const policy = new IpfsUploadPolicy();
+    const mime = await policy.validate({ buffer: PNG, mimetype: 'image/png', filename: 'evidence.png' });
+    expect(mime).toBe('image/png');
+  });
+
+  describe('size', () => {
+    it('rejects oversized files before upload', async () => {
+      const policy = new IpfsUploadPolicy();
+      await expect(
+        policy.validate({ buffer: OVERSIZED, mimetype: 'application/pdf', filename: 'big.pdf' }),
+      ).rejects.toMatchObject({ code: 'FILE_TOO_LARGE' });
+    });
+
+    it('honors a custom size limit', async () => {
+      const policy = new IpfsUploadPolicy({ maxFileBytes: 100 });
+      await expect(
+        policy.validate({ buffer: PDF, mimetype: 'application/pdf', filename: 'report.pdf' }),
+      ).rejects.toMatchObject({ code: 'FILE_TOO_LARGE' });
+    });
+
+    it('rejects empty files', async () => {
+      const policy = new IpfsUploadPolicy();
+      await expect(
+        policy.validate({ buffer: Buffer.alloc(0), mimetype: 'application/pdf', filename: 'empty.pdf' }),
+      ).rejects.toMatchObject({ code: 'EMPTY_FILE' });
+    });
+  });
+
+  describe('mime allow-list', () => {
+    it('rejects unsupported MIME types', async () => {
+      const policy = new IpfsUploadPolicy();
+      await expect(
+        policy.validate({ buffer: PDF, mimetype: 'text/html', filename: 'page.html' }),
+      ).rejects.toMatchObject({ code: 'UNSUPPORTED_MIME' });
+    });
+  });
+
+  describe('extension mismatch', () => {
+    it('rejects a declared pdf with a non-matching extension', async () => {
+      const policy = new IpfsUploadPolicy();
+      await expect(
+        policy.validate({ buffer: PDF, mimetype: 'application/pdf', filename: 'report.txt' }),
+      ).rejects.toMatchObject({ code: 'EXTENSION_MISMATCH' });
+    });
+
+    it('rejects explicitly blocked extensions', async () => {
+      const policy = new IpfsUploadPolicy();
+      await expect(
+        policy.validate({ buffer: Buffer.from('MZ...'), mimetype: 'application/octet-stream', filename: 'payload.exe' }),
+      ).rejects.toMatchObject({ code: 'BLOCKED_EXTENSION' });
+    });
+  });
+
+  describe('content sniffing', () => {
+    it('rejects when content bytes contradict the declared mime', async () => {
+      const policy = new IpfsUploadPolicy();
+      await expect(
+        policy.validate({ buffer: PDF, mimetype: 'image/png', filename: 'fake.png' }),
+      ).rejects.toMatchObject({ code: 'CONTENT_MISMATCH' });
+    });
+  });
+
+  describe('scan hook', () => {
+    it('blocks unsafe files when a scan hook rejects them', async () => {
+      const hook: FileScanHook = {
+        scan: async () => ({ safe: false, reason: 'detected malware signature' }),
+      };
+      const policy = new IpfsUploadPolicy({ scanEnabled: true, scanHook: hook });
+      await expect(
+        policy.validate({ buffer: PDF, mimetype: 'application/pdf', filename: 'report.pdf' }),
+      ).rejects.toMatchObject({ code: 'SCAN_REJECTED', message: expect.stringContaining('malware') });
+    });
+
+    it('accepts files the scan hook approves', async () => {
+      const hook: FileScanHook = { scan: async () => ({ safe: true }) };
+      const policy = new IpfsUploadPolicy({ scanEnabled: true, scanHook: hook });
+      const mime = await policy.validate({ buffer: PDF, mimetype: 'application/pdf', filename: 'report.pdf' });
+      expect(mime).toBe('application/pdf');
+    });
+
+    it('fails closed when scanning is enabled but no hook is configured', async () => {
+      const policy = new IpfsUploadPolicy({ scanEnabled: true });
+      await expect(
+        policy.validate({ buffer: PDF, mimetype: 'application/pdf', filename: 'report.pdf' }),
+      ).rejects.toMatchObject({ code: 'SCAN_UNAVAILABLE' });
+    });
+  });
+});

--- a/api/src/projects/ipfs-upload.policy.ts
+++ b/api/src/projects/ipfs-upload.policy.ts
@@ -1,0 +1,177 @@
+
+/**
+ * Upload policy for IPFS document/evidence uploads.
+ *
+ * Enforces defensive controls before untrusted content is pinned:
+ *  - maximum content size
+ *  - allowed MIME types (allow-list) with extension match
+ *  - content sniffing against magic bytes to catch extension/mime mismatch
+ *  - an optional pluggable malware-scan hook
+ *
+ * Values can be tuned via environment variables:
+ *  `IPFS_MAX_FILE_BYTES`          — max accepted payload size in bytes.
+ *  `IPFS_SCAN_ENABLED`            — 'true' to enable the scan hook.
+ *  `IPFS_BLOCKED_EXTENSIONS`      — extra extensions to reject (comma separated).
+ */
+
+export interface ScanResult {
+  /** True when the payload is considered safe to pin. */
+  safe: boolean;
+  /** Human-readable reason when rejected. */
+  reason?: string;
+}
+
+export interface FileScanHook {
+  /** Optionally return a structured buffer/mimetype for the scanner. */
+  scan(input: { buffer: Buffer; mimetype: string; filename: string }): Promise<ScanResult>;
+}
+
+export class UploadRejectedError extends Error {
+  constructor(
+    public readonly code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'UploadRejectedError';
+  }
+}
+
+export interface UploadPolicyOptions {
+  maxFileBytes?: number;
+  scanEnabled?: boolean;
+  scanHook?: FileScanHook;
+  blockedExtensions?: string[];
+}
+
+const DEFAULT_MAX_FILE_BYTES = 5 * 1024 * 1024; // 5 MiB
+
+/** Allow-list of accepted document/evidence MIME types. */
+export const ALLOWED_MIME_TYPES: Record<string, string[]> = {
+  'application/pdf': ['.pdf'],
+  'application/json': ['.json'],
+  'application/octet-stream': ['.ser', '.bin'],
+  'text/plain': ['.txt', '.md'],
+  'image/png': ['.png'],
+  'image/jpeg': ['.jpg', '.jpeg'],
+  'image/svg+xml': ['.svg'],
+};
+
+/** Magic-byte sniffers (first bytes of a buffer) to detect known types. */
+const MAGIC_SNIFFERS: Array<{ mime: string; match: (b: Buffer) => boolean }> = [
+  { mime: 'application/pdf', match: (b) => b.length >= 5 && b.subarray(0, 5).toString('latin1') === '%PDF-' },
+  { mime: 'image/png', match: (b) => b.length >= 8 && b.readUInt32BE(0) === 0x89504e47 && b.readUInt32BE(4) === 0x0d0a1a0a },
+  { mime: 'image/jpeg', match: (b) => b.length >= 3 && b[0] === 0xff && b[1] === 0xd8 && b[2] === 0xff },
+  { mime: 'image/svg+xml', match: (b) => b.length >= 5 && /^\s*</.test(b.subarray(0, 64).toString('latin1')) && b.subarray(0, 64).toString('latin1').includes('<svg') },
+  { mime: 'application/json', match: (b) => {
+      const head = b.subarray(0, 64).toString('latin1').trimStart();
+      return head.startsWith('{') || head.startsWith('[');
+    } },
+];
+
+function extensionOf(filename: string): string {
+  const idx = filename.lastIndexOf('.');
+  return idx >= 0 ? filename.slice(idx).toLowerCase() : '';
+}
+
+function sniffMime(buffer: Buffer): string | null {
+  for (const s of MAGIC_SNIFFERS) {
+    if (s.match(buffer)) return s.mime;
+  }
+  return null;
+}
+
+export class IpfsUploadPolicy {
+  private readonly maxFileBytes: number;
+  private readonly scanEnabled: boolean;
+  private readonly scanHook?: FileScanHook;
+  private readonly blockedExtensions: Set<string>;
+
+  constructor(options: UploadPolicyOptions = {}) {
+    this.maxFileBytes = options.maxFileBytes ?? this.fromEnvInt('IPFS_MAX_FILE_BYTES', DEFAULT_MAX_FILE_BYTES);
+    this.scanEnabled = options.scanEnabled ?? process.env.IPFS_SCAN_ENABLED === 'true';
+    this.scanHook = options.scanHook;
+    this.blockedExtensions = new Set([
+      ...(options.blockedExtensions ?? []),
+      ...(process.env.IPFS_BLOCKED_EXTENSIONS ?? '').split(',').map((s) => s.trim()).filter(Boolean),
+      '.exe', '.dll', '.sh', '.bat', '.cmd', '.msi', '.js', '.jar', '.apk',
+    ]);
+  }
+
+  private fromEnvInt(key: string, fallback: number): number {
+    const raw = process.env[key];
+    if (!raw) return fallback;
+    const parsed = Number.parseInt(raw, 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+  }
+
+  /**
+   * Validate a file against the upload policy. Returns the resolved allowed
+   * MIME type (falling back to the sniffed type) on success or throws an
+   * `UploadRejectedError` describing the reason.
+   */
+  async validate(input: { buffer: Buffer; mimetype: string; filename: string }): Promise<string> {
+    const { buffer, mimetype, filename } = input;
+
+    if (buffer.length === 0) {
+      throw new UploadRejectedError('EMPTY_FILE', 'Cannot upload an empty file.');
+    }
+    if (buffer.length > this.maxFileBytes) {
+      throw new UploadRejectedError(
+        'FILE_TOO_LARGE',
+        `File exceeds the ${this.maxFileBytes}-byte upload limit.`,
+      );
+    }
+
+    const ext = extensionOf(filename);
+    if (this.blockedExtensions.has(ext)) {
+      throw new UploadRejectedError('BLOCKED_EXTENSION', `File extension "${ext}" is not allowed.`);
+    }
+
+    // Allow a declared JSON/text/octet-stream type that we cannot sniff, but
+    // require a known allow-listed mimetype overall.
+    const normalizedMime = mimetype?.toLowerCase() || '';
+    const allowed = this.allowedMimeFor(normalizedMime);
+    if (!allowed) {
+      throw new UploadRejectedError('UNSUPPORTED_MIME', `MIME type "${mimetype}" is not allowed.`);
+    }
+
+    if (!ALLOWED_MIME_TYPES[allowed]!.includes(ext) && !(allowed === 'application/octet-stream')) {
+      throw new UploadRejectedError(
+        'EXTENSION_MISMATCH',
+        `Extension "${ext}" does not match MIME type "${allowed}".`,
+      );
+    }
+
+    // Content sniffing: reject when the bytes clearly indicate a different type.
+    const sniffed = sniffMime(buffer);
+    if (sniffed && sniffed !== allowed && !(allowed === 'application/octet-stream')) {
+      throw new UploadRejectedError(
+        'CONTENT_MISMATCH',
+        `Declared MIME type "${allowed}" does not match detected content type "${sniffed}".`,
+      );
+    }
+
+    if (this.scanEnabled) {
+      if (!this.scanHook) {
+        throw new UploadRejectedError(
+          'SCAN_UNAVAILABLE',
+          'Malware scanning is enabled but no scan hook is configured.',
+        );
+      }
+      const scan = await this.scanHook.scan({ buffer, mimetype: allowed, filename });
+      if (!scan.safe) {
+        throw new UploadRejectedError('SCAN_REJECTED', scan.reason || 'File was rejected by the malware scanner.');
+      }
+    }
+
+    return allowed;
+  }
+
+  private allowedMimeFor(mime: string): string | null {
+    if (ALLOWED_MIME_TYPES[mime]) return mime;
+    if (mime === 'application/octet-stream' || mime === '') {
+      return Object.keys(ALLOWED_MIME_TYPES).includes('application/octet-stream') ? 'application/octet-stream' : null;
+    }
+    return null;
+  }
+}

--- a/api/src/projects/ipfs.service.ts
+++ b/api/src/projects/ipfs.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { IpfsUploadPolicy } from './ipfs-upload.policy';
 
 interface IpfsUploadResult {
   hash: string;
@@ -15,6 +16,8 @@ export class IpfsService {
     secretKey: process.env.IPFS_SECRET_KEY || '',
     gateway: process.env.IPFS_GATEWAY || 'https://gateway.pinata.cloud/ipfs/',
   };
+
+  constructor(private readonly uploadPolicy: IpfsUploadPolicy) {}
 
   async uploadJson(data: Record<string, unknown>): Promise<IpfsUploadResult> {
     const response = await fetch(
@@ -46,11 +49,21 @@ export class IpfsService {
     };
   }
 
-  async uploadFile(buffer: Buffer, filename: string): Promise<IpfsUploadResult> {
+  async uploadFile(
+    buffer: Buffer,
+    filename: string,
+    mimetype?: string,
+  ): Promise<IpfsUploadResult> {
+    await this.uploadPolicy.validate({
+      buffer,
+      filename,
+      mimetype: mimetype ?? '',
+    });
     return this.uploadJson({
       filename,
       content: buffer.toString('base64'),
       size: buffer.length,
+      mimetype: mimetype ?? 'application/octet-stream',
     });
   }
 

--- a/api/src/projects/projects.module.ts
+++ b/api/src/projects/projects.module.ts
@@ -2,10 +2,18 @@ import { Module } from '@nestjs/common';
 import { ProjectsController } from './projects.controller';
 import { ProjectsService } from './projects.service';
 import { IpfsService } from './ipfs.service';
+import { IpfsUploadPolicy } from './ipfs-upload.policy';
 
 @Module({
   controllers: [ProjectsController],
-  providers: [ProjectsService, IpfsService],
+  providers: [
+    ProjectsService,
+    IpfsService,
+    {
+      provide: IpfsUploadPolicy,
+      useFactory: () => new IpfsUploadPolicy(),
+    },
+  ],
   exports: [IpfsService, ProjectsService],
 })
 export class ProjectsModule {}

--- a/api/src/projects/projects.service.ts
+++ b/api/src/projects/projects.service.ts
@@ -142,7 +142,7 @@ export class ProjectsService {
     const gatewayUrls: string[] = [];
 
     for (const file of files) {
-      const result = await this.ipfsService.uploadFile(file.buffer, file.originalname);
+      const result = await this.ipfsService.uploadFile(file.buffer, file.originalname, file.mimetype);
       documentHashes.push(result.hash);
       gatewayUrls.push(result.gatewayUrl);
     }

--- a/api/src/seed/fixtures.ts
+++ b/api/src/seed/fixtures.ts
@@ -1,0 +1,272 @@
+/**
+ * Deterministic, realistic seed fixtures for local development.
+ *
+ * These power the Redis-backed seed command (`scripts/seed.ts` / `npm run
+ * seed`) so that the dashboard, projects, bonds, marketplace, and oracle
+ * pages render meaningful data without requiring deployed Soroban contracts.
+ *
+ * Every value is stable (fixed UUID-ish addresses and timestamps derived from
+ * a fixed base) so the seed is repeatable and idempotent across runs.
+ */
+
+const BASE_TS = Date.UTC(2026, 0, 15); // fixed anchor used to derive timestamps
+const DAY = 86_400_000;
+
+/** Deterministic pseudo-random sequence (mulberry32) so fixtures never change. */
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const rand = mulberry32(20260115);
+
+function wallet(i: number): string {
+  // Fake but structurally valid (G + Base32-ish) addresses for local display.
+  // Deterministic and distinct per index so every entity gets a unique owner.
+  const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ234567';
+  let x = (i + 1) * 2654435761;
+  let out = 'G';
+  for (let k = 0; k < 55; k++) {
+    x = (x * 1103515245 + 12345) >>> 0;
+    out += chars[(x >>> 0) % chars.length];
+  }
+  return out;
+}
+
+export interface SeedProject {
+  id: number;
+  name: string;
+  status: 'Pending' | 'Approved' | 'Rejected' | 'Inactive';
+  methodology: string;
+  country: string;
+  metadataIpfsHash: string;
+  ownerAddress: number;
+  totalAreaHa: number;
+  carbonSequestrationEstimate: number;
+  createdAt: number;
+  description: string;
+  creditType: string;
+  blueCarbon: boolean;
+}
+
+export interface SeedBond {
+  id: number;
+  projectId: number;
+  name: string;
+  faceValue: number;
+  couponSchedule: string[];
+  creditType: 'Carbon' | 'Biodiversity' | 'Basket' | 'BlueCarbon';
+  maturityDate: number;
+  maturityStatus: 'Active' | 'Matured';
+  totalSupply: number;
+  totalSubscribed: number;
+  status: 'Active' | 'Matured' | 'Defaulted';
+  couponRate: number;
+  createdAt: number;
+}
+
+export interface SeedOrder {
+  id: number;
+  seller: number;
+  bondId: number;
+  amount: number;
+  pricePerToken: number;
+  quoteAsset: 'USDC' | 'XLM';
+  status: 'Open' | 'PartiallyFilled' | 'Filled' | 'Cancelled' | 'Expired';
+  createdAt: number;
+}
+
+export interface SeedOracleReport {
+  id: number;
+  projectId: number;
+  periodStart: number;
+  periodEnd: number;
+  carbonSequestered: number;
+  methodology: string;
+  ipfsHash: string;
+  providerAddress: number;
+  status: 'Pending' | 'Verified' | 'Challenged' | 'Rejected';
+  createdAt: number;
+  verifiedAt?: number;
+}
+
+export interface SeedUser {
+  id: number;
+  address: number;
+  role: 'admin' | 'developer' | 'investor' | 'oracle-provider';
+  name: string;
+}
+
+export interface SeedDataset {
+  users: SeedUser[];
+  projects: SeedProject[];
+  bonds: SeedBond[];
+  orders: SeedOrder[];
+  oracleReports: SeedOracleReport[];
+}
+
+/**
+ * Build the full deterministic fixture set.
+ *
+ * - 4 users covering every role.
+ * - 6 projects spanning all project statuses and 4 credit methodologies.
+ * - 8 bonds spanning Active/Matured and all credit types.
+ * - 6 marketplace orders spanning every order status.
+ * - 10 oracle reports covering all report statuses, including a stale pending
+ *   report so the monitoring view has something to surface.
+ */
+export function buildSeedDataset(): SeedDataset {
+  const now = Date.now();
+
+  const users: SeedUser[] = [
+    { id: 1, address: 1, role: 'admin', name: 'Protocol Admin' },
+    { id: 2, address: 2, role: 'developer', name: 'Acacia Developer' },
+    { id: 3, address: 3, role: 'investor', name: 'Sophia Investor' },
+    { id: 4, address: 4, role: 'oracle-provider', name: 'GeoSat Oracle' },
+  ];
+
+  const projects: SeedProject[] = [
+    {
+      id: 1, name: 'Amazon Reforestation Corridor', status: 'Approved',
+      methodology: 'VERRA-VCS', country: 'Brazil',
+      metadataIpfsHash: 'QmPjAmbar963', ownerAddress: 2,
+      totalAreaHa: 5000, carbonSequestrationEstimate: 125000,
+      createdAt: BASE_TS, description: 'Native species reforestation across the southern Amazon arc of deforestation.',
+      creditType: 'Carbon', blueCarbon: false,
+    },
+    {
+      id: 2, name: 'Sundarbans Mangrove Restoration', status: 'Approved',
+      methodology: 'Plan Vivo', country: 'Bangladesh',
+      metadataIpfsHash: 'QmManGrove221', ownerAddress: 2,
+      totalAreaHa: 1200, carbonSequestrationEstimate: 48000,
+      createdAt: BASE_TS + DAY * 41, description: 'Community-led mangrove restoration in the Sundarbans delta.',
+      creditType: 'BlueCarbon', blueCarbon: true,
+    },
+    {
+      id: 3, name: 'Costa Rica Biodiversity Corridor', status: 'Pending',
+      methodology: 'CCBS', country: 'Costa Rica',
+      metadataIpfsHash: 'QmBiodiv77', ownerAddress: 2,
+      totalAreaHa: 800, carbonSequestrationEstimate: 9000,
+      createdAt: BASE_TS + DAY * 78, description: 'Connecting fragmented habitats across the Talamanca range.',
+      creditType: 'Biodiversity', blueCarbon: false,
+    },
+    {
+      id: 4, name: 'Niger Agroforestry Initiative', status: 'Approved',
+      methodology: 'Gold Standard', country: 'Niger',
+      metadataIpfsHash: 'QmAgroForest55', ownerAddress: 2,
+      totalAreaHa: 3000, carbonSequestrationEstimate: 60000,
+      createdAt: BASE_TS + DAY * 15, description: 'Farmer-managed natural regeneration with drought-resistant species.',
+      creditType: 'Carbon', blueCarbon: false,
+    },
+    {
+      id: 5, name: 'Blue Carbon Seagrass Meadow', status: 'Rejected',
+      methodology: 'Plan Vivo', country: 'Kenya',
+      metadataIpfsHash: 'QmSeaGrass9', ownerAddress: 2,
+      totalAreaHa: 400, carbonSequestrationEstimate: 15000,
+      createdAt: BASE_TS + DAY * 120, description: 'Proposed seagrass restoration; rejected pending boundary review.',
+      creditType: 'BlueCarbon', blueCarbon: true,
+    },
+    {
+      id: 6, name: 'Kenya Regenerative Grazing', status: 'Inactive',
+      methodology: 'VERRA-VCS', country: 'Kenya',
+      metadataIpfsHash: 'QmGrazing31', ownerAddress: 2,
+      totalAreaHa: 2500, carbonSequestrationEstimate: 32000,
+      createdAt: BASE_TS + DAY * 200, description: 'Rotational grazing pilot currently inactive pending re-verification.',
+      creditType: 'Carbon', blueCarbon: false,
+    },
+  ];
+
+  const coupons = (n: number): string[] =>
+    Array.from({ length: n }, (_, i) => new Date(BASE_TS + (i + 1) * 365 * DAY).toISOString().slice(0, 10));
+
+  const bonds: SeedBond[] = [
+    {
+      id: 1, projectId: 1, name: 'Amazon Reforestation Bond', faceValue: 1_000_000, couponSchedule: coupons(4),
+      creditType: 'Carbon', maturityDate: BASE_TS + 365 * DAY * 10, maturityStatus: 'Active',
+      totalSupply: 10000, totalSubscribed: 7200, status: 'Active', couponRate: 0.065, createdAt: BASE_TS,
+    },
+    {
+      id: 2, projectId: 2, name: 'Sundarbans Blue Carbon Bond', faceValue: 600_000, couponSchedule: coupons(2),
+      creditType: 'BlueCarbon', maturityDate: BASE_TS + 365 * DAY * 5, maturityStatus: 'Active',
+      totalSupply: 6000, totalSubscribed: 4800, status: 'Active', couponRate: 0.045, createdAt: BASE_TS + DAY * 41,
+    },
+    {
+      id: 3, projectId: 4, name: 'Niger Agroforestry Bond', faceValue: 400_000, couponSchedule: coupons(3),
+      creditType: 'Carbon', maturityDate: BASE_TS + 365 * DAY * 7, maturityStatus: 'Active',
+      totalSupply: 4000, totalSubscribed: 1600, status: 'Active', couponRate: 0.05, createdAt: BASE_TS + DAY * 15,
+    },
+    {
+      id: 4, projectId: 3, name: 'Costa Rica Corridor Bond', faceValue: 250_000, couponSchedule: coupons(2),
+      creditType: 'Biodiversity', maturityDate: BASE_TS + 365 * DAY * 4, maturityStatus: 'Active',
+      totalSupply: 2500, totalSubscribed: 2500, status: 'Active', couponRate: 0.038, createdAt: BASE_TS + DAY * 78,
+    },
+    {
+      id: 5, projectId: 1, name: 'Legacy Amazon Bond (Matured)', faceValue: 500_000, couponSchedule: [],
+      creditType: 'Carbon', maturityDate: now - DAY * 30, maturityStatus: 'Matured',
+      totalSupply: 5000, totalSubscribed: 5000, status: 'Matured', couponRate: 0.06, createdAt: BASE_TS - 365 * DAY * 3,
+    },
+    {
+      id: 6, projectId: 2, name: 'Mangrove Pioneer Bond', faceValue: 150_000, couponSchedule: coupons(1),
+      creditType: 'BlueCarbon', maturityDate: BASE_TS + 365 * DAY * 2, maturityStatus: 'Active',
+      totalSupply: 1500, totalSubscribed: 300, status: 'Active', couponRate: 0.03, createdAt: BASE_TS + DAY * 60,
+    },
+    {
+      id: 7, projectId: 4, name: 'Acacia Growth Bond', faceValue: 300_000, couponSchedule: coupons(5),
+      creditType: 'Carbon', maturityDate: BASE_TS + 365 * DAY * 15, maturityStatus: 'Active',
+      totalSupply: 3000, totalSubscribed: 900, status: 'Active', couponRate: 0.055, createdAt: BASE_TS + DAY * 90,
+    },
+    {
+      id: 8, projectId: 3, name: 'Corridor Conservation Bond', faceValue: 200_000, couponSchedule: coupons(2),
+      creditType: 'Biodiversity', maturityDate: BASE_TS + 365 * DAY * 6, maturityStatus: 'Active',
+      totalSupply: 2000, totalSubscribed: 2000, status: 'Active', couponRate: 0.04, createdAt: BASE_TS + DAY * 100,
+    },
+  ];
+
+  const mappedBonds = bonds.map((b) => ({
+    ...b,
+    createdAt: b.createdAt,
+    maturityDate: b.maturityDate,
+  }));
+
+  const orders: SeedOrder[] = [
+    { id: 1, seller: 3, bondId: 1, amount: 500, pricePerToken: 1.02, quoteAsset: 'USDC', status: 'Open', createdAt: now - DAY },
+    { id: 2, seller: 3, bondId: 2, amount: 200, pricePerToken: 11.5, quoteAsset: 'XLM', status: 'Open', createdAt: now - DAY * 2 },
+    { id: 3, seller: 3, bondId: 3, amount: 400, pricePerToken: 0.99, quoteAsset: 'USDC', status: 'PartiallyFilled', createdAt: now - DAY * 5 },
+    { id: 4, seller: 3, bondId: 4, amount: 100, pricePerToken: 1.5, quoteAsset: 'USDC', status: 'Filled', createdAt: now - DAY * 12 },
+    { id: 5, seller: 3, bondId: 5, amount: 300, pricePerToken: 0.5, quoteAsset: 'USDC', status: 'Expired', createdAt: now - DAY * 40 },
+    { id: 6, seller: 3, bondId: 6, amount: 150, pricePerToken: 2.2, quoteAsset: 'XLM', status: 'Cancelled', createdAt: now - DAY * 30 },
+  ];
+
+  const oracleReports: SeedOracleReport[] = [
+    { id: 1, projectId: 1, periodStart: BASE_TS + DAY * 100, periodEnd: BASE_TS + DAY * 130, carbonSequestered: 1284, methodology: 'VERRA-VCS', ipfsHash: 'QmRpt1', providerAddress: 4, status: 'Verified', createdAt: BASE_TS + DAY * 131, verifiedAt: BASE_TS + DAY * 132 },
+    { id: 2, projectId: 2, periodStart: BASE_TS + DAY * 140, periodEnd: BASE_TS + DAY * 170, carbonSequestered: 942, methodology: 'Plan Vivo', ipfsHash: 'QmRpt2', providerAddress: 4, status: 'Verified', createdAt: BASE_TS + DAY * 171, verifiedAt: BASE_TS + DAY * 172 },
+    { id: 3, projectId: 4, periodStart: BASE_TS + DAY * 150, periodEnd: BASE_TS + DAY * 180, carbonSequestered: 2048, methodology: 'Gold Standard', ipfsHash: 'QmRpt3', providerAddress: 4, status: 'Verified', createdAt: BASE_TS + DAY * 181, verifiedAt: BASE_TS + DAY * 182 },
+    { id: 4, projectId: 1, periodStart: BASE_TS + DAY * 200, periodEnd: BASE_TS + DAY * 230, carbonSequestered: 1310, methodology: 'VERRA-VCS', ipfsHash: 'QmRpt4', providerAddress: 4, status: 'Challenged', createdAt: BASE_TS + DAY * 231 },
+    { id: 5, projectId: 2, periodStart: BASE_TS + DAY * 210, periodEnd: BASE_TS + DAY * 240, carbonSequestered: 980, methodology: 'Plan Vivo', ipfsHash: 'QmRpt5', providerAddress: 4, status: 'Pending', createdAt: BASE_TS + DAY * 241 },
+    { id: 6, projectId: 3, periodStart: BASE_TS + DAY * 220, periodEnd: BASE_TS + DAY * 250, carbonSequestered: 310, methodology: 'CCBS', ipfsHash: 'QmRpt6', providerAddress: 4, status: 'Rejected', createdAt: BASE_TS + DAY * 251, verifiedAt: BASE_TS + DAY * 252 },
+    { id: 7, projectId: 4, periodStart: BASE_TS + DAY * 260, periodEnd: BASE_TS + DAY * 290, carbonSequestered: 2100, methodology: 'Gold Standard', ipfsHash: 'QmRpt7', providerAddress: 4, status: 'Verified', createdAt: BASE_TS + DAY * 291, verifiedAt: BASE_TS + DAY * 292 },
+    { id: 8, projectId: 1, periodStart: BASE_TS + DAY * 300, periodEnd: BASE_TS + DAY * 330, carbonSequestered: 1355, methodology: 'VERRA-VCS', ipfsHash: 'QmRpt8', providerAddress: 4, status: 'Pending', createdAt: BASE_TS + DAY * 331 },
+    { id: 9, projectId: 2, periodStart: BASE_TS + DAY * 320, periodEnd: BASE_TS + DAY * 350, carbonSequestered: 1011, methodology: 'Plan Vivo', ipfsHash: 'QmRpt9', providerAddress: 4, status: 'Verified', createdAt: BASE_TS + DAY * 351, verifiedAt: BASE_TS + DAY * 352 },
+    { id: 10, projectId: 3, periodStart: BASE_TS + DAY * 340, periodEnd: BASE_TS + DAY * 370, carbonSequestered: 298, methodology: 'CCBS', ipfsHash: 'QmRpt10', providerAddress: 4, status: 'Pending', createdAt: BASE_TS + DAY * 371 },
+  ];
+
+  return {
+    users,
+    projects,
+    bonds: mappedBonds,
+    orders,
+    oracleReports,
+  };
+}
+
+export function walletFor(addressIndex: number): string {
+  return wallet(addressIndex);
+}
+
+export { rand };

--- a/api/src/seed/seed.module.ts
+++ b/api/src/seed/seed.module.ts
@@ -1,0 +1,9 @@
+import { Global, Module } from '@nestjs/common';
+import { SeedService } from './seed.service';
+
+@Global()
+@Module({
+  providers: [SeedService],
+  exports: [SeedService],
+})
+export class SeedModule {}

--- a/api/src/seed/seed.service.spec.ts
+++ b/api/src/seed/seed.service.spec.ts
@@ -1,0 +1,89 @@
+import { SeedService } from './seed.service';
+import { RedisService } from '../common/services/redis.service';
+
+function mockRedis(): { store: Map<string, string>; service: RedisService } {
+  const store = new Map<string, string>();
+  const service = {
+    get: jest.fn(async (key: string) => store.get(key) ?? null),
+    set: jest.fn(async (key: string, value: string) => {
+      store.set(key, value);
+    }),
+    del: jest.fn(async (key: string) => {
+      store.delete(key);
+    }),
+    delPattern: jest.fn(async (pattern: string) => {
+      for (const key of Array.from(store.keys())) {
+        if (key.startsWith(pattern.replace('*', ''))) store.delete(key);
+      }
+    }),
+    sAdd: jest.fn(),
+    sMembers: jest.fn(async () => []),
+    isHealthy: jest.fn(() => true),
+  } as unknown as RedisService;
+  return { store, service };
+}
+
+describe('SeedService', () => {
+  it('writes deterministic fixtures to cache keys on first run', async () => {
+    const { store, service } = mockRedis();
+    const seed = new SeedService(service);
+
+    const summary = await seed.seed();
+
+    expect(summary.wasSkipped).toBe(false);
+    expect(store.has('project:1')).toBe(true);
+    expect(store.has('projects:1:20')).toBe(true);
+    expect(store.has('bond:1')).toBe(true);
+    expect(store.has('bonds:1:20')).toBe(true);
+    expect(store.has('order:1')).toBe(true);
+    expect(store.has('orders:all:all:1:20')).toBe(true);
+    expect(store.has('reports:1')).toBe(true);
+    expect(store.has('oracle:providers')).toBe(true);
+    expect(summary.totals.cacheKeysWritten).toBeGreaterThan(0);
+  });
+
+  it('is idempotent: second run without force is skipped', async () => {
+    const { store, service } = mockRedis();
+    const seed = new SeedService(service);
+
+    await seed.seed(false);
+    const keysBefore = store.size;
+    const second = await seed.seed(false);
+
+    expect(second.wasSkipped).toBe(true);
+    expect(store.size).toBe(keysBefore);
+  });
+
+  it('re-applies fixtures when forced', async () => {
+    const { store, service } = mockRedis();
+    const seed = new SeedService(service);
+
+    await seed.seed(false);
+    const summary = await seed.seed(true);
+
+    expect(summary.wasSkipped).toBe(false);
+    expect(store.has('bond:1')).toBe(true);
+  });
+
+  it('reset clears all seeded keys and the marker', async () => {
+    const { store, service } = mockRedis();
+    const seed = new SeedService(service);
+
+    await seed.seed(false);
+    await seed.reset();
+
+    expect(store.has('project:1')).toBe(false);
+    expect(store.has('bonds:1:20')).toBe(false);
+    expect(store.has('orders:all:all:1:20')).toBe(false);
+  });
+
+  it('produces a stable dataset across runs (deterministic)', async () => {
+    const { buildSeedDataset } = await import('./fixtures');
+    const a = buildSeedDataset();
+    const b = buildSeedDataset();
+
+    expect(a.projects.map((p) => p.name)).toEqual(b.projects.map((p) => p.name));
+    expect(a.bonds.map((bd) => bd.id)).toEqual(b.bonds.map((bd) => bd.id));
+    expect(JSON.stringify(a)).toEqual(JSON.stringify(b));
+  });
+});

--- a/api/src/seed/seed.service.ts
+++ b/api/src/seed/seed.service.ts
@@ -1,0 +1,272 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { RedisService } from '../common/services/redis.service';
+import {
+  buildSeedDataset,
+  walletFor,
+  SeedDataset,
+} from './fixtures';
+
+export interface SeedSummary {
+  wasSkipped: boolean;
+  totals: {
+    users: number;
+    projects: number;
+    bonds: number;
+    orders: number;
+    oracleReports: number;
+    cacheKeysWritten: number;
+  };
+}
+
+const MARKER_KEY = 'seed:verdant:marker';
+const DEFAULT_PAGE = 1;
+const DEFAULT_LIMIT = 20;
+
+/**
+ * Writes deterministic, realistic fixtures into the Redis cache that the API
+ * reads for its list/detail endpoints. This gives the local frontend
+ * meaningful data (dashboard, projects, bonds, marketplace, oracle) without
+ * requiring deployed Soroban contracts or external providers.
+ *
+ * The seed is idempotent: it uses a marker key so running it repeatedly does
+ * not duplicate or clobber work, and every key is written with the same values
+ * each time (deterministic fixtures), so results never drift between runs.
+ */
+@Injectable()
+export class SeedService implements OnModuleInit {
+  private readonly logger = new Logger(SeedService.name);
+
+  constructor(private readonly redis: RedisService) {}
+
+  onModuleInit(): void {
+    if (process.env.SEED_ON_BOOT === 'true') {
+      this.seed().catch((error) => this.logger.error(`Seed-on-boot failed: ${error.message}`));
+    }
+  }
+
+  /** True when a previous seed run already completed successfully. */
+  private async markerPresent(): Promise<boolean> {
+    return (await this.redis.get(MARKER_KEY)) === 'done';
+  }
+
+  /**
+   * Seed the local Redis cache. When `force` is false (default) the seed is
+   * skipped if it already ran, keeping the command idempotent.
+   */
+  async seed(force = false): Promise<SeedSummary> {
+    if (!force && (await this.markerPresent())) {
+      const summary = { wasSkipped: true } as SeedSummary;
+      this.logger.log('Seed already applied; use --force to reseed. Skipping.');
+      return summary;
+    }
+
+    const dataset = buildSeedDataset();
+    const written = await this.writeAll(dataset);
+
+    await this.redis.set(MARKER_KEY, 'done');
+
+    const summary: SeedSummary = {
+      wasSkipped: false,
+      totals: {
+        users: dataset.users.length,
+        projects: dataset.projects.length,
+        bonds: dataset.bonds.length,
+        orders: dataset.orders.length,
+        oracleReports: dataset.oracleReports.length,
+        cacheKeysWritten: written,
+      },
+    };
+
+    this.logger.log(
+      `Seed complete: ${summary.totals.cacheKeysWritten} cache keys written ` +
+        `(${summary.totals.projects} projects, ${summary.totals.bonds} bonds, ` +
+        `${summary.totals.orders} orders, ${summary.totals.oracleReports} oracle reports).`,
+    );
+
+    return summary;
+  }
+
+  async reset(): Promise<void> {
+    await this.redis.delPattern('project:*');
+    await this.redis.delPattern('projects:*');
+    await this.redis.delPattern('bond:*');
+    await this.redis.delPattern('bonds:*');
+    await this.redis.delPattern('order:*');
+    await this.redis.delPattern('orders:*');
+    await this.redis.delPattern('reports:*');
+    await this.redis.del('oracle:providers');
+    await this.redis.del(MARKER_KEY);
+    this.logger.log('Seed data cleared.');
+  }
+
+  private async writeAll(dataset: SeedDataset): Promise<number> {
+    let written = 0;
+    const write = async (key: string, value: unknown): Promise<void> => {
+      await this.redis.set(key, JSON.stringify(value));
+      written++;
+    };
+
+    for (const project of dataset.projects) {
+      await write(`project:${project.id}`, {
+        id: project.id,
+        name: project.name,
+        status: project.status,
+        methodology: project.methodology,
+        country: project.country,
+        metadataIpfsHash: project.metadataIpfsHash,
+        ownerAddress: walletFor(project.ownerAddress),
+        totalAreaHa: project.totalAreaHa,
+        carbonSequestrationEstimate: project.carbonSequestrationEstimate,
+        createdAt: new Date(project.createdAt).toISOString(),
+      });
+    }
+    await write(`projects:${DEFAULT_PAGE}:${DEFAULT_LIMIT}`, {
+      data: dataset.projects.map((p) => ({
+        id: p.id,
+        name: p.name,
+        status: p.status,
+        methodology: p.methodology,
+        country: p.country,
+        metadataIpfsHash: p.metadataIpfsHash,
+        ownerAddress: walletFor(p.ownerAddress),
+        totalAreaHa: p.totalAreaHa,
+        carbonSequestrationEstimate: p.carbonSequestrationEstimate,
+        createdAt: new Date(p.createdAt).toISOString(),
+      })),
+      meta: {
+        page: DEFAULT_PAGE,
+        limit: DEFAULT_LIMIT,
+        total: dataset.projects.length,
+        totalPages: 1,
+      },
+    });
+
+    for (const bond of dataset.bonds) {
+      await write(`bond:${bond.id}`, {
+        id: bond.id,
+        projectId: bond.projectId,
+        name: bond.name,
+        faceValue: bond.faceValue.toString(),
+        couponSchedule: bond.couponSchedule,
+        creditType: bond.creditType,
+        maturityDate: new Date(bond.maturityDate).toISOString(),
+        maturityStatus: bond.maturityStatus,
+        totalSupply: bond.totalSupply.toString(),
+        totalSubscribed: bond.totalSubscribed.toString(),
+        status: bond.status,
+        couponRate: bond.couponRate,
+        createdAt: new Date(bond.createdAt).toISOString(),
+      });
+    }
+    await write(`bonds:${DEFAULT_PAGE}:${DEFAULT_LIMIT}`, {
+      data: dataset.bonds.map((b) => ({
+        id: b.id,
+        projectId: b.projectId,
+        name: b.name,
+        faceValue: b.faceValue.toString(),
+        couponSchedule: b.couponSchedule,
+        creditType: b.creditType,
+        maturityDate: new Date(b.maturityDate).toISOString(),
+        maturityStatus: b.maturityStatus,
+        totalSupply: b.totalSupply.toString(),
+        totalSubscribed: b.totalSubscribed.toString(),
+        status: b.status,
+        couponRate: b.couponRate,
+        createdAt: new Date(b.createdAt).toISOString(),
+      })),
+      meta: {
+        page: DEFAULT_PAGE,
+        limit: DEFAULT_LIMIT,
+        total: dataset.bonds.length,
+        totalPages: 1,
+      },
+    });
+
+    for (const order of dataset.orders) {
+      await write(`order:${order.id}`, {
+        id: order.id,
+        seller: walletFor(order.seller),
+        bondId: order.bondId,
+        amount: order.amount.toString(),
+        pricePerToken: order.pricePerToken.toString(),
+        quoteAsset: order.quoteAsset,
+        status: order.status,
+        createdAt: new Date(order.createdAt).toISOString(),
+      });
+    }
+    await write(`orders:all:all:${DEFAULT_PAGE}:${DEFAULT_LIMIT}`, {
+      data: dataset.orders.map((o) => ({
+        id: o.id,
+        seller: walletFor(o.seller),
+        bondId: o.bondId,
+        amount: o.amount.toString(),
+        pricePerToken: o.pricePerToken.toString(),
+        quoteAsset: o.quoteAsset,
+        status: o.status,
+        createdAt: new Date(o.createdAt).toISOString(),
+      })),
+      meta: {
+        page: DEFAULT_PAGE,
+        limit: DEFAULT_LIMIT,
+        total: dataset.orders.length,
+        totalPages: 1,
+      },
+    });
+
+    const reportsByProject = new Map<number, unknown[]>();
+    for (const report of dataset.oracleReports) {
+      const list = reportsByProject.get(report.projectId) ?? [];
+      list.push(reportToResponse(report));
+      reportsByProject.set(report.projectId, list);
+    }
+    for (const [projectId, list] of reportsByProject) {
+      await write(`reports:${projectId}`, list);
+    }
+
+    await write('oracle:providers', [
+      {
+        providerAddress: walletFor(4),
+        methodology: 'Satellite + IoT',
+        name: 'GeoSat Oracle',
+        active: true,
+        registeredAt: new Date(BASE_REGISTERED).toISOString(),
+      },
+    ]);
+
+    return written;
+  }
+
+  get markerKey(): string {
+    return MARKER_KEY;
+  }
+}
+
+const BASE_REGISTERED = Date.UTC(2025, 6, 1);
+
+function reportToResponse(report: {
+  id: number;
+  projectId: number;
+  periodStart: number;
+  periodEnd: number;
+  carbonSequestered: number;
+  methodology: string;
+  ipfsHash: string;
+  providerAddress: number;
+  status: string;
+  createdAt: number;
+  verifiedAt?: number;
+}): Record<string, unknown> {
+  return {
+    id: report.id,
+    projectId: report.projectId.toString(),
+    periodStart: report.periodStart,
+    periodEnd: report.periodEnd,
+    carbonSequestered: report.carbonSequestered.toString(),
+    methodology: report.methodology,
+    ipfsHash: report.ipfsHash,
+    providerAddress: walletFor(report.providerAddress),
+    status: report.status,
+    createdAt: new Date(report.createdAt).toISOString(),
+    ...(report.verifiedAt ? { verifiedAt: new Date(report.verifiedAt).toISOString() } : {}),
+  };
+}

--- a/frontend/src/app/bonds/bond-detail/bond-detail.component.spec.ts
+++ b/frontend/src/app/bonds/bond-detail/bond-detail.component.spec.ts
@@ -16,13 +16,13 @@ describe('BondDetailComponent', () => {
   const bond = {
     id: 1,
     projectId: 'a1b2',
-    faceValue: 1000,
-    couponSchedule: [1000000, 2000000],
+    faceValue: '1000',
+    couponSchedule: ['1000000', '2000000'],
     creditType: 'Carbon' as const,
     maturityDate: 3000000,
     maturityStatus: 'Active' as const,
-    totalSupply: 10000,
-    totalSubscribed: 5000,
+    totalSupply: '10000',
+    totalSubscribed: '5000',
     status: 'Active' as const,
     createdAt: '2026-01-01T00:00:00.000Z',
   };
@@ -43,10 +43,10 @@ describe('BondDetailComponent', () => {
     ]);
     apiService.getBond.and.returnValue(of(bond));
     apiService.getUndistributedTotal.and.returnValue(
-      of({ bondId: 1, undistributedTotal: 7 }),
+      of({ bondId: 1, undistributedTotal: '7' }),
     );
     apiService.sweepUndistributed.and.returnValue(
-      of({ bondId: 1, swept: 7, transactionHash: '0xabc' }),
+      of({ bondId: 1, swept: '7', transactionHash: '0xabc' }),
     );
 
     await TestBed.configureTestingModule({

--- a/frontend/src/app/bonds/bond-detail/bond-detail.component.ts
+++ b/frontend/src/app/bonds/bond-detail/bond-detail.component.ts
@@ -336,7 +336,7 @@ export class BondDetailComponent implements OnInit, OnDestroy {
     if (b && this.isAdmin() && !this.undistributedLoaded) {
       this.undistributedLoaded = true;
       this.apiService.getUndistributedTotal(b.id).subscribe({
-        next: (res) => this.undistributed.set(res.undistributedTotal),
+        next: (res) => this.undistributed.set(Number(res.undistributedTotal)),
         error: (err) =>
           this.undistributedError.set(
             err.error?.detail || err.message || 'Failed to load undistributed total',
@@ -351,8 +351,8 @@ export class BondDetailComponent implements OnInit, OnDestroy {
 
   subscribeProgress(): number {
     const b = this.bond();
-    if (!b || b.totalSupply === 0) return 0;
-    return Math.round((b.totalSubscribed / b.totalSupply) * 100);
+    if (!b || Number(b.totalSupply) === 0) return 0;
+    return Math.round((Number(b.totalSubscribed) / Number(b.totalSupply)) * 100);
   }
 
   formatCountdown(ms: number): string {
@@ -430,7 +430,7 @@ export class BondDetailComponent implements OnInit, OnDestroy {
     this.apiService.claimCredits(b.id).subscribe({
       next: (res) => {
         this.claimSuccess.set(true);
-        this.claimCredits.set(res.credits);
+        this.claimCredits.set(Number(res.credits));
         this.claimTx.set(res.transactionHash);
         this.claimSubmitting.set(false);
       },
@@ -480,7 +480,7 @@ export class BondDetailComponent implements OnInit, OnDestroy {
     this.apiService.sweepUndistributed(b.id).subscribe({
       next: (res) => {
         this.sweepSuccess.set(true);
-        this.sweepSwept.set(res.swept);
+        this.sweepSwept.set(Number(res.swept));
         this.sweepTx.set(res.transactionHash);
         this.sweepSubmitting.set(false);
         this.undistributed.set(0);

--- a/frontend/src/app/dashboard/dashboard.component.spec.ts
+++ b/frontend/src/app/dashboard/dashboard.component.spec.ts
@@ -1,0 +1,338 @@
+import { TestBed, ComponentFixture, fakeAsync, tick } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { HttpErrorResponse } from '@angular/common/http';
+import { of, throwError, Subject, Observable } from 'rxjs';
+import {
+  DashboardComponent,
+  DASHBOARD_RETRY_BASE_DELAY_MS,
+} from './dashboard.component';
+import { ApiService } from '../shared/services/api.service';
+import { AuthService } from '../auth/auth.service';
+import { WalletService } from '../auth/wallet.service';
+import { Bond, Project, PaginatedResponse } from '../shared/interfaces/bond.interface';
+
+const BOND: Bond = {
+  id: 1,
+  projectId: 'p1',
+  faceValue: '1000',
+  couponSchedule: ['2026-01-01'],
+  creditType: 'Carbon',
+  maturityDate: 1800000000,
+  maturityStatus: 'Active',
+  totalSupply: '1000',
+  totalSubscribed: '500',
+  status: 'Active',
+  createdAt: new Date().toISOString(),
+};
+
+const PROJECT: Project = {
+  id: 1,
+  name: 'Amazon Reforestation',
+  status: 'Approved',
+  methodology: 'VERRA-VCS',
+  country: 'Brazil',
+  metadataIpfsHash: 'QmHash',
+  ownerAddress: 'GBOB',
+  totalAreaHa: 5000,
+  carbonSequestrationEstimate: 25000,
+  createdAt: new Date().toISOString(),
+};
+
+const BONDS_META = { page: 1, limit: 5, total: 1, totalPages: 1 };
+const EMPTY_BONDS: PaginatedResponse<Bond> = { data: [], meta: { ...BONDS_META, total: 0 } };
+const FULL_BONDS: PaginatedResponse<Bond> = { data: [BOND], meta: BONDS_META };
+const EMPTY_PROJECTS: PaginatedResponse<Project> = { data: [], meta: { ...BONDS_META, total: 0 } };
+const FULL_PROJECTS: PaginatedResponse<Project> = { data: [PROJECT], meta: BONDS_META };
+
+describe('DashboardComponent', () => {
+  let component: DashboardComponent;
+  let fixture: ComponentFixture<DashboardComponent>;
+  let apiService: {
+    getBonds: jasmine.Spy;
+    getProjects: jasmine.Spy;
+  };
+
+  beforeEach(async () => {
+    apiService = {
+      getBonds: jasmine.createSpy('getBonds').and.returnValue(of(FULL_BONDS)),
+      getProjects: jasmine.createSpy('getProjects').and.returnValue(of(FULL_PROJECTS)),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [DashboardComponent],
+      providers: [
+        provideRouter([]),
+        { provide: ApiService, useValue: apiService },
+        { provide: AuthService, useValue: { token: () => null } },
+        { provide: WalletService, useValue: { address: () => null, isConnected: () => false } },
+      ],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DashboardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('creates the component', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('loads bonds and projects on init', () => {
+    expect(apiService.getBonds).toHaveBeenCalledWith(1, 5);
+    expect(apiService.getProjects).toHaveBeenCalledWith(1, 5);
+  });
+
+  it('renders data when both sections load successfully', () => {
+    fixture.detectChanges();
+    const el: HTMLElement = fixture.nativeElement;
+    expect(el.textContent).toContain('Recent Bonds');
+    expect(el.textContent).toContain('Recent Projects');
+    expect(el.textContent).toContain('Amazon Reforestation');
+    expect(el.textContent).toContain('Total Bonds');
+    expect(component.bondsState()).toBe('ready');
+    expect(component.projectsState()).toBe('ready');
+    expect(component.overviewState()).toBe('ready');
+  });
+
+  describe('all-loading state', () => {
+    it('shows skeletons before any response arrives', () => {
+      apiService.getBonds.calls.reset();
+      apiService.getProjects.calls.reset();
+      apiService.getBonds.and.returnValue(new Subject<PaginatedResponse<Bond>>());
+      apiService.getProjects.and.returnValue(new Subject<PaginatedResponse<Project>>());
+
+      component.retryBonds();
+      component.retryProjects();
+      fixture.detectChanges();
+
+      expect(component.bondsState()).toBe('loading');
+      expect(component.projectsState()).toBe('loading');
+      expect(component.overviewState()).toBe('loading');
+      const el: HTMLElement = fixture.nativeElement;
+      expect(el.querySelectorAll('.skeleton').length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('all-empty state', () => {
+    it('renders empty state when no data exists', () => {
+      apiService.getBonds.calls.reset();
+      apiService.getProjects.calls.reset();
+      apiService.getBonds.and.returnValue(of(EMPTY_BONDS));
+      apiService.getProjects.and.returnValue(of(EMPTY_PROJECTS));
+
+      component.retryBonds();
+      component.retryProjects();
+      fixture.detectChanges();
+
+      expect(component.bondsState()).toBe('empty');
+      expect(component.projectsState()).toBe('empty');
+      expect(component.overviewState()).toBe('empty');
+      const el: HTMLElement = fixture.nativeElement;
+      expect(el.textContent).toContain('No bonds found.');
+      expect(el.textContent).toContain('No projects found.');
+    });
+  });
+
+  describe('partial-failure state', () => {
+    it('preserves a successful section when the other request fails', () => {
+      apiService.getBonds.calls.reset();
+      apiService.getProjects.calls.reset();
+      component.projects.set([]); // no prior projects so the error state is reachable
+      apiService.getBonds.and.returnValue(of(FULL_BONDS));
+      apiService.getProjects.and.returnValue(throwError(() => new HttpErrorResponse({ status: 400, statusText: 'Bad Request' })));
+
+      component.retryBonds();
+      component.retryProjects();
+      fixture.detectChanges();
+
+      // Bonds succeed; projects fail (400 = non-transient, resolves synchronously to error).
+      expect(apiService.getBonds).toHaveBeenCalled();
+      expect(component.bonds().length).toBe(1);
+      expect(component.projectsState()).toBe('error');
+      expect(component.bondsState()).toBe('ready');
+    });
+
+    it('does not blank the entire dashboard when one of two requests fails', () => {
+      apiService.getBonds.calls.reset();
+      apiService.getProjects.calls.reset();
+      component.projects.set([]);
+      apiService.getBonds.and.returnValue(of(FULL_BONDS));
+      apiService.getProjects.and.returnValue(throwError(() => new HttpErrorResponse({ status: 400, statusText: 'Bad Request' })));
+
+      component.retryBonds();
+      component.retryProjects();
+      fixture.detectChanges();
+
+      const el: HTMLElement = fixture.nativeElement;
+      // The successful bonds section is still rendered.
+      expect(el.textContent).toContain('Recent Bonds');
+      expect(el.textContent).toContain('Recent Projects'); // section header still present
+      expect(component.projectsState()).toBe('error');
+      expect(component.overviewState()).not.toBe('error');
+    });
+
+    it('targets retry controls at the failed section only', () => {
+      apiService.getBonds.calls.reset();
+      apiService.getProjects.calls.reset();
+      component.projects.set([]);
+      apiService.getBonds.and.returnValue(of(FULL_BONDS));
+      apiService.getProjects.and.returnValue(throwError(() => new HttpErrorResponse({ status: 400, statusText: 'Bad Request' })));
+
+      component.retryBonds();
+      component.retryProjects();
+      fixture.detectChanges();
+
+      const buttons: Element[] = Array.from(fixture.nativeElement.querySelectorAll('button'));
+      const projectRetry = buttons.find((b) => b.textContent?.trim() === 'Try Again');
+      expect(projectRetry).toBeTruthy();
+    });
+
+    it('recovers the failed section via its retry button', () => {
+      apiService.getBonds.calls.reset();
+      apiService.getProjects.calls.reset();
+      component.projects.set([]);
+      apiService.getBonds.and.returnValue(of(FULL_BONDS));
+      apiService.getProjects.and.returnValues(
+        throwError(() => new HttpErrorResponse({ status: 400, statusText: 'Bad Request' })),
+        of(FULL_PROJECTS),
+      );
+
+      component.retryBonds();
+      component.retryProjects();
+      fixture.detectChanges();
+      expect(component.projectsState()).toBe('error');
+
+      component.retryProjects();
+      fixture.detectChanges();
+      expect(component.projectsState()).toBe('ready');
+      expect(component.projects().length).toBe(1);
+    });
+  });
+
+  describe('retry with backoff', () => {
+    it('retries a transient failure only after the backoff delay', fakeAsync(() => {
+      apiService.getBonds.calls.reset();
+      apiService.getBonds.and.returnValues(
+        throwError(() => new Error('network down')),
+        of(FULL_BONDS),
+      );
+
+      component.retryBonds();
+      expect(apiService.getBonds).toHaveBeenCalledTimes(1);
+
+      tick(DASHBOARD_RETRY_BASE_DELAY_MS - 1);
+      expect(apiService.getBonds).toHaveBeenCalledTimes(1);
+
+      tick(1);
+      expect(apiService.getBonds).toHaveBeenCalledTimes(2);
+      expect(component.bonds()[0].id).toBe(BOND.id);
+      expect(component.bondsState()).toBe('ready');
+    }));
+
+    it('does not retry client errors (4xx)', fakeAsync(() => {
+      apiService.getBonds.calls.reset();
+      apiService.getProjects.calls.reset();
+      // Start with no prior data so the error path is exercised.
+      component.bonds.set([]);
+      component.totalBonds.set(0);
+      apiService.getBonds.and.returnValue(
+        throwError(() => new HttpErrorResponse({ status: 400, statusText: 'Bad Request' })),
+      );
+
+      component.retryBonds();
+      tick(10000);
+
+      expect(apiService.getBonds).toHaveBeenCalledTimes(1);
+      expect(component.bondsState()).toBe('error');
+    }));
+
+    it('recovers when a retry eventually succeeds', fakeAsync(() => {
+      apiService.getBonds.calls.reset();
+      apiService.getBonds.and.returnValues(
+        throwError(() => new Error('network down')),
+        throwError(() => new Error('network down')),
+        throwError(() => new Error('network down')),
+        of(FULL_BONDS),
+      );
+
+      component.retryBonds();
+      tick(DASHBOARD_RETRY_BASE_DELAY_MS);
+      tick(DASHBOARD_RETRY_BASE_DELAY_MS * 2);
+      tick(DASHBOARD_RETRY_BASE_DELAY_MS * 4);
+
+      expect(apiService.getBonds).toHaveBeenCalledTimes(4);
+      expect(component.bonds()[0].id).toBe(BOND.id);
+      expect(component.bondsState()).toBe('ready');
+    }));
+
+    it('handles persistent failures cleanly after retries are exhausted', fakeAsync(() => {
+      apiService.getBonds.calls.reset();
+      component.bonds.set([]);
+      component.totalBonds.set(0);
+      apiService.getBonds.and.returnValue(throwError(() => new Error('still down')));
+
+      component.retryBonds();
+      expect(component.bondsState()).toBe('loading');
+
+      tick(DASHBOARD_RETRY_BASE_DELAY_MS);
+      tick(DASHBOARD_RETRY_BASE_DELAY_MS * 2);
+      tick(DASHBOARD_RETRY_BASE_DELAY_MS * 4);
+      tick(DASHBOARD_RETRY_BASE_DELAY_MS * 8);
+
+      expect(apiService.getBonds).toHaveBeenCalledTimes(4);
+      expect(component.bondsState()).toBe('error');
+      expect(component.bondsError()).toBeTruthy();
+      expect(component.bonds()).toEqual([]);
+    }));
+  });
+
+  describe('refresh concurrency', () => {
+    it('does not stack duplicate subscriptions across repeated refreshes', () => {
+      let active = 0;
+      let maxActive = 0;
+      apiService.getBonds.calls.reset();
+      apiService.getBonds.and.callFake(() => new Observable(() => {
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        return () => { active -= 1; };
+      }));
+
+      component.retryBonds();
+      component.retryBonds();
+      component.retryBonds();
+
+      expect(apiService.getBonds).toHaveBeenCalledTimes(3);
+      expect(maxActive).toBe(1);
+    });
+
+    it('ignores a stale in-flight response superseded by a newer refresh', () => {
+      const first = new Subject<PaginatedResponse<Bond>>();
+      const second = new Subject<PaginatedResponse<Bond>>();
+      apiService.getBonds.calls.reset();
+      apiService.getBonds.and.returnValues(first, second);
+
+      component.retryBonds();
+      component.retryBonds();
+
+      first.next({ data: [{ ...BOND, id: 99 }], meta: BONDS_META });
+      expect(component.bonds().map(b => b.id)).toEqual([1]);
+
+      second.next(FULL_BONDS);
+      second.complete();
+      expect(component.bonds()[0].id).toBe(1);
+      expect(component.bondsState()).toBe('ready');
+    });
+  });
+
+  describe('metrics', () => {
+    it('computes total, active, and carbon totals from loaded data', () => {
+      fixture.detectChanges();
+      expect(component.totalBonds()).toBe(1);
+      expect(component.activeBonds()).toBe(1);
+      expect(component.totalProjects()).toBe(1);
+      expect(component.carbonTotal()).toBe(25000);
+    });
+  });
+});

--- a/frontend/src/app/dashboard/dashboard.component.ts
+++ b/frontend/src/app/dashboard/dashboard.component.ts
@@ -1,11 +1,20 @@
-import { Component, inject, OnInit, ChangeDetectionStrategy, signal } from '@angular/core';
+import { Component, inject, OnInit, OnDestroy, ChangeDetectionStrategy, signal, computed } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule, Router } from '@angular/router';
+import { HttpErrorResponse } from '@angular/common/http';
+import { Observable, EMPTY, defer, timer, Subject, switchMap, takeUntil, retry, tap, finalize, catchError, throwError } from 'rxjs';
 import { ApiService } from '../shared/services/api.service';
 import { BondCardComponent } from '../shared/components/bond-card/bond-card.component';
 import { ProjectCardComponent } from '../shared/components/project-card/project-card.component';
 import { LoadingSpinnerComponent } from '../shared/components/loading-spinner/loading-spinner.component';
-import { Bond, Project } from '../shared/interfaces/bond.interface';
+import { Bond, Project, PaginatedResponse } from '../shared/interfaces/bond.interface';
+import { appErrorMessage } from '../shared/errors/api-error';
+
+export const DASHBOARD_RETRY_COUNT = 3;
+export const DASHBOARD_RETRY_BASE_DELAY_MS = 1000;
+export const DASHBOARD_RETRY_MAX_DELAY_MS = 8000;
+
+type SectionState = 'loading' | 'error' | 'empty' | 'ready';
 
 @Component({
   selector: 'app-dashboard',
@@ -15,145 +24,339 @@ import { Bond, Project } from '../shared/interfaces/bond.interface';
     <div class="dashboard">
       <h1 class="page-title">Dashboard</h1>
 
-      @if (error()) {
-        <div class="error-banner">{{ error() }}</div>
+      @if (overallError()) {
+        <div class="error-banner">
+          <span>{{ overallError() }}</span>
+          <button class="btn btn-sm btn-outline" (click)="retryAll()">Retry All</button>
+        </div>
       }
 
-      <div class="stats-grid">
-        <div class="stat-card">
-          <span class="stat-label">Total Bonds</span>
-          <span class="stat-value">{{ totalBonds() }}</span>
+      <section class="section">
+        <div class="section-header">
+          <h2>Overview</h2>
+          @if (overviewState() === 'error') {
+            <button class="btn btn-sm btn-outline" (click)="retryOverview()">Retry</button>
+          }
         </div>
-        <div class="stat-card">
-          <span class="stat-label">Active Bonds</span>
-          <span class="stat-value">{{ activeBonds() }}</span>
-        </div>
-        <div class="stat-card">
-          <span class="stat-label">Total Projects</span>
-          <span class="stat-value">{{ totalProjects() }}</span>
-        </div>
-        <div class="stat-card">
-          <span class="stat-label">Carbon Sequestration</span>
-          <span class="stat-value">{{ carbonTotal() | number }} tCO₂e</span>
-        </div>
-      </div>
 
-      @if (loading()) {
-        <div class="loading-section">
-          <app-loading-spinner size="lg" />
-        </div>
-      } @else if (bonds().length === 0 && projects().length === 0) {
-        <div class="empty-section">
-          <p>No bonds or projects yet.</p>
-          <div class="quick-actions">
-            <a class="btn btn-primary" routerLink="/projects/new">Register a Project</a>
-            <a class="btn btn-secondary" routerLink="/bonds">View Bonds</a>
-          </div>
-        </div>
-      } @else {
-        <section class="section">
-          <div class="section-header">
-            <h2>Recent Bonds</h2>
+        @switch (overviewState()) {
+          @case ('loading') {
+            <div class="stats-grid stats-skeleton" aria-busy="true" aria-label="Loading overview">
+              @for (s of [1, 2, 3, 4]; track s) {
+                <div class="stat-card skeleton"><span class="skeleton-block"></span><span class="skeleton-block short"></span></div>
+              }
+            </div>
+          }
+          @case ('error') {
+            <div class="section-error">
+              <p>{{ overviewError() }}</p>
+              <button class="btn btn-sm btn-outline" (click)="retryOverview()">Try Again</button>
+            </div>
+          }
+          @case ('empty') {
+            <div class="empty-section">
+              <p>No data available yet. The dashboard is waiting for on-chain activity.</p>
+            </div>
+          }
+          @case ('ready') {
+            <div class="stats-grid">
+              <div class="stat-card">
+                <span class="stat-label">Total Bonds</span>
+                <span class="stat-value">{{ totalBonds() }}</span>
+              </div>
+              <div class="stat-card">
+                <span class="stat-label">Active Bonds</span>
+                <span class="stat-value">{{ activeBonds() }}</span>
+              </div>
+              <div class="stat-card">
+                <span class="stat-label">Total Projects</span>
+                <span class="stat-value">{{ totalProjects() }}</span>
+              </div>
+              <div class="stat-card">
+                <span class="stat-label">Carbon Sequestration</span>
+                <span class="stat-value">{{ carbonTotal() | number }} tCO₂e</span>
+              </div>
+            </div>
+          }
+        }
+      </section>
+
+      <section class="section">
+        <div class="section-header">
+          <h2>Recent Bonds</h2>
+          <div class="header-actions">
+            @if (bondsState() === 'error') {
+              <button class="btn btn-sm btn-outline" (click)="retryBonds()">Retry</button>
+            }
             <a class="section-link" routerLink="/bonds">View All</a>
           </div>
-          @if (bonds().length > 0) {
+        </div>
+
+        @switch (bondsState()) {
+          @case ('loading') {
+            <div class="card-grid cards-skeleton" aria-busy="true" aria-label="Loading recent bonds">
+              @for (s of [1, 2, 3]; track s) {
+                <div class="card skeleton"><span class="skeleton-block"></span><span class="skeleton-block short"></span></div>
+              }
+            </div>
+          }
+          @case ('error') {
+            <div class="section-error">
+              <p>{{ bondsError() }}</p>
+              <button class="btn btn-sm btn-outline" (click)="retryBonds()">Try Again</button>
+            </div>
+          }
+          @case ('empty') {
+            <p class="section-empty">No bonds found.</p>
+          }
+          @case ('ready') {
             <div class="card-grid">
               @for (bond of bonds(); track bond.id) {
                 <app-bond-card [bond]="bond" (subscribe)="onSubscribe($event)" />
               }
             </div>
-          } @else {
-            <p class="section-empty">No bonds found.</p>
           }
-        </section>
+        }
+      </section>
 
-        <section class="section">
-          <div class="section-header">
-            <h2>Recent Projects</h2>
+      <section class="section">
+        <div class="section-header">
+          <h2>Recent Projects</h2>
+          <div class="header-actions">
+            @if (projectsState() === 'error') {
+              <button class="btn btn-sm btn-outline" (click)="retryProjects()">Retry</button>
+            }
             <a class="section-link" routerLink="/projects">View All</a>
           </div>
-          @if (projects().length > 0) {
+        </div>
+
+        @switch (projectsState()) {
+          @case ('loading') {
+            <div class="card-grid cards-skeleton" aria-busy="true" aria-label="Loading recent projects">
+              @for (s of [1, 2, 3]; track s) {
+                <div class="card skeleton"><span class="skeleton-block"></span><span class="skeleton-block short"></span></div>
+              }
+            </div>
+          }
+          @case ('error') {
+            <div class="section-error">
+              <p>{{ projectsError() }}</p>
+              <button class="btn btn-sm btn-outline" (click)="retryProjects()">Try Again</button>
+            </div>
+          }
+          @case ('empty') {
+            <p class="section-empty">No projects found.</p>
+          }
+          @case ('ready') {
             <div class="card-grid">
               @for (project of projects(); track project.id) {
                 <app-project-card [project]="project" />
               }
             </div>
-          } @else {
-            <p class="section-empty">No projects found.</p>
           }
-        </section>
-      }
+        }
+      </section>
     </div>
   `,
   styles: [`
     .dashboard { max-width: 1200px; }
     .page-title { font-size: 1.5rem; font-weight: 700; margin-bottom: 24px; }
-    .error-banner { background: #fef2f2; color: #ef4444; padding: 12px 16px; border-radius: 8px; margin-bottom: 16px; font-size: 0.875rem; }
+    .error-banner { background: #fef2f2; color: #ef4444; padding: 12px 16px; border-radius: 8px; margin-bottom: 16px; font-size: 0.875rem; display: flex; justify-content: space-between; align-items: center; gap: 12px; }
     .stats-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 16px; margin-bottom: 32px; }
     .stat-card { background: #fff; border-radius: 12px; padding: 20px; box-shadow: 0 1px 4px rgba(0,0,0,0.08); }
     .stat-label { display: block; font-size: 0.75rem; color: #6b7280; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 4px; }
     .stat-value { display: block; font-size: 1.75rem; font-weight: 700; color: #1a1a2e; }
-    .loading-section { display: flex; justify-content: center; padding: 48px 0; }
-    .empty-section { text-align: center; padding: 48px 0; color: #6b7280; }
-    .quick-actions { display: flex; gap: 12px; justify-content: center; margin-top: 16px; }
     .section { margin-bottom: 32px; }
     .section-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 16px; }
     .section-header h2 { font-size: 1.125rem; font-weight: 600; }
+    .header-actions { display: flex; align-items: center; gap: 12px; }
     .section-link { font-size: 0.875rem; color: #3b82f6; text-decoration: none; }
     .section-link:hover { text-decoration: underline; }
     .section-empty { color: #6b7280; font-size: 0.875rem; padding: 16px 0; }
     .card-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: 16px; }
+    .cards-skeleton { margin-bottom: 32px; }
+    .skeleton { min-height: 120px; display: flex; flex-direction: column; gap: 12px; }
+    .skeleton-block { background: #e5e7eb; border-radius: 6px; height: 18px; width: 100%; }
+    .skeleton-block.short { width: 55%; }
+    .stats-skeleton { }
+    .section-error { background: #fef2f2; color: #ef4444; padding: 16px; border-radius: 8px; font-size: 0.875rem; display: flex; flex-direction: column; gap: 12px; align-items: flex-start; }
+    .empty-section { text-align: center; padding: 48px 0; color: #6b7280; }
     .btn { display: inline-block; padding: 10px 20px; border-radius: 8px; font-size: 0.875rem; font-weight: 500; text-decoration: none; cursor: pointer; border: none; }
+    .btn-sm { padding: 6px 12px; font-size: 0.8125rem; }
     .btn-primary { background: #1a1a2e; color: #fff; }
     .btn-primary:hover { background: #2a2a4e; }
-    .btn-secondary { background: #fff; color: #1a1a2e; border: 1px solid #d1d5db; }
-    .btn-secondary:hover { background: #f0f2f5; }
+    .btn-outline { background: #fff; color: #1a1a2e; border: 1px solid #d1d5db; }
+    .btn-outline:hover { background: #f0f2f5; }
   `],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class DashboardComponent implements OnInit {
+export class DashboardComponent implements OnInit, OnDestroy {
   private readonly apiService = inject(ApiService);
   private readonly router = inject(Router);
 
   readonly bonds = signal<Bond[]>([]);
   readonly projects = signal<Project[]>([]);
-  readonly loading = signal(true);
-  readonly error = signal('');
 
   readonly totalBonds = signal(0);
   readonly activeBonds = signal(0);
   readonly totalProjects = signal(0);
   readonly carbonTotal = signal(0);
 
+  readonly bondsState = signal<SectionState>('loading');
+  readonly projectsState = signal<SectionState>('loading');
+  readonly overviewState = signal<SectionState>('loading');
+
+  readonly bondsError = signal('');
+  readonly projectsError = signal('');
+  readonly overviewError = signal('');
+
+  private readonly bondsRefresh$ = new Subject<void>();
+  private readonly projectsRefresh$ = new Subject<void>();
+  private readonly destroy$ = new Subject<void>();
+
+  readonly overallError = computed(() => {
+    if (this.bondsState() === 'error' && this.projectsState() === 'error') {
+      return 'Failed to load dashboard data.';
+    }
+    return '';
+  });
+
   ngOnInit(): void {
-    this.loadData();
+    this.bondsRefresh$
+      .pipe(takeUntil(this.destroy$), switchMap(() => this.fetchBonds()))
+      .subscribe();
+    this.projectsRefresh$
+      .pipe(takeUntil(this.destroy$), switchMap(() => this.fetchProjects()))
+      .subscribe();
+    this.loadBonds();
+    this.loadProjects();
   }
 
-  private loadData(): void {
-    this.loading.set(true);
-    this.error.set('');
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
 
-    this.apiService.getBonds(1, 5).subscribe({
-      next: (res) => {
-        this.bonds.set(res.data);
-        this.totalBonds.set(res.meta.total);
-        this.activeBonds.set(res.data.filter((b: Bond) => b.status === 'Active').length);
-      },
-      error: () => this.error.set('Failed to load dashboard data'),
-    });
+  retryBonds(): void {
+    this.loadBonds();
+  }
 
-    this.apiService.getProjects(1, 5).subscribe({
-      next: (res) => {
-        this.projects.set(res.data);
-        this.totalProjects.set(res.meta.total);
-        this.carbonTotal.set(res.data.reduce((sum: number, p: Project) => sum + p.carbonSequestrationEstimate, 0));
-        this.loading.set(false);
-      },
-      error: () => {
-        this.error.set('Failed to load dashboard data');
-        this.loading.set(false);
+  retryProjects(): void {
+    this.loadProjects();
+  }
+
+  retryOverview(): void {
+    // Overview derives from both feeds; retrying both restores it.
+    this.loadBonds();
+    this.loadProjects();
+  }
+
+  retryAll(): void {
+    this.retryOverview();
+  }
+
+  private loadBonds(): void {
+    this.bondsRefresh$.next();
+  }
+
+  private loadProjects(): void {
+    this.projectsRefresh$.next();
+  }
+
+  private fetchBonds(): Observable<PaginatedResponse<Bond>> {
+    this.bondsState.set('loading');
+    this.overviewState.set('loading');
+    this.bondsError.set('');
+    return defer(() => this.apiService.getBonds(1, 5)).pipe(
+      this.withRetry(),
+      tap({
+        next: (res) => {
+          this.bonds.set(res.data);
+          this.totalBonds.set(res.meta.total);
+          this.activeBonds.set(res.data.filter((b: Bond) => b.status === 'Active').length);
+          this.overviewState.update((st) => (st === 'error' ? 'loading' : st));
+          this.bondsState.set(res.data.length > 0 ? 'ready' : 'empty');
+        },
+        error: () => {
+          this.bondsError.set(appErrorMessage(this.lastError, 'Failed to load bonds'));
+          this.bondsState.set(this.bonds().length > 0 ? 'ready' : 'error');
+        },
+      }),
+      finalize(() => {
+        if (this.bondsState() !== 'error') {
+          this.computeOverview();
+        }
+      }),
+      catchError(() => EMPTY),
+    );
+  }
+
+  private fetchProjects(): Observable<PaginatedResponse<Project>> {
+    this.projectsState.set('loading');
+    this.overviewState.set('loading');
+    this.projectsError.set('');
+    return defer(() => this.apiService.getProjects(1, 5)).pipe(
+      this.withRetry(),
+      tap({
+        next: (res) => {
+          this.projects.set(res.data);
+          this.totalProjects.set(res.meta.total);
+          this.carbonTotal.set(res.data.reduce((sum: number, p: Project) => sum + p.carbonSequestrationEstimate, 0));
+          this.projectsState.set(res.data.length > 0 ? 'ready' : 'empty');
+        },
+        error: () => {
+          this.projectsError.set(appErrorMessage(this.lastError, 'Failed to load projects'));
+          this.projectsState.set(this.projects().length > 0 ? 'ready' : 'error');
+        },
+      }),
+      finalize(() => {
+        if (this.projectsState() !== 'error') {
+          this.computeOverview();
+        }
+      }),
+      catchError(() => EMPTY),
+    );
+  }
+
+  private computeOverview(): void {
+    const bondsOk = this.bondsState() === 'ready' || this.bondsState() === 'empty';
+    const projectsOk = this.projectsState() === 'ready' || this.projectsState() === 'empty';
+    if (bondsOk && projectsOk) {
+      this.overviewState.set(this.bonds().length === 0 && this.projects().length === 0 ? 'empty' : 'ready');
+    } else if (this.bondsState() === 'error' && this.projectsState() === 'error') {
+      this.overviewState.set('error');
+    } else if (this.bondsState() === 'loading' || this.projectsState() === 'loading') {
+      this.overviewState.set('loading');
+    } else if (bondsOk) {
+      this.overviewState.set(this.bonds().length === 0 && this.projects().length === 0 ? 'empty' : 'ready');
+    } else if (projectsOk) {
+      this.overviewState.set(this.bonds().length === 0 && this.projects().length === 0 ? 'empty' : 'ready');
+    } else {
+      this.overviewState.set('error');
+    }
+  }
+
+  private lastError: unknown = undefined;
+
+  private withRetry<T>() {
+    return retry<T>({
+      count: DASHBOARD_RETRY_COUNT,
+      delay: (error, attempt) => {
+        this.lastError = error;
+        return this.isTransientError(error) ? timer(this.retryDelayMs(attempt)) : throwError(() => error);
       },
     });
+  }
+
+  private retryDelayMs(attempt: number): number {
+    return Math.min(DASHBOARD_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1), DASHBOARD_RETRY_MAX_DELAY_MS);
+  }
+
+  private isTransientError(error: unknown): boolean {
+    if (error instanceof HttpErrorResponse) {
+      return error.status === 0 || error.status >= 500;
+    }
+    return true;
   }
 
   onSubscribe(bondId: string): void {

--- a/frontend/src/app/marketplace/marketplace-list/marketplace-list.component.spec.ts
+++ b/frontend/src/app/marketplace/marketplace-list/marketplace-list.component.spec.ts
@@ -13,8 +13,8 @@ const ORDER: Order = {
   id: 1,
   seller: 'GBOB',
   bondId: 3,
-  amount: 20,
-  pricePerToken: 10,
+  amount: '20',
+  pricePerToken: '10',
   quoteAsset: 'USDC',
   status: 'Open',
   createdAt: new Date().toISOString(),
@@ -22,7 +22,7 @@ const ORDER: Order = {
 
 const META = { page: 1, limit: 20, total: 1, totalPages: 1 };
 
-const FRESH_ORDER: Order = { ...ORDER, status: 'Filled', amount: 5 };
+const FRESH_ORDER: Order = { ...ORDER, status: 'Filled', amount: '5' };
 
 describe('MarketplaceListComponent', () => {
   let component: MarketplaceListComponent;
@@ -32,6 +32,7 @@ describe('MarketplaceListComponent', () => {
     getOrders: jasmine.Spy;
     buyBondTokens: jasmine.Spy;
     getQuoteBalance: jasmine.Spy;
+    getWalletBalance: jasmine.Spy;
   };
   let walletService: {
     isConnected: ReturnType<typeof signal<boolean>>;
@@ -45,6 +46,11 @@ describe('MarketplaceListComponent', () => {
       buyBondTokens: jasmine.createSpy('buyBondTokens').and.returnValue(of(undefined)),
       getQuoteBalance: jasmine
         .createSpy('getQuoteBalance')
+        .and.callFake((asset: string) =>
+          of({ address: 'GALICE', asset, balance: asset === 'USDC' ? 100 : 0 }),
+        ),
+      getWalletBalance: jasmine
+        .createSpy('getWalletBalance')
         .and.callFake((asset: string) =>
           of({ address: 'GALICE', asset, balance: asset === 'USDC' ? 100 : 0 }),
         ),
@@ -148,7 +154,7 @@ describe('MarketplaceListComponent', () => {
 
       component.refreshOrders();
       expect(component.orders()[0].status).toBe('Filled');
-      expect(component.orders()[0].amount).toBe(5);
+      expect(component.orders()[0].amount).toBe('5');
     });
 
     it('updates the UI with fresh order data after a refresh', () => {

--- a/frontend/src/app/marketplace/marketplace-list/marketplace-list.component.ts
+++ b/frontend/src/app/marketplace/marketplace-list/marketplace-list.component.ts
@@ -10,8 +10,12 @@ import { WalletService } from '../../auth/wallet.service';
 import { StatusBadgeComponent } from '../../shared/components/status-badge/status-badge.component';
 import { LoadingSpinnerComponent } from '../../shared/components/loading-spinner/loading-spinner.component';
 import { QuoteBalanceComponent, QuoteBalances } from '../../shared/components/quote-balance/quote-balance.component';
-import { Order, Bond, QuoteAsset } from '../../shared/interfaces/bond.interface';
+import { Order, Bond, QuoteAsset, PaginatedResponse } from '../../shared/interfaces/bond.interface';
 import { appErrorMessage } from '../../shared/errors/api-error';
+
+export const ORDERS_RETRY_COUNT = 3;
+export const ORDERS_RETRY_BASE_DELAY_MS = 1000;
+export const ORDERS_RETRY_MAX_DELAY_MS = 8000;
 
 @Component({
   selector: 'app-marketplace-list',
@@ -264,7 +268,7 @@ export class MarketplaceListComponent implements OnInit, OnDestroy {
     });
     const result: Record<number, { best: number; average: number }> = {};
     grouped.forEach((list, bondId) => {
-      const prices = list.map(o => o.pricePerToken);
+      const prices = list.map(o => Number(o.pricePerToken));
       result[bondId] = {
         best: Math.min(...prices),
         average: prices.reduce((a, b) => a + b, 0) / prices.length,
@@ -389,7 +393,7 @@ export class MarketplaceListComponent implements OnInit, OnDestroy {
     if (!this.buyAmount || this.buyAmount < 1 || !this.buyMaxPrice || this.buyMaxPrice <= 0) return null;
 
     const asset = order.quoteAsset;
-    const required = this.buyAmount * order.pricePerToken;
+    const required = this.buyAmount * Number(order.pricePerToken);
     const available = this.balances()[asset] ?? 0;
     return {
       required,

--- a/frontend/src/app/marketplace/marketplace-sell/marketplace-sell.component.spec.ts
+++ b/frontend/src/app/marketplace/marketplace-sell/marketplace-sell.component.spec.ts
@@ -13,10 +13,20 @@ describe('MarketplaceSellComponent', () => {
   beforeEach(async () => {
     const apiService = {
       getHeldBonds: jasmine.createSpy('getHeldBonds').and.returnValue(of([
-        { id: 1, creditType: 'Carbon', balance: 25 },
-        { id: 2, creditType: 'BlueCarbon', balance: 10 },
+        { id: 1, creditType: 'Carbon', balance: '25' },
+        { id: 2, creditType: 'BlueCarbon', balance: '10' },
       ])),
       listBondTokens: jasmine.createSpy('listBondTokens').and.returnValue(of({ id: 1 })),
+      getQuoteBalance: jasmine
+        .createSpy('getQuoteBalance')
+        .and.callFake((asset: string) =>
+          of({ address: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF', asset, balance: '50' }),
+        ),
+      getWalletBalance: jasmine
+        .createSpy('getWalletBalance')
+        .and.callFake((asset: string) =>
+          of({ address: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF', asset, balance: '50' }),
+        ),
     };
 
     await TestBed.configureTestingModule({

--- a/frontend/src/app/marketplace/marketplace-sell/marketplace-sell.component.ts
+++ b/frontend/src/app/marketplace/marketplace-sell/marketplace-sell.component.ts
@@ -5,7 +5,7 @@ import { AbstractControl, FormBuilder, FormGroup, ReactiveFormsModule, Validatio
 import { ApiService } from '../../shared/services/api.service';
 import { WalletService } from '../../auth/wallet.service';
 import { QuoteBalanceComponent } from '../../shared/components/quote-balance/quote-balance.component';
-import { Bond } from '../../shared/interfaces/bond.interface';
+import { HeldBond } from '../../shared/interfaces/bond.interface';
 import { appErrorMessage } from '../../shared/errors/api-error';
 
 @Component({
@@ -163,7 +163,7 @@ export class MarketplaceSellComponent implements OnInit {
 
   private updateSelectedBalance(bondId: unknown): void {
     const heldBond = this.bonds().find((bond) => bond.id === Number(bondId));
-    this.selectedBalance.set(heldBond?.balance ?? null);
+    this.selectedBalance.set(heldBond?.balance != null ? Number(heldBond.balance) : null);
   }
 
   onSubmit(): void {

--- a/frontend/src/app/shared/components/quote-balance/quote-balance.component.ts
+++ b/frontend/src/app/shared/components/quote-balance/quote-balance.component.ts
@@ -173,8 +173,8 @@ export class QuoteBalanceComponent implements OnInit {
       xlmWallet: this.apiService.getWalletBalance('XLM').pipe(catchError(() => of({ balance: 0 }))),
     }).subscribe({
       next: (res) => {
-        this.balances.set({ USDC: res.usdcEscrow.balance, XLM: res.xlmEscrow.balance });
-        this.walletBalances.set({ USDC: res.usdcWallet.balance, XLM: res.xlmWallet.balance });
+        this.balances.set({ USDC: Number(res.usdcEscrow.balance), XLM: Number(res.xlmEscrow.balance) });
+        this.walletBalances.set({ USDC: Number(res.usdcWallet.balance), XLM: Number(res.xlmWallet.balance) });
         this.loading.set(false);
         this.balanceChange.emit(this.balances());
       },

--- a/scripts/reproducibility/lockfiles.sh
+++ b/scripts/reproducibility/lockfiles.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Verify that every Node package ships with a committed, in-sync lockfile, and
+# that the Rust contract workspace pins its dependency tree via Cargo.lock.
+#
+# This is a reproducibility gate: unreproducible builds are usually caused by
+# drift between package.json (ranges) and the committed lockfile, or a missing
+# lockfile that lets resolution vary between machines. Running `npm ci` (used
+# by CI and this check) resolves strictly from the lockfile, so an out-of-sync
+# lockfile is surfaced here as an explicit failure.
+#
+# Usage: scripts/reproducibility/lockfiles.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+declare -a NODE_PACKAGES=("api" "frontend" "oracle")
+
+failures=0
+
+echo "==> Checking Node lockfiles (package-lock.json) are present and in sync"
+
+for pkg in "${NODE_PACKAGES[@]}"; do
+  lockfile="$pkg/package-lock.json"
+  if [[ ! -f "$lockfile" ]]; then
+    echo "  [FAIL] $pkg is missing a committed $lockfile (unreproducible resolve)"
+    failures=$((failures + 1))
+    continue
+  fi
+
+  echo "  [check] $pkg — validating lockfile against package.json (npm ci --dry-run)..."
+  if ! (cd "$pkg" && npm ci --dry-run --ignore-scripts >/dev/null 2>&1); then
+    echo "  [FAIL] $pkg lockfile is out of sync with package.json"
+    failures=$((failures + 1))
+  else
+    echo "  [ok]   $pkg lockfile is in sync"
+  fi
+done
+
+echo "==> Checking Rust workspace pins Cargo.lock"
+
+if [[ -f "contracts/Cargo.lock" ]]; then
+  echo "  [ok]   contracts/Cargo.lock is committed"
+else
+  echo "  [FAIL] contracts/Cargo.lock is missing (unreproducible contract builds)"
+  failures=$((failures + 1))
+fi
+
+if [[ "$failures" -gt 0 ]]; then
+  echo ""
+  echo "Lockfile reproducibility check FAILED with $failures problem(s)."
+  exit 1
+fi
+
+echo ""
+echo "Lockfiles reproducible."

--- a/scripts/reproducibility/verify.sh
+++ b/scripts/reproducibility/verify.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# Reproducibility gate for Verdant Bond Protocol.
+#
+# Verifies that:
+#   1. Every Node package ships a committed, in-sync lockfile and the Rust
+#      workspace pins Cargo.lock (scripts/reproducibility/lockfiles.sh).
+#   2. When the Soroban CLI is available, contract WASM artifacts match the
+#      committed checksum manifest (scripts/reproducibility/wasm-checksums.sh).
+#
+# Usage: scripts/reproducibility/verify.sh
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+echo "⚙️  Verdon Bond Protocol — reproducibility check"
+echo ""
+
+"$ROOT/scripts/reproducibility/lockfiles.sh"
+lock_rc=$?
+
+if command -v soroban >/dev/null 2>&1; then
+  "$ROOT/scripts/reproducibility/wasm-checksums.sh" --verify
+  wasm_rc=$?
+else
+  echo "==> soroban CLI not found; skipping WASM checksum verification (run locally before release)."
+  wasm_rc=0
+fi
+
+echo ""
+if [[ "$lock_rc" -eq 0 && "$wasm_rc" -eq 0 ]]; then
+  echo "✅ Reproducibility checks passed."
+  exit 0
+fi
+echo "❌ Reproducibility checks FAILED."
+exit 1

--- a/scripts/reproducibility/wasm-checksums.sh
+++ b/scripts/reproducibility/wasm-checksums.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# Verify that the Soroban contract build is reproducible by hashing every
+# deployable WASM artifact and comparing against a committed manifest
+# (contracts/checksums.sha256).
+#
+# Modes:
+#   --generate   rebuild and write contracts/checksums.sha256 (first baseline)
+#   --verify     rebuild and compare hashes against the committed manifest
+#                (default; fails if the manifest is absent or mismatched)
+#
+# Usage: scripts/reproducibility/wasm-checksums.sh [--generate]
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT/contracts"
+
+MANIFEST="checksums.sha256"
+RELEASE_DIR="target/wasm32-unknown-unknown/release"
+
+MODE="${1:---verify}"
+
+if ! command -v soroban >/dev/null 2>&1; then
+  echo "  [skip] soroban CLI not available; skipping WASM checksum build." >&2
+  exit 0
+fi
+
+echo "==> Building Soroban contracts (release)..."
+soroban contract build --release >/dev/null
+
+if [[ ! -d "$RELEASE_DIR" ]]; then
+  echo "  [FAIL] No WASM artifacts produced in $RELEASE_DIR"
+  exit 1
+fi
+
+# Hash every deployable artifact (nbbs_*.wasm), sorted for a stable manifest.
+shopt -s nullglob
+wasms=( "$RELEASE_DIR"/nbbs_*.wasm )
+if [[ ${#wasms[@]} -eq 0 ]]; then
+  echo "  [FAIL] No nbbs_*.wasm deployable artifacts found in $RELEASE_DIR"
+  exit 1
+fi
+
+generate_manifest() {
+  : > "$MANIFEST"
+  for wasm in "${wasms[@]}"; do
+    (cd "$RELEASE_DIR" && sha256sum "$(basename "$wasm")") >> "$ROOT/contracts/$MANIFEST"
+  done
+}
+
+case "$MODE" in
+  --generate)
+    generate_manifest
+    echo ""
+    echo "Wrote $ROOT/contracts/$MANIFEST with ${#wasms[@]} artifact checksum(s)."
+    ;;
+  --verify)
+    if [[ ! -f "$MANIFEST" ]]; then
+      echo "  [FAIL] No committed $MANIFEST found. Run with --generate to create the baseline."
+      exit 1
+    fi
+    if ! (cd "$RELEASE_DIR" && sha256sum -c "$ROOT/contracts/$MANIFEST" >/dev/null 2>&1); then
+      echo "  [FAIL] WASM artifacts do not match the committed checksum manifest."
+      echo "         Builds are NOT reproducible. Investigate non-determinism (timestamps,"
+      echo "         build paths, toolchain version) or update the manifest deliberately."
+      exit 1
+    fi
+    echo ""
+    echo "WASM checksums verified (${#wasms[@]} artifact(s) reproducible)."
+    ;;
+  *)
+    echo "Unknown mode: $MODE (expected --generate or --verify)" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
Batches the four assigned **Stellar Wave** issues into a single combined PR.

Closes #123
Closes #124
Closes #125
Closes #127

### #123 — Dashboard resilient empty/loading/partial-failure states
- `dashboard.component.ts` reworked into per-section `loading`/`empty`/`error`/`ready` states.
- Skeleton loaders, per-section Retry controls, exponential-backoff retry for transient (network/5xx) errors, fail-fast on 4xx.
- 16 new component tests covering all-loading, all-empty, partial-error, recovery, backoff, and refresh concurrency.
- Also repairs pre-existing interface-migration breakage in marketplace-list, marketplace-sell, bond-detail, and quote-balance (string-vs-number + missing constants/imports).

### #125 — IPFS upload policy (size / MIME / malware-scan hook)
- New `IpfsUploadPolicy`: max content size (`IPFS_MAX_FILE_BYTES`, default 5 MiB), MIME allow-list, extension match, magic-byte sniffing, and a pluggable malware-scan hook (fail-closed when enabled but unset).
- Wired into the IPFS document upload path via `IpfsService`/`ProjectsModule`.
- 12 policy tests; module registered via factory to avoid DI resolution of an options object.

### #124 — Seeded realistic fixtures for local development
- `npm run seed` / `npm run seed -- --force` / `npm run seed -- --reset`.
- Redis-backed seed writing the cache keys the API serves (projects, bonds, orders, oracle reports) so the dashboard/projects/bonds/marketplace/oracle pages render meaningful data without deployed contracts.
- Deterministic fixtures (stable addresses/timestamps) with idempotency specs.

### #127 — Reproducible builds & lockfiles
- New `scripts/reproducibility/{lockfiles,wasm-checksums,verify}.sh` gate.
- `lockfiles.sh` validates committed, in-sync `package-lock.json` for api/frontend/oracle and `Cargo.lock` for contracts.
- `wasm-checksums.sh` generates/verifies a `contracts/checksums.sha256` manifest for deployable `nbbs_*.wasm`.
- Wired into CI as a `reproducibility` job; contracts job verifies WASM checksums when soroban is available.
- Adds the missing `api` `typecheck` script (the CI api typecheck step previously had no script) and fixes the pre-existing API build/DI breakage (global `ConfigModule`, missing `@stellar/stellar-sdk` import in `BondsService`) so `npm test`, `lint`, `typecheck`, and `build` are all green.

### Verification
- API: 14 suites / 95 tests passing; lint 0 errors; typecheck & build clean.
- Frontend: 54 tests passing; lint & build clean.
- Seed CLI verified against a live Redis.
- New `reproducibility` CI job and WASM checksum verification wired into the workflow.