### PR TITLE
Fix API problem details, request logging, and wallet recovery

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,6 +127,14 @@ chore(ci): add cargo-audit to workflow
 - Use Angular reactive forms for user input
 - Follow the existing component structure in `frontend/src/app/shared/`
 
+### Accessibility Checklist
+
+- Confirm wallet, project creation, bond detail, marketplace, and claim flows are usable with keyboard navigation only.
+- Ensure every interactive control has a visible focus state and an accessible name.
+- Tie validation errors to their fields with `aria-describedby`, and announce form-level failures with `role="alert"` or `aria-live`.
+- Verify dialogs, menus, and dropdowns can be opened, used, and dismissed without losing focus.
+- Add or update automated accessibility assertions for shared controls when changing core workflows.
+
 ## Testing
 
 ### Smart Contracts

--- a/api/src/common/filters/rfc7807-exception.filter.spec.ts
+++ b/api/src/common/filters/rfc7807-exception.filter.spec.ts
@@ -1,0 +1,67 @@
+import { BadRequestException } from '@nestjs/common';
+import { Rfc7807ExceptionFilter } from './rfc7807-exception.filter';
+import { ContractException, StableErrorCode } from '../../stellar/contract-errors';
+
+function makeHost(exceptionPath = '/api/test') {
+  const json = jest.fn();
+  const status = jest.fn(() => ({ json }));
+  const response = { status, setHeader: jest.fn() };
+  const request = { url: exceptionPath, correlationId: 'corr-123' };
+  const host: any = {
+    switchToHttp: () => ({
+      getResponse: () => response,
+      getRequest: () => request,
+    }),
+  };
+  return { host, status, json };
+}
+
+describe('Rfc7807ExceptionFilter', () => {
+  it('normalizes validation errors with field details and correlation id', () => {
+    const { host, status, json } = makeHost();
+    const filter = new Rfc7807ExceptionFilter();
+
+    filter.catch(new BadRequestException(['address must be a Stellar public key']), host);
+
+    expect(status).toHaveBeenCalledWith(400);
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'https://errors.verdant-bond-protocol.org/VALIDATION_ERROR',
+        status: 400,
+        code: 'VALIDATION_ERROR',
+        correlationId: 'corr-123',
+        errors: [{ field: 'address', message: 'address must be a Stellar public key' }],
+      }),
+    );
+  });
+
+  it('includes safe contract context for mapped contract exceptions', () => {
+    const { host, status, json } = makeHost('/api/marketplace/buy');
+    const filter = new Rfc7807ExceptionFilter();
+
+    filter.catch(
+      new ContractException(
+        StableErrorCode.DEX_ORDER_ALREADY_FILLED,
+        'Marketplace order is already filled',
+        'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC',
+        'buy_order',
+        5,
+      ),
+      host,
+    );
+
+    expect(status).toHaveBeenCalledWith(400);
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Contract Error',
+        code: StableErrorCode.DEX_ORDER_ALREADY_FILLED,
+        detail: 'Marketplace order is already filled',
+        contract: {
+          address: 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC',
+          method: 'buy_order',
+          rawErrorCode: 5,
+        },
+      }),
+    );
+  });
+});

--- a/api/src/common/filters/rfc7807-exception.filter.ts
+++ b/api/src/common/filters/rfc7807-exception.filter.ts
@@ -3,8 +3,47 @@ import {
   Catch,
   ArgumentsHost,
   HttpException,
+  BadRequestException,
 } from '@nestjs/common';
 import { Response, Request } from 'express';
+import { ContractException } from '../../stellar/contract-errors';
+
+type ProblemDetail = {
+  type: string;
+  title: string;
+  status: number;
+  detail: string;
+  code: string;
+  instance: string;
+  correlationId?: string;
+  timestamp: string;
+  errors?: Array<{ field: string; message: string }>;
+  contract?: {
+    address?: string;
+    method?: string;
+    rawErrorCode?: number;
+  };
+};
+
+function validationErrors(message: unknown): Array<{ field: string; message: string }> | undefined {
+  if (!Array.isArray(message)) return undefined;
+  return message.map((item) => {
+    if (typeof item === 'string') {
+      const field = item.split(' ')[0] || 'request';
+      return { field, message: item };
+    }
+    return { field: 'request', message: String(item) };
+  });
+}
+
+function defaultCode(status: number): string {
+  if (status === 400) return 'VALIDATION_ERROR';
+  if (status === 401) return 'AUTHENTICATION_REQUIRED';
+  if (status === 403) return 'FORBIDDEN';
+  if (status === 404) return 'NOT_FOUND';
+  if (status === 409) return 'CONFLICT';
+  return status >= 500 ? 'INTERNAL_ERROR' : `HTTP_${status}`;
+}
 
 @Catch()
 export class Rfc7807ExceptionFilter implements ExceptionFilter {
@@ -16,7 +55,9 @@ export class Rfc7807ExceptionFilter implements ExceptionFilter {
     let status = 500;
     let title = 'Internal Server Error';
     let detail = 'An unexpected error occurred';
-    let code: string | undefined = undefined;
+    let code = 'INTERNAL_ERROR';
+    let errors: ProblemDetail['errors'];
+    let contract: ProblemDetail['contract'];
 
     if (exception instanceof HttpException) {
       status = exception.getStatus();
@@ -24,22 +65,43 @@ export class Rfc7807ExceptionFilter implements ExceptionFilter {
 
       if (typeof exResponse === 'object' && exResponse !== null) {
         const resp = exResponse as Record<string, any>;
-        title = resp.message || exception.message;
+        errors = validationErrors(resp.message);
+        title = resp.error || (exception instanceof BadRequestException ? 'Bad Request' : exception.message);
         detail = resp.detail || (typeof resp.message === 'string' ? resp.message : JSON.stringify(resp.message));
-        code = resp.code;
+        code = resp.code || defaultCode(status);
       } else {
+        title = exception.message;
         detail = String(exResponse);
+        code = defaultCode(status);
+      }
+      if (exception instanceof ContractException) {
+        title = 'Contract Error';
+        code = exception.code;
+        detail = exception.detail;
+        contract = {
+          address: exception.contractAddress,
+          method: exception.method,
+          rawErrorCode: exception.rawErrorCode,
+        };
       }
     }
 
-    response.status(status).json({
-      type: `https://errors.verdant-bond-protocol.org/${code || status}`,
+    const problem: ProblemDetail = {
+      type: `https://errors.verdant-bond-protocol.org/${code}`,
       title,
       status,
       detail,
       code,
       instance: request.url,
+      correlationId: (request as any).correlationId || (request as any).requestId,
       timestamp: new Date().toISOString(),
-    });
+    };
+    if (errors) problem.errors = errors;
+    if (contract) problem.contract = contract;
+
+    if (problem.correlationId) {
+      response.setHeader('x-correlation-id', problem.correlationId);
+    }
+    response.status(status).json(problem);
   }
 }

--- a/api/src/common/interceptors/request-logging.interceptor.spec.ts
+++ b/api/src/common/interceptors/request-logging.interceptor.spec.ts
@@ -1,0 +1,76 @@
+import { of, throwError } from 'rxjs';
+import {
+  redactLogObject,
+  redactLogValue,
+  RequestLoggingInterceptor,
+} from './request-logging.interceptor';
+
+describe('request logging correlation and redaction', () => {
+  it('redacts secrets, signatures, transactions, and wallet addresses', () => {
+    const redacted = redactLogObject({
+      authorization: 'Bearer raw.jwt.token',
+      sourceSecretKey: 'SAABC',
+      signedTxXdr: 'AAAA',
+      transactionHash: 'hash',
+      walletAddress: 'GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+      nested: {
+        holder: 'GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+      },
+    });
+
+    expect(redacted.authorization).toBe('[REDACTED]');
+    expect(redacted.sourceSecretKey).toBe('[REDACTED]');
+    expect(redacted.signedTxXdr).toBe('[REDACTED]');
+    expect(redacted.transactionHash).toBe('[REDACTED]');
+    expect(redacted.walletAddress).toBe('GABCDE...WXYZ');
+    expect((redacted.nested as any).holder).toBe('GABCDE...WXYZ');
+  });
+
+  it('sets a stable x-correlation-id response header', (done) => {
+    const setHeader = jest.fn();
+    const context: any = {
+      switchToHttp: () => ({
+        getRequest: () => ({
+          method: 'GET',
+          url: '/api/health',
+          headers: { 'x-correlation-id': 'test-correlation-id' },
+          body: {},
+        }),
+        getResponse: () => ({ setHeader }),
+      }),
+    };
+    const interceptor = new RequestLoggingInterceptor();
+
+    interceptor.intercept(context, { handle: () => of({ ok: true }) } as any).subscribe({
+      complete: () => {
+        expect(setHeader).toHaveBeenCalledWith('x-correlation-id', 'test-correlation-id');
+        done();
+      },
+    });
+  });
+
+  it('preserves thrown errors while helper redaction hides secret fields', (done) => {
+    const context: any = {
+      switchToHttp: () => ({
+        getRequest: () => ({
+          method: 'POST',
+          url: '/api/contracts',
+          headers: {},
+          body: { sourceSecretKey: 'raw-secret' },
+        }),
+        getResponse: () => ({ setHeader: jest.fn() }),
+      }),
+    };
+    const interceptor = new RequestLoggingInterceptor();
+
+    interceptor.intercept(context, { handle: () => throwError(() => new Error('boom')) } as any).subscribe({
+      error: (err) => {
+        expect(redactLogValue({ sourceSecretKey: 'raw-secret' })).toEqual({
+          sourceSecretKey: '[REDACTED]',
+        });
+        expect(err.message).toBe('boom');
+        done();
+      },
+    });
+  });
+});

--- a/api/src/common/interceptors/request-logging.interceptor.ts
+++ b/api/src/common/interceptors/request-logging.interceptor.ts
@@ -9,22 +9,90 @@ import { Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
 import * as crypto from 'crypto';
 
+const REDACTED = '[REDACTED]';
+const SENSITIVE_KEY_PATTERN = /(authorization|token|secret|signature|signed|xdr|private|password|transaction|tx)/i;
+const WALLET_KEY_PATTERN = /(wallet|address|account|issuer|holder|investor|from|to)/i;
+const STELLAR_ADDRESS_PATTERN = /\bG[A-Z2-7]{20,60}\b/g;
+
+export function redactLogValue(value: unknown): unknown {
+  if (typeof value === 'string') {
+    return value.replace(STELLAR_ADDRESS_PATTERN, (match) => `${match.slice(0, 6)}...${match.slice(-4)}`);
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => redactLogValue(item));
+  }
+  if (value && typeof value === 'object') {
+    return redactLogObject(value as Record<string, unknown>);
+  }
+  return value;
+}
+
+export function redactLogObject(input: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(input).map(([key, value]) => {
+      if (SENSITIVE_KEY_PATTERN.test(key)) {
+        return [key, REDACTED];
+      }
+      if (WALLET_KEY_PATTERN.test(key) && typeof value === 'string') {
+        return [key, redactLogValue(value)];
+      }
+      return [key, redactLogValue(value)];
+    }),
+  );
+}
+
+export function resolveCorrelationId(request: any): string {
+  const incoming = request.headers?.['x-correlation-id'] || request.headers?.['x-request-id'];
+  return typeof incoming === 'string' && incoming.trim()
+    ? incoming.trim().slice(0, 128)
+    : crypto.randomUUID();
+}
+
 @Injectable()
 export class RequestLoggingInterceptor implements NestInterceptor {
   private readonly logger = new Logger('HTTP');
 
   intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
     const request = context.switchToHttp().getRequest();
-    const requestId = crypto.randomUUID();
+    const response = context.switchToHttp().getResponse();
+    const requestId = resolveCorrelationId(request);
     request.requestId = requestId;
+    request.correlationId = requestId;
+    response?.setHeader?.('x-correlation-id', requestId);
 
     const start = Date.now();
-    this.logger.log(`[${requestId}] ${request.method} ${request.url}`);
+    this.logger.log(
+      JSON.stringify({
+        event: 'http_request',
+        correlationId: requestId,
+        method: request.method,
+        url: request.url,
+        body: redactLogValue(request.body),
+        headers: redactLogObject(request.headers ?? {}),
+      }),
+    );
 
     return next.handle().pipe(
       tap({
-        next: () => this.logger.log(`[${requestId}] ${Date.now() - start}ms`),
-        error: (err) => this.logger.error(`[${requestId}] ${err.message}`, err.stack),
+        next: () =>
+          this.logger.log(
+            JSON.stringify({
+              event: 'http_response',
+              correlationId: requestId,
+              durationMs: Date.now() - start,
+            }),
+          ),
+        error: (err) =>
+          this.logger.error(
+            JSON.stringify({
+              event: 'http_error',
+              correlationId: requestId,
+              durationMs: Date.now() - start,
+              error: err?.message,
+              meta: redactLogValue(err),
+            }),
+            err.stack,
+          ),
       }),
     );
   }

--- a/frontend/src/app/auth/wallet.service.ts
+++ b/frontend/src/app/auth/wallet.service.ts
@@ -1,36 +1,119 @@
 import { Injectable, signal } from '@angular/core';
-import { isConnected, getAddress, signTransaction } from '@stellar/freighter-api';
+import { getAddress, getNetwork, isConnected, signTransaction } from '@stellar/freighter-api';
+import { environment } from '../../environments/environment';
+
+export type WalletStatus =
+  | 'idle'
+  | 'connecting'
+  | 'connected'
+  | 'missing'
+  | 'locked'
+  | 'rejected'
+  | 'network_mismatch'
+  | 'account_changed'
+  | 'error';
 
 @Injectable({ providedIn: 'root' })
 export class WalletService {
   readonly address = signal<string | null>(null);
   readonly isConnected = signal(false);
   readonly isConnecting = signal(false);
+  readonly status = signal<WalletStatus>('idle');
+  readonly errorMessage = signal<string | null>(null);
+  readonly networkPassphrase = signal<string | null>(null);
+  private readonly expectedNetworkPassphrase = environment.networkPassphrase;
+  private accountPollId: ReturnType<typeof setInterval> | null = null;
 
   async connect(): Promise<void> {
     this.isConnecting.set(true);
+    this.status.set('connecting');
+    this.errorMessage.set(null);
     try {
       const connected = await isConnected();
       if (!connected.isConnected) {
+        this.status.set('missing');
+        this.errorMessage.set('Freighter is not installed or is unavailable.');
         throw new Error('Freighter not detected');
       }
       const { address } = await getAddress();
+      if (!address) {
+        this.status.set('locked');
+        this.errorMessage.set('Unlock Freighter and try again.');
+        throw new Error('Freighter wallet is locked');
+      }
+      await this.verifyNetwork();
       this.address.set(address);
       this.isConnected.set(true);
+      this.status.set('connected');
+      this.startAccountWatcher();
+    } catch (error) {
+      if (this.status() === 'connecting') {
+        const message = error instanceof Error ? error.message : String(error);
+        this.status.set(/reject|cancel/i.test(message) ? 'rejected' : 'error');
+        this.errorMessage.set(message);
+      }
+      throw error;
     } finally {
       this.isConnecting.set(false);
     }
   }
 
   async signChallenge(challenge: string): Promise<string> {
+    await this.verifyNetwork();
     const { signedTxXdr } = await signTransaction(challenge, {
-      networkPassphrase: 'Test SDF Network ; September 2015',
+      networkPassphrase: this.expectedNetworkPassphrase,
     });
     return signedTxXdr;
   }
 
   disconnect(): void {
+    this.stopAccountWatcher();
     this.address.set(null);
     this.isConnected.set(false);
+    this.status.set('idle');
+    this.errorMessage.set(null);
+    this.networkPassphrase.set(null);
+  }
+
+  async refreshAccountState(): Promise<void> {
+    if (!this.isConnected()) return;
+    try {
+      const { address } = await getAddress();
+      if (address && address !== this.address()) {
+        this.address.set(address);
+        this.status.set('account_changed');
+        this.errorMessage.set('Wallet account changed. Review the active session before continuing.');
+      }
+      await this.verifyNetwork();
+    } catch {
+      this.status.set('locked');
+      this.errorMessage.set('Freighter is locked or unavailable.');
+      this.isConnected.set(false);
+    }
+  }
+
+  private async verifyNetwork(): Promise<void> {
+    const network = await getNetwork();
+    const passphrase = typeof network === 'string' ? network : network.networkPassphrase;
+    this.networkPassphrase.set(passphrase);
+    if (passphrase !== this.expectedNetworkPassphrase) {
+      this.status.set('network_mismatch');
+      this.errorMessage.set('Switch Freighter to the configured Stellar network before continuing.');
+      throw new Error('Freighter network mismatch');
+    }
+  }
+
+  private startAccountWatcher(): void {
+    this.stopAccountWatcher();
+    this.accountPollId = setInterval(() => {
+      void this.refreshAccountState();
+    }, 5_000);
+  }
+
+  private stopAccountWatcher(): void {
+    if (this.accountPollId) {
+      clearInterval(this.accountPollId);
+      this.accountPollId = null;
+    }
   }
 }

--- a/frontend/src/app/shared/components/wallet-button/wallet-button.component.ts
+++ b/frontend/src/app/shared/components/wallet-button/wallet-button.component.ts
@@ -7,17 +7,43 @@ import { WalletService } from '../../../auth/wallet.service';
   standalone: true,
   imports: [CommonModule],
   template: `
-    <button *ngIf="!walletService.isConnected()" (click)="connect()" class="wallet-btn">
+    <button
+      *ngIf="!walletService.isConnected()"
+      type="button"
+      (click)="connect()"
+      class="wallet-btn"
+      [disabled]="walletService.isConnecting()"
+      [attr.aria-busy]="walletService.isConnecting()"
+      [attr.aria-describedby]="walletService.errorMessage() ? 'wallet-status' : null"
+    >
       Connect Wallet
     </button>
-    <button *ngIf="walletService.isConnected()" class="wallet-btn connected">
+    <button
+      *ngIf="walletService.isConnected()"
+      type="button"
+      class="wallet-btn connected"
+      (click)="walletService.refreshAccountState()"
+      [attr.aria-label]="'Connected wallet ' + walletService.address() + '. Activate to refresh wallet state.'"
+    >
       {{ walletService.address()?.slice(0, 6) }}...{{ walletService.address()?.slice(-4) }}
     </button>
+    <p
+      *ngIf="walletService.errorMessage()"
+      id="wallet-status"
+      class="wallet-status"
+      role="status"
+      aria-live="polite"
+    >
+      {{ walletService.errorMessage() }}
+    </p>
   `,
   styles: [`
     .wallet-btn { padding: 8px 16px; border: 1px solid #1a1a2e; border-radius: 8px; background: transparent; color: #1a1a2e; cursor: pointer; font-size: 0.875rem; font-weight: 500; }
+    .wallet-btn:focus-visible { outline: 3px solid #2f80ed; outline-offset: 2px; }
+    .wallet-btn:disabled { opacity: 0.65; cursor: wait; }
     .wallet-btn:hover { background: #1a1a2e; color: #fff; }
     .wallet-btn.connected { background: #1a1a2e; color: #fff; font-family: monospace; }
+    .wallet-status { margin: 0.25rem 0 0; font-size: 0.75rem; color: #8a4b00; }
   `],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/frontend/src/app/shared/services/api.service.ts
+++ b/frontend/src/app/shared/services/api.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
-import { HttpClient, HttpHeaders } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { HttpClient, HttpErrorResponse, HttpHeaders } from '@angular/common/http';
+import { catchError, Observable, throwError } from 'rxjs';
 import { AuthService } from '../../auth/auth.service';
 import { WalletService } from '../../auth/wallet.service';
 import {
@@ -11,6 +11,24 @@ import {
   QuoteBalanceResponse, QuoteTransactionResponse,
   QuoteAsset, DepositQuoteDto, WithdrawQuoteDto,
 } from '../interfaces/bond.interface';
+
+export interface ProblemDetails {
+  type: string;
+  title: string;
+  status: number;
+  detail: string;
+  code: string;
+  instance?: string;
+  correlationId?: string;
+  errors?: Array<{ field: string; message: string }>;
+  contract?: { address?: string; method?: string; rawErrorCode?: number };
+}
+
+export class ApiProblemError extends Error {
+  constructor(readonly problem: ProblemDetails) {
+    super(problem.detail || problem.title);
+  }
+}
 
 @Injectable({ providedIn: 'root' })
 export class ApiService {
@@ -30,81 +48,93 @@ export class ApiService {
     return headers;
   }
 
+  private withProblemDetails<T>(source: Observable<T>): Observable<T> {
+    return source.pipe(
+      catchError((error: HttpErrorResponse) => {
+        const body = error.error;
+        if (body && typeof body === 'object' && 'type' in body && 'status' in body && 'code' in body) {
+          return throwError(() => new ApiProblemError(body as ProblemDetails));
+        }
+        return throwError(() => error);
+      }),
+    );
+  }
+
   getBonds(page = 1, limit = 20): Observable<PaginatedResponse<Bond>> {
-    return this.http.get<PaginatedResponse<Bond>>('/api/bonds', {
+    return this.withProblemDetails(this.http.get<PaginatedResponse<Bond>>('/api/bonds', {
       params: { page, limit },
       headers: this.headers(),
-    });
+    }));
   }
 
   getBond(id: number): Observable<Bond> {
-    return this.http.get<Bond>(`/api/bonds/${id}`, { headers: this.headers() });
+    return this.withProblemDetails(this.http.get<Bond>(`/api/bonds/${id}`, { headers: this.headers() }));
   }
 
   getHeldBonds(address: string): Observable<HeldBond[]> {
-    return this.http.get<HeldBond[]>(`/api/bonds/held/${address}`, {
+    return this.withProblemDetails(this.http.get<HeldBond[]>(`/api/bonds/held/${address}`, {
       headers: this.headers(),
-    });
+    }));
   }
 
   issueBond(data: any): Observable<Bond> {
-    return this.http.post<Bond>('/api/bonds', data, { headers: this.headers() });
+    return this.withProblemDetails(this.http.post<Bond>('/api/bonds', data, { headers: this.headers() }));
   }
 
   subscribeToBond(id: number, amount: number): Observable<SubscriptionResponse> {
     const investorAddress = this.walletService.address();
-    return this.http.post<SubscriptionResponse>(
+    return this.withProblemDetails(this.http.post<SubscriptionResponse>(
       `/api/bonds/${id}/subscribe`,
       { amount, investorAddress },
       { headers: this.headers() },
-    );
+    ));
   }
 
   claimCredits(id: number): Observable<ClaimCreditsResponse> {
     const investorAddress = this.walletService.address();
-    return this.http.post<ClaimCreditsResponse>(
+    return this.withProblemDetails(this.http.post<ClaimCreditsResponse>(
       `/api/bonds/${id}/claim`,
       { investorAddress },
       { headers: this.headers() },
-    );
+    ));
   }
 
   transferBond(id: number, toAddress: string, amount: number): Observable<TransferResponse> {
     const fromAddress = this.walletService.address();
-    return this.http.post<TransferResponse>(
+    return this.withProblemDetails(this.http.post<TransferResponse>(
       `/api/bonds/${id}/transfer`,
       { fromAddress, toAddress, amount },
       { headers: this.headers() },
-    );
+    ));
   }
 
   getUndistributedTotal(id: number): Observable<UndistributedTotalResponse> {
-    return this.http.get<UndistributedTotalResponse>(
+    return this.withProblemDetails(this.http.get<UndistributedTotalResponse>(
       `/api/bonds/${id}/undistributed`,
       { headers: this.headers() },
-    );
+    ));
   }
 
   sweepUndistributed(id: number): Observable<SweepUndistributedResponse> {
-    return this.http.post<SweepUndistributedResponse>(
+    return this.withProblemDetails(this.http.post<SweepUndistributedResponse>(
       `/api/bonds/${id}/sweep-undistributed`,
       {},
       { headers: this.headers() },
-    );
+    ));
   }
 
   getProjects(page = 1, limit = 20): Observable<PaginatedResponse<Project>> {
-    return this.http.get<PaginatedResponse<Project>>('/api/projects', {
+    return this.withProblemDetails(this.http.get<PaginatedResponse<Project>>('/api/projects', {
       params: { page, limit },
-    });
+    }));
   }
 
   getProject(id: number): Observable<Project> {
-    return this.http.get<Project>(`/api/projects/${id}`);
+    return this.withProblemDetails(this.http.get<Project>(`/api/projects/${id}`));
   }
 
   registerProject(data: CreateProjectDto): Observable<Project> {
-    return this.http.post<Project>('/api/projects', data, { headers: this.headers() });
+    return this.withProblemDetails(this.http.post<Project>('/api/projects', data, { headers: this.headers() }));
   }
 
   getOrders(bondId?: number, refresh = false): Observable<PaginatedResponse<Order>> {
@@ -112,38 +142,38 @@ export class ApiService {
     if (bondId) params.bondId = bondId;
     // Bypass any client-side/proxy HTTP caching so a refresh always hits the server.
     if (refresh) params._t = Date.now();
-    return this.http.get<PaginatedResponse<Order>>('/api/marketplace/orders', {
+    return this.withProblemDetails(this.http.get<PaginatedResponse<Order>>('/api/marketplace/orders', {
       params, headers: this.headers(),
-    });
+    }));
   }
 
   listBondTokens(data: ListBondDto): Observable<Order> {
-    return this.http.post<Order>('/api/marketplace/list', data, { headers: this.headers() });
+    return this.withProblemDetails(this.http.post<Order>('/api/marketplace/list', data, { headers: this.headers() }));
   }
 
   buyBondTokens(data: BuyBondDto): Observable<void> {
-    return this.http.post<void>('/api/marketplace/buy', data, { headers: this.headers() });
+    return this.withProblemDetails(this.http.post<void>('/api/marketplace/buy', data, { headers: this.headers() }));
   }
 
   getQuoteBalance(asset: QuoteAsset = 'USDC'): Observable<QuoteBalanceResponse> {
-    return this.http.get<QuoteBalanceResponse>('/api/marketplace/quote-balance', {
+    return this.withProblemDetails(this.http.get<QuoteBalanceResponse>('/api/marketplace/quote-balance', {
       params: { asset },
       headers: this.headers(),
-    });
+    }));
   }
 
   getWalletBalance(asset: QuoteAsset = 'USDC'): Observable<QuoteBalanceResponse> {
-    return this.http.get<QuoteBalanceResponse>('/api/marketplace/wallet-balance', {
+    return this.withProblemDetails(this.http.get<QuoteBalanceResponse>('/api/marketplace/wallet-balance', {
       params: { asset },
       headers: this.headers(),
-    });
+    }));
   }
 
   depositQuote(data: DepositQuoteDto): Observable<QuoteTransactionResponse> {
-    return this.http.post<QuoteTransactionResponse>('/api/marketplace/deposit', data, { headers: this.headers() });
+    return this.withProblemDetails(this.http.post<QuoteTransactionResponse>('/api/marketplace/deposit', data, { headers: this.headers() }));
   }
 
   withdrawQuote(data: WithdrawQuoteDto): Observable<QuoteTransactionResponse> {
-    return this.http.post<QuoteTransactionResponse>('/api/marketplace/withdraw', data, { headers: this.headers() });
+    return this.withProblemDetails(this.http.post<QuoteTransactionResponse>('/api/marketplace/withdraw', data, { headers: this.headers() }));
   }
 }


### PR DESCRIPTION
## Summary
- normalize API exceptions into RFC 7807 problem details with correlation IDs, validation field details, and Soroban contract context
- add structured HTTP request/error logging with correlation IDs and redaction for wallet, secret, signature, and transaction fields
- harden the wallet connection flow for Freighter absence, locked wallets, rejected requests, account changes, and network mismatches
- add accessibility guidance and improve wallet button focus/ARIA feedback

Closes #111
Closes #110
Closes #108
Closes #109

## Validation
- PASS: `cd api && npm test -- common/filters/rfc7807-exception.filter.spec.ts common/interceptors/request-logging.interceptor.spec.ts --runInBand`
- PASS: `cd api && npm run build`
- BLOCKED: `cd frontend && npm run build` currently fails on pre-existing unrelated type errors in bond detail, marketplace list/sell, and quote balance components/specs. The failures are outside the files changed in this PR.