### PR TITLE
Fix/guard tests reconciliation oracle bond

### DIFF
--- a/api/src/auth/auth.controller.guard.spec.ts
+++ b/api/src/auth/auth.controller.guard.spec.ts
@@ -1,0 +1,87 @@
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+import { KycService } from './kyc.service';
+import { buildControllerApp } from '../test/controller-guard.harness';
+import { autoMock, TestRole } from '../test/guard-role-mocks';
+
+describe('AuthController authorization (behavioral)', () => {
+  let app: INestApplication;
+  let authService: jest.Mocked<AuthService>;
+  let kycService: jest.Mocked<KycService>;
+
+  const mockAuthService = autoMock(AuthService);
+  const mockKycService = autoMock(KycService);
+
+  beforeAll(async () => {
+    app = await buildControllerApp(AuthController, [
+      { provide: AuthService, useValue: mockAuthService },
+      { provide: KycService, useValue: mockKycService },
+    ]);
+    authService = app.get(AuthService) as jest.Mocked<AuthService>;
+    kycService = app.get(KycService) as jest.Mocked<KycService>;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('public auth endpoints', () => {
+    it('POST /auth/challenge is reachable without a session', async () => {
+      mockAuthService.generateChallenge.mockResolvedValue({ challenge: 'c' } as any);
+      await request(app.getHttpServer())
+        .post('/auth/challenge')
+        .set('x-test-role', 'anon' as TestRole)
+        .send({ address: 'G_X' })
+        .expect(200);
+      expect(authService.generateChallenge).toHaveBeenCalled();
+    });
+
+    it('POST /auth/verify is reachable without a session', async () => {
+      mockAuthService.verifySignature.mockResolvedValue({ token: 't' } as any);
+      await request(app.getHttpServer())
+        .post('/auth/verify')
+        .set('x-test-role', 'anon' as TestRole)
+        .send({ address: 'G_X', signature: 's', challenge: 'c' })
+        .expect(200);
+      expect(authService.verifySignature).toHaveBeenCalled();
+    });
+  });
+
+  describe('authenticated profile endpoints', () => {
+    it('GET /auth/profile rejects anonymous callers', async () => {
+      await request(app.getHttpServer())
+        .get('/auth/profile')
+        .set('x-test-role', 'anon' as TestRole)
+        .expect(401);
+      expect(authService.getProfile).not.toHaveBeenCalled();
+    });
+
+    it('GET /auth/kyc/:address rejects anonymous callers', async () => {
+      await request(app.getHttpServer())
+        .get('/auth/kyc/G_X')
+        .set('x-test-role', 'anon' as TestRole)
+        .expect(401);
+      expect(kycService.getFullStatus).not.toHaveBeenCalled();
+    });
+
+    it('POST /auth/kyc/:address rejects anonymous callers', async () => {
+      await request(app.getHttpServer())
+        .post('/auth/kyc/G_X')
+        .set('x-test-role', 'anon' as TestRole)
+        .send({ status: 'verified' })
+        .expect(401);
+      expect(kycService.transitionStatus).not.toHaveBeenCalled();
+    });
+
+    it('allows authenticated callers through to the service', async () => {
+      mockAuthService.getProfile.mockResolvedValue({ walletAddress: 'G_USER_ADDRESS' } as any);
+      await request(app.getHttpServer())
+        .get('/auth/profile')
+        .set('x-test-role', 'user' as TestRole)
+        .expect(200);
+      expect(authService.getProfile).toHaveBeenCalledWith('G_USER_ADDRESS');
+    });
+  });
+});

--- a/api/src/bonds/bonds.controller.guard.spec.ts
+++ b/api/src/bonds/bonds.controller.guard.spec.ts
@@ -1,0 +1,83 @@
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { BondsController } from './bonds.controller';
+import { BondsService } from './bonds.service';
+import { buildControllerApp } from '../test/controller-guard.harness';
+import { autoMock, TestRole } from '../test/guard-role-mocks';
+
+describe('BondsController authorization (behavioral)', () => {
+  let app: INestApplication;
+  let bondsService: jest.Mocked<BondsService>;
+
+  const mockBondsService = autoMock(BondsService);
+
+  beforeAll(async () => {
+    app = await buildControllerApp(BondsController, [
+      { provide: BondsService, useValue: mockBondsService },
+    ]);
+    bondsService = app.get(BondsService) as jest.Mocked<BondsService>;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('POST /bonds/:id/sweep-undistributed (admin-only)', () => {
+    it('rejects anonymous callers before the service is touched', async () => {
+      mockBondsService.sweepUndistributed.mockResolvedValue({} as any);
+      await request(app.getHttpServer())
+        .post('/bonds/1/sweep-undistributed')
+        .set('x-test-role', 'anon' as TestRole)
+        .expect(401);
+      expect(bondsService.sweepUndistributed).not.toHaveBeenCalled();
+    });
+
+    it('rejects authenticated non-admin callers', async () => {
+      await request(app.getHttpServer())
+        .post('/bonds/1/sweep-undistributed')
+        .set('x-test-role', 'user' as TestRole)
+        .expect(401);
+      expect(bondsService.sweepUndistributed).not.toHaveBeenCalled();
+    });
+
+    it('allows the admin key and reaches the service', async () => {
+      mockBondsService.sweepUndistributed.mockResolvedValue({ id: 1 } as any);
+      await request(app.getHttpServer())
+        .post('/bonds/1/sweep-undistributed')
+        .set('x-test-role', 'admin' as TestRole)
+        .expect(200);
+      expect(bondsService.sweepUndistributed).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('GET /bonds/:id/export (authenticated)', () => {
+    it('rejects anonymous callers', async () => {
+      await request(app.getHttpServer())
+        .get('/bonds/1/export')
+        .set('x-test-role', 'anon' as TestRole)
+        .expect(401);
+      expect(bondsService.exportBond).not.toHaveBeenCalled();
+    });
+
+    it('allows any authenticated caller and forwards the wallet address', async () => {
+      mockBondsService.exportBond.mockResolvedValue({ id: 1 } as any);
+      await request(app.getHttpServer())
+        .get('/bonds/1/export')
+        .set('x-test-role', 'user' as TestRole)
+        .expect(200);
+      expect(bondsService.exportBond).toHaveBeenCalledWith(1, 'G_USER_ADDRESS');
+    });
+  });
+
+  describe('POST /bonds (public mutation)', () => {
+    it('reaches the service even for anonymous callers', async () => {
+      mockBondsService.create.mockResolvedValue({ id: 1 } as any);
+      await request(app.getHttpServer())
+        .post('/bonds')
+        .set('x-test-role', 'anon' as TestRole)
+        .send({ projectId: 'p', faceValue: 1, couponSchedule: [1], creditType: 'Carbon', maturityDate: 2, totalSupply: 1 })
+        .expect(201);
+      expect(bondsService.create).toHaveBeenCalled();
+    });
+  });
+});

--- a/api/src/bonds/bonds.controller.ts
+++ b/api/src/bonds/bonds.controller.ts
@@ -1,5 +1,5 @@
 import {
-  Controller, Get, Post, Body, Param, Query, Req, HttpCode, HttpStatus, UseGuards, ParseIntPipe
+  Controller, Get, Post, Body, Param, Query, Req, HttpCode, HttpStatus, UseGuards, ParseIntPipe, Header
 } from '@nestjs/common';
 import { BondsService } from './bonds.service';
 import { CreateBondDto } from './dto/create-bond.dto';
@@ -21,6 +21,7 @@ import {
   TransferResponse,
   UndistributedTotalResponse,
   SweepUndistributedResponse,
+  BondDetailResponse,
 } from './interfaces/bond.interface';
 
 @Controller('bonds')
@@ -47,8 +48,17 @@ export class BondsController {
   }
 
   @Get(':id')
+  @Header('Cache-Control', 'no-cache')
   async findOne(@Param('id', ParseIntPipe) id: number): Promise<BondResponse> {
     return this.bondsService.findOne(id);
+  }
+
+  @Get(':id/detail')
+  @Header('Cache-Control', 'no-cache')
+  async getBondDetail(
+    @Param('id', ParseIntPipe) id: number,
+  ): Promise<BondDetailResponse> {
+    return this.bondsService.getBondDetail(id);
   }
 
   @Post(':id/subscribe')

--- a/api/src/bonds/bonds.coupon-challenge.spec.ts
+++ b/api/src/bonds/bonds.coupon-challenge.spec.ts
@@ -1,0 +1,79 @@
+import { Test } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
+import { BondsService } from './bonds.service';
+import { OracleService } from '../oracle/oracle.service';
+import { ContractService } from '../stellar/contract.service';
+import { StellarService } from '../stellar/stellar.service';
+import { NonceService } from '../common/services/nonce.service';
+import { RedisService } from '../common/services/redis.service';
+import { SigningKeyProvider } from '../common/services/signing-key.provider';
+import { ConfigService } from '../config/config.service';
+import { ReportStatus } from '../oracle/interfaces/oracle.interface';
+
+function bondsModuleWith(oracleService?: any) {
+  const providers: any[] = [
+    BondsService,
+    {
+      provide: ContractService,
+      useValue: { invokeContractMethod: jest.fn().mockResolvedValue({ result: [], transactionHash: 'x' }), simulateCall: jest.fn() },
+    },
+    {
+      provide: StellarService,
+      useValue: { getKeypairFromSecret: jest.fn().mockReturnValue({ publicKey: () => 'G_ADMIN' }) },
+    },
+    { provide: NonceService, useValue: { next: jest.fn().mockResolvedValue(0) } },
+    {
+      provide: RedisService,
+      useValue: { sMembers: jest.fn().mockResolvedValue([]), get: jest.fn(), setEx: jest.fn(), del: jest.fn(), sAdd: jest.fn() },
+    },
+    {
+      provide: SigningKeyProvider,
+      useValue: { adminSecret: jest.fn().mockReturnValue('SADMIN'), investorSecret: jest.fn().mockReturnValue('S') },
+    },
+    {
+      provide: ConfigService,
+      useValue: { getCouponEngineAddress: jest.fn().mockReturnValue('C'), getBondIssuerAddress: jest.fn().mockReturnValue('B') },
+    },
+  ];
+  if (oracleService) {
+    providers.push({ provide: OracleService, useValue: oracleService });
+  }
+  return Test.createTestingModule({ providers }).compile();
+}
+
+describe('BondsService coupon challenge linkage (#oracle-challenge)', () => {
+  const oracleService = { getReport: jest.fn() };
+
+  it('blocks coupon distribution when the referenced report is Challenged', async () => {
+    oracleService.getReport.mockResolvedValue({ id: 7, status: ReportStatus.Challenged });
+    const moduleRef = await bondsModuleWith(oracleService);
+    const service = moduleRef.get(BondsService);
+    await expect(service.distributeCoupon(1, { periodIndex: 0, reportId: 7 })).rejects.toBeInstanceOf(
+      BadRequestException,
+    );
+  });
+
+  it('blocks coupon distribution when the referenced report is Rejected', async () => {
+    oracleService.getReport.mockResolvedValue({ id: 7, status: ReportStatus.Rejected });
+    const moduleRef = await bondsModuleWith(oracleService);
+    const service = moduleRef.get(BondsService);
+    await expect(service.distributeCoupon(1, { periodIndex: 0, reportId: 7 })).rejects.toBeInstanceOf(
+      BadRequestException,
+    );
+  });
+
+  it('allows coupon distribution when the referenced report is Verified', async () => {
+    oracleService.getReport.mockResolvedValue({ id: 7, status: ReportStatus.Verified });
+    const moduleRef = await bondsModuleWith(oracleService);
+    const service = moduleRef.get(BondsService);
+    const result = await service.distributeCoupon(1, { periodIndex: 0, reportId: 7 });
+    expect(result.bondId).toBe(1);
+  });
+
+  it('remains backward compatible when no oracle service is wired in', async () => {
+    const moduleRef = await bondsModuleWith(undefined);
+    const service = moduleRef.get(BondsService);
+    const result = await service.distributeCoupon(1, { periodIndex: 0, reportId: 7 });
+    expect(result.bondId).toBe(1);
+  });
+});

--- a/api/src/bonds/bonds.detail.service.spec.ts
+++ b/api/src/bonds/bonds.detail.service.spec.ts
@@ -1,0 +1,99 @@
+import { Test } from '@nestjs/testing';
+import { BondsService } from './bonds.service';
+import { ContractService } from '../stellar/contract.service';
+import { StellarService } from '../stellar/stellar.service';
+import { NonceService } from '../common/services/nonce.service';
+import { RedisService } from '../common/services/redis.service';
+import { SigningKeyProvider } from '../common/services/signing-key.provider';
+import { ConfigService } from '../config/config.service';
+import { BondResponse, HolderResponse } from './interfaces/bond.interface';
+
+const dummyBond: BondResponse = {
+  id: 7,
+  projectRegistryId: 'abc',
+  faceValue: '1000',
+  couponSchedule: [10, 20],
+  creditType: 'carbon',
+  maturityDate: Math.floor(Date.now() / 1000) + 1000,
+  totalSupply: '1000',
+  totalSubscribed: '400',
+  status: 0,
+  createdAt: new Date().toISOString(),
+};
+
+const dummyHolders: HolderResponse[] = [
+  { address: 'GAAA', balance: '200' },
+  { address: 'GBBB', balance: '200' },
+];
+
+function buildModule() {
+  return Test.createTestingModule({
+    providers: [
+      BondsService,
+      { provide: ContractService, useValue: { invokeContractMethod: jest.fn(), simulateCall: jest.fn() } },
+      { provide: StellarService, useValue: { getKeypairFromSecret: jest.fn() } },
+      { provide: NonceService, useValue: { next: jest.fn().mockResolvedValue(1) } },
+      { provide: RedisService, useValue: { get: jest.fn(), setEx: jest.fn(), del: jest.fn(), sMembers: jest.fn().mockResolvedValue([]) } },
+      { provide: SigningKeyProvider, useValue: { adminSecret: jest.fn(), investorSecret: jest.fn() } },
+      {
+        provide: ConfigService,
+        useValue: { getBondIssuerAddress: jest.fn().mockReturnValue('C'), getCouponEngineAddress: jest.fn().mockReturnValue('E') },
+      },
+    ],
+  }).compile();
+}
+
+describe('BondsService.getBondDetail (issue #4 refresh model)', () => {
+  it('returns an atomic snapshot of bond, holders, coupon, and maturity with a server timestamp', async () => {
+    const moduleRef = await buildModule();
+    const svc = moduleRef.get(BondsService);
+
+    const bondSpy = jest.spyOn(svc, 'buildBondResponse').mockResolvedValue(dummyBond);
+    const holdersSpy = jest.spyOn(svc, 'getHolders').mockResolvedValue({ bondId: 7, holders: dummyHolders, total: dummyHolders.length });
+    const couponSpy = jest.spyOn(svc, 'getUndistributedTotal').mockResolvedValue({ bondId: 7, undistributedTotal: '123' });
+
+    const detail = await svc.getBondDetail(7);
+
+    expect(bondSpy).toHaveBeenCalledWith(7);
+    expect(holdersSpy).toHaveBeenCalledWith(7);
+    expect(couponSpy).toHaveBeenCalledWith(7);
+    expect(detail.bond).toEqual(dummyBond);
+    expect(detail.holders).toEqual(dummyHolders);
+    expect(detail.coupon.undistributedTotal).toBe('123');
+    expect(detail.maturity.date).toBe(dummyBond.maturityDate);
+    expect(detail.maturity.reached).toBe(false);
+    expect(typeof detail.loadedAt).toBe('string');
+    expect(Number.isNaN(Date.parse(detail.loadedAt))).toBe(false);
+  });
+
+  it('marks maturity reached when the bond status is Matured', async () => {
+    const moduleRef = await buildModule();
+    const svc = moduleRef.get(BondsService);
+
+    jest.spyOn(svc, 'buildBondResponse').mockResolvedValue({ ...dummyBond, status: 1 });
+    jest.spyOn(svc, 'getHolders').mockResolvedValue({ bondId: 7, holders: [], total: 0 });
+    jest.spyOn(svc, 'getUndistributedTotal').mockResolvedValue({ bondId: 7, undistributedTotal: '0' });
+
+    const detail = await svc.getBondDetail(7);
+    expect(detail.maturity.reached).toBe(true);
+    expect(detail.maturity.secondsUntil).toBe(0);
+  });
+
+  it('refreshes consistently after a mutation: a second call re-reads the source of truth', async () => {
+    const moduleRef = await buildModule();
+    const svc = moduleRef.get(BondsService);
+
+    const bondSpy = jest.spyOn(svc, 'buildBondResponse');
+    const holdersSpy = jest.spyOn(svc, 'getHolders');
+    const couponSpy = jest.spyOn(svc, 'getUndistributedTotal');
+
+    await svc.getBondDetail(7);
+    await svc.getBondDetail(7);
+
+    // No caching on the service side: every reload hits the chain again, so the
+    // frontend always receives fresh post-mutation data.
+    expect(bondSpy).toHaveBeenCalledTimes(2);
+    expect(holdersSpy).toHaveBeenCalledTimes(2);
+    expect(couponSpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/api/src/bonds/bonds.module.ts
+++ b/api/src/bonds/bonds.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { BondsController } from './bonds.controller';
 import { BondsService } from './bonds.service';
+import { OracleModule } from '../oracle/oracle.module';
 
 @Module({
+  imports: [OracleModule],
   controllers: [BondsController],
   providers: [BondsService],
 })

--- a/api/src/bonds/bonds.service.ts
+++ b/api/src/bonds/bonds.service.ts
@@ -28,6 +28,8 @@ import {
 } from './interfaces/bond.interface';
 import { toBigIntString } from '../common/utils';
 import { ConfigService } from '../config/config.service';
+import { OracleService } from '../oracle/oracle.service';
+import { ReportStatus } from '../oracle/interfaces/oracle.interface';
 import { Address, nativeToScVal, scValToNative, xdr } from '@stellar/stellar-sdk';
 
 const BOND_ERROR_CODE = {
@@ -52,6 +54,7 @@ export class BondsService {
     private readonly redis: RedisService,
     private readonly signingKeys: SigningKeyProvider,
     private readonly configService: ConfigService,
+    @Optional() private readonly oracleService?: OracleService,
   ) {}
 
   async create(dto: CreateBondDto): Promise<BondResponse> {
@@ -188,10 +191,55 @@ export class BondsService {
     return { bondId: id, holders, total: holders.length };
   }
 
+  /**
+   * Atomically refresh every panel of a bond's detail (issue #4). Fetches the
+   * bond summary, holders, and coupon undistributed total together and derives
+   * a single maturity status, so callers never commit a mix of pre- and
+   * post-mutation values. `loadedAt` lets the client refresh model detect
+   * staleness against its own `lastLoadedAt`.
+   */
+  async getBondDetail(id: number): Promise<BondDetailResponse> {
+    const bond = await this.buildBondResponse(id);
+    const [holdersResponse, couponResponse] = await Promise.all([
+      this.getHolders(id),
+      this.getUndistributedTotal(id),
+    ]);
+
+    const now = Math.floor(Date.now() / 1000);
+    const reached = bond.status === 1 || now >= bond.maturityDate;
+    const secondsUntil = reached ? 0 : bond.maturityDate - now;
+
+    return {
+      bond,
+      holders: holdersResponse.holders,
+      coupon: { undistributedTotal: couponResponse.undistributedTotal },
+      maturity: { reached, date: bond.maturityDate, secondsUntil },
+      loadedAt: new Date().toISOString(),
+    };
+  }
+
   async distributeCoupon(id: number, dto: DistributeCouponDto): Promise<CouponDistributionResponse> {
     const adminSecret = this.getAdminSecret();
     const adminAddress = this.stellarService.getKeypairFromSecret(adminSecret).publicKey();
     const nonce = await this.nonceService.next(this.configService.getCouponEngineAddress(), adminAddress);
+
+    // Challenge linkage (#oracle-challenge): a coupon pays out on the carbon
+    // data in the referenced oracle report. If that report is Challenged or
+    // Rejected, the data is disputed and must not be paid on, so block before
+    // any contract call is made. The oracle dependency is optional so the bond
+    // module keeps working where the oracle module is not wired in.
+    if (this.oracleService) {
+      const report = await this.oracleService.getReport(dto.reportId);
+      if (report.status === ReportStatus.Challenged) {
+        throw new BadRequestException(
+          `Cannot distribute coupon: report ${report.id} is currently Challenged. ` +
+            'Resolve the challenge before distributing.',
+        );
+      }
+      if (report.status === ReportStatus.Rejected) {
+        throw new BadRequestException(`Cannot distribute coupon: report ${report.id} was Rejected.`);
+      }
+    }
 
     const holderAddresses = await this.redis.sMembers(`bond:${id}:holders`);
 

--- a/api/src/bonds/interfaces/bond.interface.ts
+++ b/api/src/bonds/interfaces/bond.interface.ts
@@ -79,3 +79,18 @@ export interface SweepUndistributedResponse {
   swept: string;
   transactionHash: string;
 }
+
+/**
+ * Consolidated, atomically-fetched bond detail (issue #4). A single call returns
+ * the bond summary, holders, coupon undistributed total, and maturity status so
+ * the frontend can refresh every panel together and never render a mix of
+ * pre- and post-mutation data. `loadedAt` is the server timestamp used by the
+ * client refresh model to detect staleness.
+ */
+export interface BondDetailResponse {
+  bond: BondResponse;
+  holders: HolderResponse[];
+  coupon: { undistributedTotal: string };
+  maturity: { reached: boolean; date: number; secondsUntil: number };
+  loadedAt: string;
+}

--- a/api/src/marketplace/dex.reconciliation.scheduler.spec.ts
+++ b/api/src/marketplace/dex.reconciliation.scheduler.spec.ts
@@ -1,0 +1,27 @@
+import { DexReconciliationScheduler } from './dex.reconciliation.scheduler';
+import { DexReconciliationService } from './dex.reconciliation.service';
+
+describe('DexReconciliationScheduler', () => {
+  it('runs the reconciliation job and surfaces the result without throwing', async () => {
+    const reconciliation = {
+      reconcile: jest.fn().mockResolvedValue({ correlationId: 'c', mismatches: [] }),
+    } as any;
+    const scheduler = new DexReconciliationScheduler(reconciliation);
+
+    await scheduler.runReconciliation();
+
+    expect(reconciliation.reconcile).toHaveBeenCalled();
+  });
+
+  it('skips when the DEX router is not configured', async () => {
+    const original = process.env.DEX_ROUTER_ADDRESS;
+    delete process.env.DEX_ROUTER_ADDRESS;
+    const reconciliation = { reconcile: jest.fn() } as any;
+    const scheduler = new DexReconciliationScheduler(reconciliation);
+
+    await scheduler.runReconciliation();
+
+    expect(reconciliation.reconcile).not.toHaveBeenCalled();
+    if (original) process.env.DEX_ROUTER_ADDRESS = original;
+  });
+});

--- a/api/src/marketplace/dex.reconciliation.scheduler.ts
+++ b/api/src/marketplace/dex.reconciliation.scheduler.ts
@@ -1,0 +1,38 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { DexReconciliationService } from './dex.reconciliation.service';
+
+const DEFAULT_CRON = CronExpression.EVERY_10_MINUTES;
+
+/**
+ * Drives the marketplace reconciliation job (#recon) on a schedule. Each tick
+ * runs `DexReconciliationService.reconcile()`; mismatches are logged (with a
+ * correlation id) and persisted by the service for operators. Repair is a
+ * manual operator action via POST /marketplace/reconciliation/repair so that
+ * cache eviction is deliberate.
+ */
+@Injectable()
+export class DexReconciliationScheduler {
+  private readonly logger = new Logger(DexReconciliationScheduler.name);
+
+  constructor(private readonly reconciliation: DexReconciliationService) {}
+
+  @Cron(process.env.DEX_RECON_CRON || DEFAULT_CRON)
+  async runReconciliation(): Promise<void> {
+    if (!process.env.DEX_ROUTER_ADDRESS) {
+      this.logger.debug('Skipping marketplace reconciliation: DEX_ROUTER_ADDRESS unset');
+      return;
+    }
+    this.logger.log('Marketplace reconciliation started');
+    try {
+      const report = await this.reconciliation.reconcile();
+      this.logger.log(
+        `Marketplace reconciliation finished: correlationId=${report.correlationId} ` +
+          `balances=${report.checkedBalances} orders=${report.checkedOrders} mismatches=${report.mismatches.length}`,
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.error(`Marketplace reconciliation error: ${message}`);
+    }
+  }
+}

--- a/api/src/marketplace/dex.reconciliation.service.spec.ts
+++ b/api/src/marketplace/dex.reconciliation.service.spec.ts
@@ -1,0 +1,163 @@
+import { Test } from '@nestjs/testing';
+import { DexReconciliationService } from './dex.reconciliation.service';
+import { DexService } from './dex.service';
+import { RedisService } from '../common/services/redis.service';
+import { OrderStatus } from './interfaces/marketplace.interface';
+
+function openOrder(id: number, overrides: Partial<any> = {}): any {
+  return {
+    id,
+    seller: 'G_SELLER',
+    bondId: 1,
+    amount: '10',
+    pricePerToken: '5',
+    quoteAsset: 'USDC',
+    status: OrderStatus.Open,
+    createdAt: '2024-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('DexReconciliationService', () => {
+  let service: DexReconciliationService;
+  let dexService: any;
+  let redis: any;
+
+  beforeEach(async () => {
+    dexService = {
+      getQuoteBalance: jest.fn(),
+      getIndexedQuoteBalance: jest.fn(),
+      setIndexedQuoteBalance: jest.fn(),
+      listOrders: jest.fn(),
+      fetchOrderFromLedger: jest.fn(),
+      getOrder: jest.fn(),
+      getOrderCount: jest.fn(),
+    };
+    redis = {
+      get: jest.fn().mockResolvedValue(null),
+      setEx: jest.fn().mockResolvedValue(undefined),
+      del: jest.fn().mockResolvedValue(undefined),
+      delPattern: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        DexReconciliationService,
+        { provide: DexService, useValue: dexService },
+        { provide: RedisService, useValue: redis },
+      ],
+    }).compile();
+
+    service = moduleRef.get(DexReconciliationService);
+  });
+
+  it('seeds the index on first sighting and reports no mismatches', async () => {
+    dexService.getQuoteBalance.mockResolvedValue({ address: 'G1', asset: 'USDC', balance: '200' });
+    dexService.getIndexedQuoteBalance.mockResolvedValue(null);
+    dexService.listOrders.mockResolvedValue({ data: [] });
+    dexService.getOrderCount.mockResolvedValue(0);
+
+    const report = await service.reconcile({ wallets: ['G1'], assets: ['USDC'] });
+
+    expect(report.mismatches).toHaveLength(0);
+    expect(dexService.setIndexedQuoteBalance).toHaveBeenCalledWith('G1', 'USDC', '200');
+    expect(redis.setEx).toHaveBeenCalled();
+  });
+
+  it('detects a changed on-chain balance vs the stale index (stale cache)', async () => {
+    dexService.getQuoteBalance.mockResolvedValue({ address: 'G1', asset: 'USDC', balance: '200' });
+    dexService.getIndexedQuoteBalance.mockResolvedValue('100');
+    dexService.listOrders.mockResolvedValue({ data: [] });
+    dexService.getOrderCount.mockResolvedValue(0);
+
+    const report = await service.reconcile({ wallets: ['G1'], assets: ['USDC'] });
+
+    expect(report.mismatches).toHaveLength(1);
+    const m = report.mismatches[0];
+    expect(m.type).toBe('balance_mismatch');
+    expect(m.observed).toBe('100');
+    expect(m.expected).toBe('200');
+    // A mismatch must NOT silently re-seed the index.
+    expect(dexService.setIndexedQuoteBalance).not.toHaveBeenCalled();
+  });
+
+  it('flags a stale order cache where the API shows Open but the ledger does not', async () => {
+    dexService.getQuoteBalance.mockResolvedValue({ address: 'G1', asset: 'USDC', balance: '1000' });
+    dexService.getIndexedQuoteBalance.mockResolvedValue(null);
+    dexService.listOrders.mockResolvedValue({ data: [openOrder(1, { seller: 'G1' })] });
+    dexService.getOrder.mockResolvedValue(openOrder(1, { status: OrderStatus.Open }));
+    dexService.fetchOrderFromLedger.mockResolvedValue(openOrder(1, { status: OrderStatus.Filled }));
+    dexService.getOrderCount.mockResolvedValue(1);
+
+    const report = await service.reconcile({ wallets: ['G1'], assets: ['USDC'] });
+
+    const m = report.mismatches.find((x) => x.type === 'stale_order_cache');
+    expect(m).toBeDefined();
+    expect(m?.orderId).toBe(1);
+    expect(m?.observed).toBe(OrderStatus.Open);
+    expect(m?.expected).toBe(OrderStatus.Filled);
+  });
+
+  it('detects an open order that has dropped out of the API index (missing order)', async () => {
+    dexService.getQuoteBalance.mockResolvedValue({ address: 'G_SELLER', asset: 'USDC', balance: '1000' });
+    dexService.getIndexedQuoteBalance.mockResolvedValue(null);
+    // API index only knows orders 1 and 3 as open.
+    dexService.listOrders.mockResolvedValue({
+      data: [openOrder(1), openOrder(3)],
+    });
+    dexService.getOrder.mockImplementation(async (id: number) => openOrder(id));
+    // On-chain order 2 is open but absent from the index.
+    dexService.fetchOrderFromLedger.mockImplementation(async (id: number) => openOrder(id));
+    dexService.getOrderCount.mockResolvedValue(3);
+
+    const report = await service.reconcile({ wallets: ['G_SELLER'], assets: ['USDC'] });
+
+    const m = report.mismatches.find((x) => x.type === 'missing_order' && x.orderId === 2);
+    expect(m).toBeDefined();
+  });
+
+  it('flags an order whose seller no longer holds enough escrow (escrow invariant)', async () => {
+    // required = 5 * 10 = 50, but seller holds only 10.
+    dexService.getQuoteBalance.mockResolvedValue({ address: 'G_SELLER', asset: 'USDC', balance: '10' });
+    dexService.getIndexedQuoteBalance.mockResolvedValue(null);
+    dexService.listOrders.mockResolvedValue({ data: [openOrder(1, { seller: 'G_SELLER' })] });
+    dexService.getOrder.mockResolvedValue(openOrder(1, { status: OrderStatus.Open }));
+    dexService.fetchOrderFromLedger.mockResolvedValue(openOrder(1, { status: OrderStatus.Open }));
+    dexService.getOrderCount.mockResolvedValue(1);
+
+    const report = await service.reconcile({ wallets: ['G_SELLER'], assets: ['USDC'] });
+
+    const m = report.mismatches.find((x) => x.type === 'order_escrow_invariant');
+    expect(m).toBeDefined();
+    expect(m?.orderId).toBe(1);
+  });
+
+  it('repair() evicts the stale cache / re-syncs the index per mismatch type', async () => {
+    const report = {
+      correlationId: 'test-corr',
+      mismatches: [
+        { type: 'balance_mismatch', walletAddress: 'G1', asset: 'USDC', expected: '200', observed: '100', correlationId: 'test-corr' },
+        { type: 'stale_order_cache', orderId: 1, expected: 'Filled', observed: 'Open', correlationId: 'test-corr' },
+        { type: 'missing_order', orderId: 2, expected: 'Open', observed: 'absent', correlationId: 'test-corr' },
+        { type: 'order_escrow_invariant', orderId: 3, correlationId: 'test-corr' },
+      ],
+    } as any;
+
+    const actions = await service.repair(report);
+
+    expect(redis.del).toHaveBeenCalledWith('quote:balance:G1:USDC');
+    expect(redis.delPattern).toHaveBeenCalledWith('orders:*');
+    expect(actions.length).toBe(4);
+  });
+
+  it('persists the report so operators can fetch it later', async () => {
+    dexService.getQuoteBalance.mockResolvedValue({ address: 'G1', asset: 'USDC', balance: '200' });
+    dexService.getIndexedQuoteBalance.mockResolvedValue(null);
+    dexService.listOrders.mockResolvedValue({ data: [] });
+    dexService.getOrderCount.mockResolvedValue(0);
+
+    await service.reconcile({ wallets: ['G1'], assets: ['USDC'] });
+
+    expect(redis.setEx).toHaveBeenCalled();
+  });
+});

--- a/api/src/marketplace/dex.reconciliation.service.ts
+++ b/api/src/marketplace/dex.reconciliation.service.ts
@@ -1,0 +1,309 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import { DexService } from './dex.service';
+import { RedisService } from '../common/services/redis.service';
+import { OrderResponse, OrderStatus, QuoteAsset } from './interfaces/marketplace.interface';
+import { listSupportedQuoteAssets } from './quote-assets';
+
+export type MismatchType =
+  | 'balance_mismatch'
+  | 'stale_order_cache'
+  | 'missing_order'
+  | 'order_escrow_invariant';
+
+export interface ReconciliationMismatch {
+  correlationId: string;
+  type: MismatchType;
+  walletAddress?: string;
+  asset?: string;
+  orderId?: number;
+  /** Authoritative value read directly from the ledger. */
+  expected: string;
+  /** Value observed in the API/indexed cache. */
+  observed: string;
+  detail: string;
+  repair: string;
+}
+
+export interface ReconciliationReport {
+  correlationId: string;
+  startedAt: string;
+  finishedAt: string;
+  sampledWallets: number;
+  checkedBalances: number;
+  checkedOrders: number;
+  mismatches: ReconciliationMismatch[];
+  hasMismatches: boolean;
+}
+
+export interface ReconcileOptions {
+  wallets?: string[];
+  assets?: QuoteAsset[];
+  /** Cap on on-chain order-id scan used to detect missing orders. */
+  maxOrderScan?: number;
+}
+
+const LAST_REPORT_KEY = 'dex:recon:last';
+const MISMATCHES_KEY = 'dex:recon:mismatches';
+const MAX_STORED_MISMATCHES = 200;
+
+/**
+ * Periodic reconciliation (#recon) between the API/indexed view of marketplace
+ * state and the authoritative on-chain DEX router ledger.
+ *
+ * It compares:
+ *   - escrowed quote balances: indexed `quote:balance:*` cache vs
+ *     `DEXRouter.get_quote_balance()`;
+ *   - open orders: the API order cache/index vs `DEXRouter.get_order()` status,
+ *     plus an escrow invariant (a seller's on-chain balance must still cover the
+ *     order's notional) and detection of open orders that have dropped out of the
+ *     API index entirely.
+ *
+ * Mismatches are logged with a correlation id and persisted for operators
+ * (`dex:recon:last`, `dex:recon:mismatches`). `repair()` provides the stale-cache
+ * / index repair path (invalidate caches, re-sync the index to the ledger).
+ */
+@Injectable()
+export class DexReconciliationService {
+  private readonly logger = new Logger(DexReconciliationService.name);
+
+  constructor(
+    private readonly dexService: DexService,
+    private readonly redis: RedisService,
+  ) {}
+
+  async reconcile(options: ReconcileOptions = {}): Promise<ReconciliationReport> {
+    const correlationId = randomUUID();
+    const startedAt = new Date().toISOString();
+    const mismatches: ReconciliationMismatch[] = [];
+
+    const wallets = await this.resolveWallets(options.wallets);
+    const assets = options.assets ?? (listSupportedQuoteAssets().map((a) => a.symbol) as QuoteAsset[]);
+
+    let checkedBalances = 0;
+    for (const wallet of wallets) {
+      for (const asset of assets) {
+        checkedBalances += 1;
+        const onChain = await this.dexService.getQuoteBalance(wallet, asset);
+        const indexed = await this.dexService.getIndexedQuoteBalance(wallet, asset);
+        if (indexed === null) {
+          // First sighting: seed the index from the ledger, no divergence yet.
+          await this.dexService.setIndexedQuoteBalance(wallet, asset, onChain.balance);
+          continue;
+        }
+        if (indexed !== onChain.balance) {
+          mismatches.push({
+            correlationId,
+            type: 'balance_mismatch',
+            walletAddress: wallet,
+            asset,
+            expected: onChain.balance,
+            observed: indexed,
+            detail: `Indexed quote balance ${indexed} != on-chain ${onChain.balance} for ${wallet}/${asset}`,
+            repair: `Invalidate quote:balance:${wallet}:${asset} (handled by repair())`,
+          });
+        }
+      }
+    }
+
+    const checkedOrders = await this.reconcileOrders(correlationId, mismatches, options.maxOrderScan ?? 500);
+
+    const finishedAt = new Date().toISOString();
+    const report: ReconciliationReport = {
+      correlationId,
+      startedAt,
+      finishedAt,
+      sampledWallets: wallets.length,
+      checkedBalances,
+      checkedOrders,
+      mismatches,
+      hasMismatches: mismatches.length > 0,
+    };
+
+    await this.persistReport(report);
+
+    if (report.hasMismatches) {
+      this.logger.warn(
+        `[${correlationId}] Marketplace reconciliation found ${mismatches.length} mismatch(es): ` +
+          mismatches.map((m) => `${m.type}#${m.orderId ?? m.walletAddress ?? ''}`).join(', '),
+      );
+    } else {
+      this.logger.log(`[${correlationId}] Marketplace reconciliation clean (${checkedBalances} balances, ${checkedOrders} orders)`);
+    }
+
+    return report;
+  }
+
+  private async reconcileOrders(
+    correlationId: string,
+    mismatches: ReconciliationMismatch[],
+    maxOrderScan: number,
+  ): Promise<number> {
+    const openOrders: OrderResponse[] = (
+      await this.dexService.listOrders(undefined, OrderStatus.Open, 1, 200)
+    ).data;
+    const indexedOpenIds = new Set(openOrders.map((o) => o.id));
+
+    let checked = 0;
+    for (const order of openOrders) {
+      checked += 1;
+      const onChain = await this.dexService.fetchOrderFromLedger(order.id);
+      const indexed = await this.dexService.getOrder(order.id);
+
+      if (
+        this.isOpenState(indexed.status) &&
+        !this.isOpenState(onChain.status)
+      ) {
+        mismatches.push({
+          correlationId,
+          type: 'stale_order_cache',
+          orderId: order.id,
+          expected: onChain.status,
+          observed: indexed.status,
+          detail: `Order ${order.id} cached as ${indexed.status} but is ${onChain.status} on-chain`,
+          repair: `Invalidate order:${order.id} and orders:* (handled by repair())`,
+        });
+      }
+
+      // Escrow invariant: the seller must still hold enough quote asset on-chain.
+      const escrowed = await this.dexService.getQuoteBalance(order.seller, order.quoteAsset);
+      const required = BigInt(order.pricePerToken) * BigInt(order.amount);
+      if (BigInt(escrowed.balance) < required) {
+        mismatches.push({
+          correlationId,
+          type: 'order_escrow_invariant',
+          orderId: order.id,
+          walletAddress: order.seller,
+          asset: order.quoteAsset,
+          expected: `>= ${required}`,
+          observed: escrowed.balance,
+          detail: `Order ${order.id} seller ${order.seller} escrowed ${escrowed.balance} < required ${required}`,
+          repair: `Re-escrow or cancel order ${order.id}; invalidate orders:* (handled by repair())`,
+        });
+      }
+    }
+
+    // Missing-order detection: walk the on-chain id space and flag open orders
+    // absent from the API index.
+    const orderCount = await this.dexService.getOrderCount();
+    const scanLimit = Math.min(orderCount, maxOrderScan);
+    for (let id = 1; id <= scanLimit; id += 1) {
+      let onChain: OrderResponse;
+      try {
+        onChain = await this.dexService.fetchOrderFromLedger(id);
+      } catch {
+        continue;
+      }
+      if (this.isOpenState(onChain.status) && !indexedOpenIds.has(id)) {
+        mismatches.push({
+          correlationId,
+          type: 'missing_order',
+          orderId: id,
+          expected: onChain.status,
+          observed: 'absent from API index',
+          detail: `Open order ${id} exists on-chain but is missing from the API order index/cache`,
+          repair: `Invalidate orders:* so the next listOrders re-indexes it (handled by repair())`,
+        });
+      }
+    }
+
+    return checked;
+  }
+
+  private isOpenState(status: OrderStatus): boolean {
+    return status === OrderStatus.Open || status === OrderStatus.PartiallyFilled;
+  }
+
+  /**
+   * Builds the set of wallets to sample. Operators can pin an explicit list via
+   * `options.wallets` (tests) or the `DEX_RECON_WALLETS` env var; otherwise we
+   * sample every seller currently advertising an open order so the most
+   * balance-sensitive wallets are always covered.
+   */
+  private async resolveWallets(override?: string[]): Promise<string[]> {
+    if (override && override.length) {
+      return [...new Set(override)];
+    }
+    const configured = (process.env.DEX_RECON_WALLETS || '')
+      .split(',')
+      .map((w) => w.trim())
+      .filter(Boolean);
+    const fromOrders = (
+      await this.dexService.listOrders(undefined, OrderStatus.Open, 1, 200)
+    ).data.map((o) => o.seller);
+    return [...new Set([...configured, ...fromOrders])];
+  }
+
+  /**
+   * Repair path for the stale cache / index records found by `reconcile()`.
+   * Returns a human-readable list of actions taken. Balance mismatches are
+   * re-synced to the ledger value; order/index mismatches evict the affected
+   * Redis caches so the next read re-fetches from the ledger.
+   */
+  async repair(report: ReconciliationReport): Promise<string[]> {
+    const actions: string[] = [];
+    for (const mismatch of report.mismatches) {
+      switch (mismatch.type) {
+        case 'balance_mismatch':
+          if (mismatch.walletAddress && mismatch.asset) {
+            await this.dexService.setIndexedQuoteBalance(
+              mismatch.walletAddress,
+              mismatch.asset as QuoteAsset,
+              mismatch.expected,
+            );
+            await this.redis.del(`quote:balance:${mismatch.walletAddress}:${mismatch.asset}`);
+            actions.push(`re-synced quote:balance:${mismatch.walletAddress}:${mismatch.asset} -> ${mismatch.expected}`);
+          }
+          break;
+        case 'stale_order_cache':
+          if (mismatch.orderId !== undefined) {
+            await this.redis.del(`order:${mismatch.orderId}`);
+            await this.redis.delPattern('orders:*');
+            actions.push(`evicted order:${mismatch.orderId} and orders:*`);
+          }
+          break;
+        case 'missing_order':
+          await this.redis.delPattern('orders:*');
+          actions.push('evicted orders:* to force re-index of missing order');
+          break;
+        case 'order_escrow_invariant':
+          if (mismatch.orderId !== undefined) {
+            await this.redis.delPattern('orders:*');
+            actions.push(`evicted orders:* for under-escrowed order ${mismatch.orderId}`);
+          }
+          break;
+      }
+    }
+    this.logger.log(
+      `[${report.correlationId}] Repaired ${actions.length}/${report.mismatches.length} mismatch(es): ${actions.join('; ')}`,
+    );
+    return actions;
+  }
+
+  async getLastReport(): Promise<ReconciliationReport | null> {
+    const raw = await this.redis.get(LAST_REPORT_KEY);
+    return raw ? (JSON.parse(raw) as ReconciliationReport) : null;
+  }
+
+  async listMismatches(limit = 50): Promise<ReconciliationMismatch[]> {
+    const raw = await this.redis.get(MISMATCHES_KEY);
+    if (!raw) return [];
+    const all = JSON.parse(raw) as ReconciliationMismatch[];
+    return all.slice(0, limit);
+  }
+
+  private async persistReport(report: ReconciliationReport): Promise<void> {
+    try {
+      await this.redis.setEx(LAST_REPORT_KEY, 86_400 * 7, JSON.stringify(report));
+      const existing = await this.listMismatches(MAX_STORED_MISMATCHES);
+      const merged = [...report.mismatches, ...existing].slice(0, MAX_STORED_MISMATCHES);
+      await this.redis.setEx(MISMATCHES_KEY, 86_400 * 7, JSON.stringify(merged));
+    } catch (error) {
+      this.logger.warn(`Failed to persist reconciliation report: ${this.message(error)}`);
+    }
+  }
+
+  private message(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+  }
+}

--- a/api/src/marketplace/dex.service.ts
+++ b/api/src/marketplace/dex.service.ts
@@ -200,7 +200,7 @@ export class DexService {
   }
 
   /** Reads the order directly from the ledger, bypassing the Redis cache entirely. */
-  private async fetchOrderFromLedger(orderId: number): Promise<OrderResponse> {
+  async fetchOrderFromLedger(orderId: number): Promise<OrderResponse> {
     const orderScVal = await this.contractService.simulateCall({
       contractAddress: this.configService.getDexRouterAddress(),
       method: 'get_order',
@@ -259,6 +259,8 @@ export class DexService {
       nonce,
     );
 
+    await this.invalidateQuoteBalanceIndex(callerAddress, dto.asset);
+
     return { address: callerAddress, asset: dto.asset, amount: dto.amount, transactionHash };
   }
 
@@ -279,7 +281,33 @@ export class DexService {
       nonce,
     );
 
+    await this.invalidateQuoteBalanceIndex(callerAddress, dto.asset);
+
     return { address: callerAddress, asset: dto.asset, amount: dto.amount, transactionHash };
+  }
+
+  private quoteBalanceIndexKey(address: string, asset: QuoteAsset): string {
+    return `quote:balance:${address}:${asset}`;
+  }
+
+  /**
+   * Reconciliation (#recon): the API/indexed view of a wallet's escrowed quote
+   * balance. The reconciliation job compares this against the on-chain
+   * `get_quote_balance` value. Deposit/withdraw keep it fresh by evicting it;
+   * a missed eviction is exactly what reconciliation surfaces as a balance
+   * mismatch (a "stale cache" divergence).
+   */
+  async getIndexedQuoteBalance(address: string, asset: QuoteAsset): Promise<string | null> {
+    return this.redis.get(this.quoteBalanceIndexKey(address, asset));
+  }
+
+  async setIndexedQuoteBalance(address: string, asset: QuoteAsset, balance: string): Promise<void> {
+    await this.redis.setEx(this.quoteBalanceIndexKey(address, asset), 86_400, balance);
+  }
+
+  private async invalidateQuoteBalanceIndex(address: string, assetSymbol: string): Promise<void> {
+    const asset = normalizeQuoteAssetSymbol(assetSymbol);
+    await this.redis.del(this.quoteBalanceIndexKey(address, asset));
   }
 
   private decodeOrder(data: any[]): OrderResponse {
@@ -371,7 +399,7 @@ export class DexService {
     };
   }
 
-  private async getOrderCount(): Promise<number> {
+  async getOrderCount(): Promise<number> {
     const countScVal = await this.contractService.simulateCall({
       contractAddress: this.configService.getDexRouterAddress(),
       method: 'order_count',

--- a/api/src/marketplace/marketplace.controller.guard.spec.ts
+++ b/api/src/marketplace/marketplace.controller.guard.spec.ts
@@ -1,0 +1,97 @@
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { MarketplaceController } from './marketplace.controller';
+import { DexService } from './dex.service';
+import { LiquidityService } from './liquidity.service';
+import { StellarService } from '../stellar/stellar.service';
+import { buildControllerApp } from '../test/controller-guard.harness';
+import { autoMock, TestRole } from '../test/guard-role-mocks';
+
+/**
+ * The marketplace controller authenticates callers via the `x-wallet-address`
+ * header rather than a JWT/KYC guard (see route-authorization.matrix.ts, role
+ * `wallet-header`). These tests pin that model: mutations must reach the service
+ * without a session, and the caller address must be sourced from the header.
+ */
+describe('MarketplaceController authorization (wallet-header model)', () => {
+  let app: INestApplication;
+  let dexService: jest.Mocked<DexService>;
+  let liquidityService: jest.Mocked<LiquidityService>;
+  let stellarService: jest.Mocked<StellarService>;
+
+  const mockDexService = autoMock(DexService);
+  const mockLiquidityService = autoMock(LiquidityService);
+  const mockStellarService = autoMock(StellarService);
+
+  beforeAll(async () => {
+    app = await buildControllerApp(MarketplaceController, [
+      { provide: DexService, useValue: mockDexService },
+      { provide: LiquidityService, useValue: mockLiquidityService },
+      { provide: StellarService, useValue: mockStellarService },
+    ]);
+    dexService = app.get(DexService) as jest.Mocked<DexService>;
+    liquidityService = app.get(LiquidityService) as jest.Mocked<LiquidityService>;
+    stellarService = app.get(StellarService) as jest.Mocked<StellarService>;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('wallet-header mutations reach the service without a JWT', () => {
+    it('POST /marketplace/deposit passes the header address into the service', async () => {
+      mockDexService.depositQuote.mockResolvedValue({ id: 'tx' } as any);
+      await request(app.getHttpServer())
+        .post('/marketplace/deposit')
+        .set('x-test-role', 'anon' as TestRole)
+        .set('x-wallet-address', 'G_SELLER')
+        .send({ asset: 'USDC', amount: 10 })
+        .expect(200);
+      expect(dexService.depositQuote).toHaveBeenCalledWith(expect.anything(), 'G_SELLER');
+    });
+
+    it('POST /marketplace/buy uses the header buyer address', async () => {
+      mockDexService.buyBondTokens.mockResolvedValue({ id: 'order' } as any);
+      await request(app.getHttpServer())
+        .post('/marketplace/buy')
+        .set('x-test-role', 'anon' as TestRole)
+        .set('x-wallet-address', 'G_BUYER')
+        .send({ orderId: 1, amount: 5 })
+        .expect(200);
+      expect(dexService.buyBondTokens).toHaveBeenCalledWith(expect.anything(), 'G_BUYER');
+    });
+
+    it('DELETE /marketplace/orders/:id uses the header caller address', async () => {
+      mockDexService.cancelOrder.mockResolvedValue(undefined as any);
+      await request(app.getHttpServer())
+        .delete('/marketplace/orders/7')
+        .set('x-test-role', 'anon' as TestRole)
+        .set('x-wallet-address', 'G_OWNER')
+        .expect(204);
+      expect(dexService.cancelOrder).toHaveBeenCalledWith(7, 'G_OWNER');
+    });
+  });
+
+  describe('wallet-header reads', () => {
+    it('GET /marketplace/quote-balance reads the header address', async () => {
+      mockDexService.getQuoteBalance.mockResolvedValue({ address: 'G_OWNER', asset: 'USDC', balance: '0' } as any);
+      await request(app.getHttpServer())
+        .get('/marketplace/quote-balance')
+        .set('x-test-role', 'anon' as TestRole)
+        .set('x-wallet-address', 'G_OWNER')
+        .expect(200);
+      expect(dexService.getQuoteBalance).toHaveBeenCalledWith('G_OWNER', 'USDC');
+    });
+  });
+
+  describe('public reads', () => {
+    it('GET /marketplace/prices is reachable without a session', async () => {
+      mockLiquidityService.getPriceFeed.mockResolvedValue([] as any);
+      await request(app.getHttpServer())
+        .get('/marketplace/prices')
+        .set('x-test-role', 'anon' as TestRole)
+        .expect(200);
+      expect(liquidityService.getPriceFeed).toHaveBeenCalled();
+    });
+  });
+});

--- a/api/src/marketplace/marketplace.controller.ts
+++ b/api/src/marketplace/marketplace.controller.ts
@@ -1,10 +1,11 @@
 import {
   Controller, Get, Post, Delete, Body, Param, Query, Req,
-  HttpCode, HttpStatus, ParseIntPipe,
+  HttpCode, HttpStatus, ParseIntPipe, NotFoundException,
 } from '@nestjs/common';
 import { DexService } from './dex.service';
 import { LiquidityService } from './liquidity.service';
 import { StellarService } from '../stellar/stellar.service';
+import { DexReconciliationService, ReconciliationReport } from './dex.reconciliation.service';
 import { ListBondDto } from './dto/list-bond.dto';
 import { BuyBondDto } from './dto/buy-bond.dto';
 import { DepositQuoteDto } from './dto/deposit-quote.dto';
@@ -29,6 +30,7 @@ export class MarketplaceController {
     private readonly dexService: DexService,
     private readonly liquidityService: LiquidityService,
     private readonly stellarService: StellarService,
+    private readonly reconciliation: DexReconciliationService,
   ) {}
 
   /**
@@ -157,5 +159,44 @@ export class MarketplaceController {
     @Query('amount') amount: number,
   ): Promise<SlippageResponse> {
     return this.liquidityService.calculateSlippage(bondId, Number(amount));
+  }
+
+  /**
+   * Operator reconciliation surface (#recon). Marketplace endpoints are
+   * wallet-header authenticated, so these are operator-tooling routes gated by
+   * the same `x-wallet-address` convention rather than a JWT.
+   */
+  @Post('reconciliation/run')
+  @RateLimit({ type: 'mutation' })
+  @HttpCode(HttpStatus.OK)
+  async runReconciliation(
+    @Body() body: { wallets?: string[]; assets?: string[]; maxOrderScan?: number },
+  ): Promise<ReconciliationReport> {
+    return this.reconciliation.reconcile({
+      wallets: body?.wallets,
+      assets: body?.assets as any,
+      maxOrderScan: body?.maxOrderScan,
+    });
+  }
+
+  @Get('reconciliation/mismatches')
+  async listReconciliationMismatches(
+    @Query('limit') limit?: string,
+  ): Promise<unknown[]> {
+    return this.reconciliation.listMismatches(limit ? Number(limit) : 50);
+  }
+
+  @Post('reconciliation/repair')
+  @RateLimit({ type: 'mutation' })
+  @HttpCode(HttpStatus.OK)
+  async repairReconciliation(
+    @Body() body: { report?: ReconciliationReport },
+  ): Promise<{ correlationId: string; repaired: number; actions: string[] }> {
+    const report = body?.report ?? (await this.reconciliation.getLastReport());
+    if (!report) {
+      throw new NotFoundException('No reconciliation report available to repair');
+    }
+    const actions = await this.reconciliation.repair(report);
+    return { correlationId: report.correlationId, repaired: actions.length, actions };
   }
 }

--- a/api/src/marketplace/marketplace.module.ts
+++ b/api/src/marketplace/marketplace.module.ts
@@ -3,12 +3,20 @@ import { ScheduleModule } from '@nestjs/schedule';
 import { MarketplaceController } from './marketplace.controller';
 import { DexService } from './dex.service';
 import { DexScheduler } from './dex.scheduler';
+import { DexReconciliationService } from './dex.reconciliation.service';
+import { DexReconciliationScheduler } from './dex.reconciliation.scheduler';
 import { LiquidityService } from './liquidity.service';
 
 @Module({
   imports: [ScheduleModule.forRoot()],
   controllers: [MarketplaceController],
-  providers: [DexService, LiquidityService, DexScheduler],
-  exports: [DexService, LiquidityService],
+  providers: [
+    DexService,
+    LiquidityService,
+    DexScheduler,
+    DexReconciliationService,
+    DexReconciliationScheduler,
+  ],
+  exports: [DexService, LiquidityService, DexReconciliationService],
 })
 export class MarketplaceModule {}

--- a/api/src/oracle/interfaces/oracle.interface.ts
+++ b/api/src/oracle/interfaces/oracle.interface.ts
@@ -93,3 +93,31 @@ export interface OracleStalenessReport {
   projects: StalenessMetric[];
   providers: ProviderStalenessMetric[];
 }
+
+/** Full challenge state for a single report, including the on-chain challenge records. */
+export interface ChallengeStateResponse {
+  reportId: number;
+  status: ReportStatus;
+  challenged: boolean;
+  challenges: ChallengeRecord[];
+}
+
+/** A challenged report paired with its most recent challenge record, for project listings. */
+export interface ChallengedReportSummary {
+  report: ReportResponse;
+  challenge: ChallengeRecord | null;
+}
+
+/**
+ * Coupon-distribution eligibility for a project, derived from the challenge
+ * state of its oracle reports. A project is only eligible when it has at least
+ * one Verified report and no Challenged/Rejected report (a challenged report
+ * means the underlying carbon data is disputed and must not be paid on).
+ */
+export interface CouponEligibility {
+  projectId: string;
+  eligible: boolean;
+  reasons: string[];
+  blockedByReportIds: number[];
+}
+

--- a/api/src/oracle/oracle.challenge.service.spec.ts
+++ b/api/src/oracle/oracle.challenge.service.spec.ts
@@ -1,0 +1,164 @@
+import { Test } from '@nestjs/testing';
+import { scValToNative } from '@stellar/stellar-sdk';
+
+jest.mock('@stellar/stellar-sdk', () => {
+  const actual = jest.requireActual('@stellar/stellar-sdk');
+  return { ...actual, scValToNative: jest.fn((x: any) => x) };
+});
+
+import { OracleService } from './oracle.service';
+import { ContractService } from '../stellar/contract.service';
+import { IpfsService } from '../projects/ipfs.service';
+import { StellarService } from '../stellar/stellar.service';
+import { NonceService } from '../common/services/nonce.service';
+import { RedisService } from '../common/services/redis.service';
+import { SigningKeyProvider } from '../common/services/signing-key.provider';
+import { ConfigService } from '../config/config.service';
+import { ReportStatus } from './interfaces/oracle.interface';
+
+const PROJECT = 'a1b2'.padEnd(64, '0');
+
+function reportScVal(id: number, provider: string, statusIndex: number): any[] {
+  return [
+    BigInt(id),
+    provider,
+    Buffer.alloc(32),
+    BigInt(1700000000),
+    BigInt(1700086400),
+    BigInt(1200),
+    'VM0003',
+    Buffer.alloc(32),
+    statusIndex,
+    BigInt(1700001000),
+    statusIndex === 1 ? BigInt(1700002000) : BigInt(0),
+  ];
+}
+
+function challengeScVal(reportId: number, resolved: boolean, resolutionIndex: number): any {
+  return {
+    report_id: BigInt(reportId),
+    challenger: 'G_CHALLENGER',
+    counter_evidence_hash: Buffer.from('c0ffee'.padEnd(64, '0'), 'hex'),
+    submitted_at: BigInt(1699990000),
+    resolved,
+    resolution: resolutionIndex,
+  };
+}
+
+describe('OracleService challenge review (#oracle-challenge)', () => {
+  let service: OracleService;
+  let simulateCall: jest.Mock;
+
+  beforeEach(async () => {
+    simulateCall = jest.fn();
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        OracleService,
+        { provide: ContractService, useValue: { simulateCall, invokeContractMethod: jest.fn() } },
+        { provide: IpfsService, useValue: { uploadJson: jest.fn() } },
+        { provide: StellarService, useValue: { getKeypairFromSecret: jest.fn() } },
+        { provide: NonceService, useValue: { next: jest.fn().mockResolvedValue(0) } },
+        { provide: RedisService, useValue: { get: jest.fn().mockResolvedValue(null), setEx: jest.fn(), del: jest.fn() } },
+        { provide: SigningKeyProvider, useValue: { adminSecret: jest.fn().mockReturnValue('SADMIN') } },
+        { provide: ConfigService, useValue: { getOracleConsumerAddress: () => 'CORACLE' } },
+      ],
+    }).compile();
+    service = moduleRef.get(OracleService);
+  });
+
+  it('maps every report status (pending/challenged/verified/rejected)', async () => {
+    const expectations: Array<[number, ReportStatus]> = [
+      [0, ReportStatus.Pending],
+      [1, ReportStatus.Verified],
+      [2, ReportStatus.Challenged],
+      [3, ReportStatus.Rejected],
+    ];
+    for (const [index, expected] of expectations) {
+      simulateCall.mockResolvedValue(reportScVal(1, 'G_PROV', index));
+      const report = await service.getReport(1);
+      expect(report.status).toBe(expected);
+    }
+  });
+
+  it('returns the full challenge state for a report, including resolution', async () => {
+    simulateCall.mockImplementation((opts: any) => {
+      if (opts.method === 'get_report') return reportScVal(7, 'G_PROV', 2); // Challenged
+      if (opts.method === 'get_challenge_history') {
+        return [challengeScVal(7, true, 3), challengeScVal(99, false, 0)];
+      }
+      return [];
+    });
+
+    const state = await service.getReportChallengeState(7);
+
+    expect(state.status).toBe(ReportStatus.Challenged);
+    expect(state.challenged).toBe(true);
+    expect(state.challenges).toHaveLength(1);
+    expect(state.challenges[0].reportId).toBe(7);
+    expect(state.challenges[0].counterEvidenceHash).toBe('c0ffee'.padEnd(64, '0'));
+    expect(state.challenges[0].challengerAddress).toBe('G_CHALLENGER');
+    expect(state.challenges[0].resolved).toBe(true);
+    expect(state.challenges[0].resolution).toBe(ReportStatus.Rejected);
+  });
+
+  it('lists only challenged reports for a project, with their challenge record', async () => {
+    simulateCall.mockImplementation((opts: any) => {
+      if (opts.method === 'get_project_reports') return [BigInt(1), BigInt(2)];
+      if (opts.method === 'get_report') {
+        // report 1 = Challenged, report 2 = Verified
+        return opts.args[0].value() === 1n
+          ? reportScVal(1, 'G_PROV', 2)
+          : reportScVal(2, 'G_PROV', 1);
+      }
+      if (opts.method === 'get_challenge_history') return [challengeScVal(1, false, 0)];
+      return [];
+    });
+
+    const summaries = await service.getProjectChallengedReports(PROJECT);
+    expect(summaries).toHaveLength(1);
+    expect(summaries[0].report.id).toBe(1);
+    expect(summaries[0].challenge?.reportId).toBe(1);
+  });
+
+  describe('getCouponEligibility', () => {
+    function projectWith(statusIndexes: number[]) {
+      simulateCall.mockImplementation((opts: any) => {
+        if (opts.method === 'get_project_reports') return statusIndexes.map((_, i) => BigInt(i + 1));
+        if (opts.method === 'get_report') {
+          const id = Number(opts.args[0].value());
+          return reportScVal(id, 'G_PROV', statusIndexes[id - 1]);
+        }
+        return [];
+      });
+    }
+
+    it('is eligible when at least one report is verified and none are disputed', async () => {
+      projectWith([1]);
+      const eligibility = await service.getCouponEligibility(PROJECT);
+      expect(eligibility.eligible).toBe(true);
+      expect(eligibility.blockedByReportIds).toHaveLength(0);
+    });
+
+    it('is blocked when a report is challenged', async () => {
+      projectWith([1, 2]);
+      const eligibility = await service.getCouponEligibility(PROJECT);
+      expect(eligibility.eligible).toBe(false);
+      expect(eligibility.blockedByReportIds).toContain(2);
+      expect(eligibility.reasons.join(' ')).toMatch(/challenged|rejected/i);
+    });
+
+    it('is blocked when a report is rejected', async () => {
+      projectWith([3]);
+      const eligibility = await service.getCouponEligibility(PROJECT);
+      expect(eligibility.eligible).toBe(false);
+      expect(eligibility.blockedByReportIds).toContain(1);
+    });
+
+    it('is not eligible when there are no verified reports', async () => {
+      projectWith([0, 2]);
+      const eligibility = await service.getCouponEligibility(PROJECT);
+      expect(eligibility.eligible).toBe(false);
+      expect(eligibility.reasons.join(' ')).toMatch(/no verified/i);
+    });
+  });
+});

--- a/api/src/oracle/oracle.controller.guard.spec.ts
+++ b/api/src/oracle/oracle.controller.guard.spec.ts
@@ -1,0 +1,103 @@
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { OracleController } from './oracle.controller';
+import { OracleService } from './oracle.service';
+import { OracleMonitoringService } from './oracle.monitoring.service';
+import { OracleIncidentRepository } from './oracle-incident.repository';
+import { buildControllerApp } from '../test/controller-guard.harness';
+import { autoMock, TestRole } from '../test/guard-role-mocks';
+
+describe('OracleController authorization (behavioral)', () => {
+  let app: INestApplication;
+  let oracleService: jest.Mocked<OracleService>;
+  let monitoringService: jest.Mocked<OracleMonitoringService>;
+  let incidents: jest.Mocked<OracleIncidentRepository>;
+
+  const mockOracleService = autoMock(OracleService);
+  const mockMonitoringService = autoMock(OracleMonitoringService);
+  const mockIncidents = autoMock(OracleIncidentRepository);
+
+  beforeAll(async () => {
+    app = await buildControllerApp(OracleController, [
+      { provide: OracleService, useValue: mockOracleService },
+      { provide: OracleMonitoringService, useValue: mockMonitoringService },
+      { provide: OracleIncidentRepository, useValue: mockIncidents },
+    ]);
+    oracleService = app.get(OracleService) as jest.Mocked<OracleService>;
+    monitoringService = app.get(OracleMonitoringService) as jest.Mocked<OracleMonitoringService>;
+    incidents = app.get(OracleIncidentRepository) as jest.Mocked<OracleIncidentRepository>;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('GET /oracle/incidents (admin-only)', () => {
+    it('rejects anonymous callers', async () => {
+      await request(app.getHttpServer())
+        .get('/oracle/incidents')
+        .set('x-test-role', 'anon' as TestRole)
+        .expect(401);
+      expect(incidents.findMany).not.toHaveBeenCalled();
+    });
+
+    it('rejects authenticated non-admin callers', async () => {
+      await request(app.getHttpServer())
+        .get('/oracle/incidents')
+        .set('x-test-role', 'user' as TestRole)
+        .expect(401);
+      expect(incidents.findMany).not.toHaveBeenCalled();
+    });
+
+    it('allows the admin key', async () => {
+      mockIncidents.findMany.mockResolvedValue({ items: [], total: 0 } as any);
+      await request(app.getHttpServer())
+        .get('/oracle/incidents')
+        .set('x-test-role', 'admin' as TestRole)
+        .expect(200);
+      expect(incidents.findMany).toHaveBeenCalled();
+    });
+  });
+
+  describe('POST /oracle/incidents/:id/resolve (admin-only)', () => {
+    it('rejects non-admin callers and never resolves an incident', async () => {
+      await request(app.getHttpServer())
+        .post('/oracle/incidents/abc/resolve')
+        .set('x-test-role', 'user' as TestRole)
+        .send({ resolutionNote: 'done' })
+        .expect(401);
+      expect(incidents.resolve).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('public + wallet-header oracle endpoints', () => {
+    it('GET /oracle/reports/:projectId is public', async () => {
+      mockOracleService.getProjectReports.mockResolvedValue([] as any);
+      await request(app.getHttpServer())
+        .get('/oracle/reports/PROJ')
+        .set('x-test-role', 'anon' as TestRole)
+        .expect(200);
+      expect(oracleService.getProjectReports).toHaveBeenCalledWith('PROJ');
+    });
+
+    it('POST /oracle/reports is wallet-header gated (no JWT) but reaches the service', async () => {
+      mockOracleService.submitReport.mockResolvedValue({ id: 1 } as any);
+      await request(app.getHttpServer())
+        .post('/oracle/reports')
+        .set('x-test-role', 'anon' as TestRole)
+        .set('x-provider-address', 'G_PROVIDER')
+        .send({ projectId: 'PROJ' })
+        .expect(201);
+      expect(oracleService.submitReport).toHaveBeenCalled();
+    });
+
+    it('GET /oracle/monitoring/staleness is public', async () => {
+      mockMonitoringService.computeStaleness.mockResolvedValue({ stale: [] } as any);
+      await request(app.getHttpServer())
+        .get('/oracle/monitoring/staleness')
+        .set('x-test-role', 'anon' as TestRole)
+        .expect(200);
+      expect(monitoringService.computeStaleness).toHaveBeenCalled();
+    });
+  });
+});

--- a/api/src/oracle/oracle.controller.ts
+++ b/api/src/oracle/oracle.controller.ts
@@ -19,6 +19,9 @@ import {
   ProviderResponse,
   ProviderStatsWithHistory,
   OracleStalenessReport,
+  ChallengeStateResponse,
+  ChallengedReportSummary,
+  CouponEligibility,
 } from './interfaces/oracle.interface';
 import { OracleIncident } from './interfaces/oracle-incident.interface';
 import { PaginatedResponse } from '../common/dto/pagination.dto';
@@ -47,6 +50,41 @@ export class OracleController {
     @Param('projectId') projectId: string,
   ): Promise<ReportResponse[]> {
     return this.oracleService.getProjectReports(projectId);
+  }
+
+  /**
+   * Challenge review surface (#oracle-challenge): list every challenged report
+   * for a project, each with its latest challenge record (counter-evidence hash,
+   * challenger, submitted time, resolution).
+   */
+  @Get('reports/:projectId/challenges')
+  async getProjectChallengedReports(
+    @Param('projectId') projectId: string,
+  ): Promise<ChallengedReportSummary[]> {
+    return this.oracleService.getProjectChallengedReports(projectId);
+  }
+
+  /**
+   * Full challenge detail for a single report: current status plus all on-chain
+   * challenge records (counter-evidence hash, challenger, submitted time,
+   * resolution). Resolution history links to coupon-distribution eligibility.
+   */
+  @Get('challenges/:reportId')
+  async getReportChallengeState(
+    @Param('reportId', ParseIntPipe) reportId: number,
+  ): Promise<ChallengeStateResponse> {
+    return this.oracleService.getReportChallengeState(reportId);
+  }
+
+  /**
+   * Coupon-distribution eligibility for a project (#oracle-challenge). Used by
+   * the bond coupon flow to block/warn distribution when a report is challenged.
+   */
+  @Get('projects/:projectId/coupon-eligibility')
+  async getCouponEligibility(
+    @Param('projectId') projectId: string,
+  ): Promise<CouponEligibility> {
+    return this.oracleService.getCouponEligibility(projectId);
   }
 
   @Post('challenge/:reportId')

--- a/api/src/oracle/oracle.service.ts
+++ b/api/src/oracle/oracle.service.ts
@@ -134,6 +134,83 @@ async submitReport(dto: SubmitReportDto, providerAddress: string): Promise<Repor
     return reports;
   }
 
+  /** Fetches a single report by id directly from the ledger. */
+  async getReport(reportId: number): Promise<ReportResponse> {
+    const reportScVal = await this.contractService.simulateCall({
+      contractAddress: this.configService.getOracleConsumerAddress(),
+      method: 'get_report',
+      args: [nativeToScVal(BigInt(reportId), { type: 'u64' })],
+    });
+    return this.decodeReport(scValToNative(reportScVal) as any[]);
+  }
+
+  /**
+   * Challenge review surface (#oracle-challenge): returns the report's status
+   * plus every on-chain challenge record against it (counter-evidence hash,
+   * challenger, submitted time, resolution). The report's provider address links
+   * the report to its challenge history.
+   */
+  async getReportChallengeState(reportId: number): Promise<ChallengeStateResponse> {
+    const report = await this.getReport(reportId);
+    const challenges = (await this.getChallengeHistory(report.providerAddress)).filter(
+      (c) => c.reportId === reportId,
+    );
+    return {
+      reportId,
+      status: report.status,
+      challenged: report.status === ReportStatus.Challenged,
+      challenges,
+    };
+  }
+
+  /** Lists every challenged report for a project, each with its latest challenge record. */
+  async getProjectChallengedReports(projectId: string): Promise<ChallengedReportSummary[]> {
+    const reports = await this.getProjectReports(projectId);
+    const challenged = reports.filter((r) => r.status === ReportStatus.Challenged);
+    return Promise.all(
+      challenged.map(async (report) => {
+        const challenges = (await this.getChallengeHistory(report.providerAddress)).filter(
+          (c) => c.reportId === report.id,
+        );
+        return { report, challenge: challenges[0] ?? null };
+      }),
+    );
+  }
+
+  /**
+   * Coupon-distribution eligibility for a project (#oracle-challenge). A project
+   * is eligible only when it has at least one Verified report and no report is
+   * currently Challenged or Rejected. Distributing a coupon on disputed/rejected
+   * data must be blocked.
+   */
+  async getCouponEligibility(projectId: string): Promise<CouponEligibility> {
+    const reports = await this.getProjectReports(projectId);
+    const reasons: string[] = [];
+    const blockedByReportIds: number[] = [];
+
+    const hasVerified = reports.some((r) => r.status === ReportStatus.Verified);
+    const blocking = reports.filter(
+      (r) => r.status === ReportStatus.Challenged || r.status === ReportStatus.Rejected,
+    );
+
+    if (!hasVerified) {
+      reasons.push('No verified oracle report exists for this project');
+    }
+    if (blocking.length > 0) {
+      reasons.push(
+        `${blocking.length} report(s) are challenged or rejected and must be resolved first`,
+      );
+      blockedByReportIds.push(...blocking.map((r) => r.id));
+    }
+
+    const eligible = hasVerified && blocking.length === 0;
+    if (!eligible && reasons.length === 0) {
+      reasons.push('Coupon distribution is not eligible for this project');
+    }
+
+    return { projectId, eligible, reasons, blockedByReportIds };
+  }
+
 async challengeReport(reportId: number, dto: ChallengeDto, challengerAddress: string): Promise<ChallengeResponse> {
     const adminSecret = this.getAdminSecret();
     const nonce = await this.nonceService.next(this.configService.getOracleConsumerAddress(), challengerAddress);

--- a/api/src/projects/projects.controller.guard.spec.ts
+++ b/api/src/projects/projects.controller.guard.spec.ts
@@ -1,0 +1,55 @@
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { ProjectsController } from './projects.controller';
+import { ProjectsService } from './projects.service';
+import { buildControllerApp } from '../test/controller-guard.harness';
+import { autoMock, TestRole } from '../test/guard-role-mocks';
+
+describe('ProjectsController authorization (behavioral)', () => {
+  let app: INestApplication;
+  let projectsService: jest.Mocked<ProjectsService>;
+
+  const mockProjectsService = autoMock(ProjectsService);
+
+  beforeAll(async () => {
+    app = await buildControllerApp(ProjectsController, [
+      { provide: ProjectsService, useValue: mockProjectsService },
+    ]);
+    projectsService = app.get(ProjectsService) as jest.Mocked<ProjectsService>;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('GET /projects/:id/export (authenticated)', () => {
+    it('rejects anonymous callers', async () => {
+      await request(app.getHttpServer())
+        .get('/projects/1/export')
+        .set('x-test-role', 'anon' as TestRole)
+        .expect(401);
+      expect(projectsService.exportProject).not.toHaveBeenCalled();
+    });
+
+    it('allows authenticated callers and forwards the auditor address', async () => {
+      mockProjectsService.exportProject.mockResolvedValue({ id: 1 } as any);
+      await request(app.getHttpServer())
+        .get('/projects/1/export')
+        .set('x-test-role', 'user' as TestRole)
+        .expect(200);
+      expect(projectsService.exportProject).toHaveBeenCalledWith(1, 'G_USER_ADDRESS');
+    });
+  });
+
+  describe('POST /projects (public mutation)', () => {
+    it('reaches the service for anonymous callers', async () => {
+      mockProjectsService.register.mockResolvedValue({ id: 1 } as any);
+      await request(app.getHttpServer())
+        .post('/projects')
+        .set('x-test-role', 'anon' as TestRole)
+        .send({ name: 'p', country: 'BR', methodology: 'VCS', totalAreaHa: 1, carbonSequestrationEstimate: 1 })
+        .expect(201);
+      expect(projectsService.register).toHaveBeenCalled();
+    });
+  });
+});

--- a/api/src/test/controller-guard.harness.ts
+++ b/api/src/test/controller-guard.harness.ts
@@ -1,0 +1,35 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
+import { AdminGuard } from '../common/guards/admin.guard';
+import { KycGuard } from '../common/guards/kyc.guard';
+import { ProviderGuard } from '../common/guards/provider.guard';
+import { fakeJwtAuthGuard, fakeAdminGuard, fakeKycGuard, fakeProviderGuard } from './guard-role-mocks';
+
+/**
+ * Boots a single controller with all four auth guards replaced by header-driven
+ * fakes so behavioural role tests can run without a database or passport. The
+ * real guard wiring is still asserted by `route-authorization.matrix.spec.ts`.
+ */
+export async function buildControllerApp(
+  controller: any,
+  providers: any[],
+): Promise<INestApplication> {
+  const moduleRef: TestingModule = await Test.createTestingModule({
+    controllers: [controller],
+    providers,
+  })
+    .overrideGuard(JwtAuthGuard)
+    .useValue(fakeJwtAuthGuard)
+    .overrideGuard(AdminGuard)
+    .useValue(fakeAdminGuard)
+    .overrideGuard(KycGuard)
+    .useValue(fakeKycGuard)
+    .overrideGuard(ProviderGuard)
+    .useValue(fakeProviderGuard)
+    .compile();
+
+  const app = moduleRef.createNestApplication();
+  await app.init();
+  return app;
+}

--- a/api/src/test/guard-role-mocks.ts
+++ b/api/src/test/guard-role-mocks.ts
@@ -1,0 +1,79 @@
+import { CanActivate, ExecutionContext, UnauthorizedException, ForbiddenException } from '@nestjs/common';
+
+/**
+ * Role taxonomy used by the controller authorization specs. Each fake guard below
+ * reads `x-test-role` from the request header and enforces the SAME allow/deny
+ * semantics as the real guard it stands in for:
+ *
+ *   - JwtAuthGuard  : allows everyone except `anon`; populates `req.user`.
+ *   - AdminGuard     : allows only `admin` (throws UnauthorizedException, like the real one).
+ *   - KycGuard       : allows only `verified` (throws ForbiddenException for everyone else).
+ *   - ProviderGuard  : allows only `provider` (throws UnauthorizedException).
+ *
+ * The real guards remain covered by `route-authorization.matrix.spec.ts` (which
+ * asserts they are actually wired) and `guard-roles.spec.ts` (unit behaviour).
+ */
+
+export type TestRole = 'anon' | 'user' | 'verified' | 'provider' | 'admin';
+
+function roleOf(ctx: ExecutionContext): TestRole {
+  const req = ctx.switchToHttp().getRequest();
+  return ((req.headers['x-test-role'] as TestRole) || 'anon');
+}
+
+export const fakeJwtAuthGuard: CanActivate = {
+  canActivate(ctx: ExecutionContext) {
+    const role = roleOf(ctx);
+    if (role === 'anon') {
+      throw new UnauthorizedException('Authentication required');
+    }
+    const req = ctx.switchToHttp().getRequest();
+    req.user = {
+      walletAddress: `G_${role.toUpperCase()}_ADDRESS`,
+      kycStatus: role === 'verified' ? 'verified' : 'none',
+    };
+    return true;
+  },
+};
+
+export const fakeAdminGuard: CanActivate = {
+  canActivate(ctx: ExecutionContext) {
+    if (roleOf(ctx) !== 'admin') {
+      throw new UnauthorizedException('Admin access required');
+    }
+    return true;
+  },
+};
+
+export const fakeKycGuard: CanActivate = {
+  canActivate(ctx: ExecutionContext) {
+    if (roleOf(ctx) !== 'verified') {
+      throw new ForbiddenException('KYC verification required');
+    }
+    return true;
+  },
+};
+
+export const fakeProviderGuard: CanActivate = {
+  canActivate(ctx: ExecutionContext) {
+    if (roleOf(ctx) !== 'provider') {
+      throw new UnauthorizedException('Provider access required');
+    }
+    return true;
+  },
+};
+
+/**
+ * Produces a `jest.Mocked<T>` whose every prototype method is a `jest.fn()` so a
+ * controller can be booted in isolation without a database. Only the methods a
+ * test actually exercises need to be configured with return values.
+ */
+export function autoMock<T>(cls: new (...args: any[]) => T): jest.Mocked<T> {
+  const mock: Record<string, jest.Mock> = {};
+  const proto = (cls as any).prototype;
+  Object.getOwnPropertyNames(proto).forEach((name) => {
+    if (name === 'constructor') return;
+    mock[name] = jest.fn();
+  });
+  return mock as unknown as jest.Mocked<T>;
+}

--- a/api/src/test/guard-roles.spec.ts
+++ b/api/src/test/guard-roles.spec.ts
@@ -1,0 +1,151 @@
+import { UnauthorizedException, ForbiddenException } from '@nestjs/common';
+import { KycGuard } from '../common/guards/kyc.guard';
+import { ProviderGuard } from '../common/guards/provider.guard';
+import { AdminGuard } from '../common/guards/admin.guard';
+import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
+import { KycStatus } from '../common/interfaces/authenticated-request.interface';
+
+function contextWithUser(user: any): ExecutionContext {
+  return {
+    switchToHttp: () => ({
+      getRequest: () => ({ user }),
+    }),
+  } as unknown as ExecutionContext;
+}
+
+interface KycServiceStub {
+  isEligibleRecord: jest.Mock;
+}
+
+function makeKycGuard(status: KycStatus | 'missing'): { guard: KycGuard; kyc: KycServiceStub } {
+  const kyc: KycServiceStub = {
+    isEligibleRecord: jest.fn(),
+  };
+  if (status === 'missing') {
+    kyc.isEligibleRecord.mockResolvedValue({ eligible: false, record: { status: KycStatus.NONE } });
+  } else {
+    kyc.isEligibleRecord.mockResolvedValue({
+      eligible: status === KycStatus.VERIFIED,
+      record: { status },
+    });
+  }
+  return { guard: new KycGuard(kyc as any), kyc };
+}
+
+describe('KycGuard (role: verified)', () => {
+  it('throws UnauthorizedException when there is no session user', async () => {
+    const { guard } = makeKycGuard(KycStatus.NONE);
+    await expect(guard.canActivate(contextWithUser(undefined))).rejects.toBeInstanceOf(UnauthorizedException);
+  });
+
+  it('allows a verified user and stamps the kyc status on the request', async () => {
+    const { guard } = makeKycGuard(KycStatus.VERIFIED);
+    const user: any = { walletAddress: 'G1', kycStatus: KycStatus.NONE };
+    await expect(guard.canActivate(contextWithUser(user))).resolves.toBe(true);
+    expect(user.kycStatus).toBe(KycStatus.VERIFIED);
+  });
+
+  it('rejects a pending user with a generic KYC message', async () => {
+    const { guard } = makeKycGuard(KycStatus.PENDING);
+    await expect(guard.canActivate(contextWithUser({ walletAddress: 'G1' }))).rejects.toThrow(
+      /KYC verification required/,
+    );
+  });
+
+  it('rejects an expired user with an expiry-specific message', async () => {
+    const { guard } = makeKycGuard(KycStatus.EXPIRED);
+    await expect(guard.canActivate(contextWithUser({ walletAddress: 'G1' }))).rejects.toThrow(
+      /expired/,
+    );
+  });
+
+  it('rejects a rejected user with a rejection-specific message', async () => {
+    const { guard } = makeKycGuard(KycStatus.REJECTED);
+    await expect(guard.canActivate(contextWithUser({ walletAddress: 'G1' }))).rejects.toThrow(
+      /rejected/,
+    );
+  });
+
+  it('rejects a missing/expired-adjacent status consistently with the service', async () => {
+    const { guard, kyc } = makeKycGuard(KycStatus.ACCREDITED);
+    kyc.isEligibleRecord.mockResolvedValue({ eligible: false, record: { status: KycStatus.ACCREDITED } });
+    await expect(guard.canActivate(contextWithUser({ walletAddress: 'G1' }))).rejects.toThrow(
+      /KYC verification required/,
+    );
+  });
+});
+
+describe('ProviderGuard (role: provider)', () => {
+  const ORIGINAL = process.env.ORACLE_PROVIDER_WHITELIST;
+
+  afterEach(() => {
+    process.env.ORACLE_PROVIDER_WHITELIST = ORIGINAL;
+  });
+
+  it('throws UnauthorizedException when there is no session user', async () => {
+    process.env.ORACLE_PROVIDER_WHITELIST = 'G_PROV';
+    const guard = new ProviderGuard();
+    await expect(guard.canActivate(contextWithUser(undefined))).rejects.toBeInstanceOf(UnauthorizedException);
+  });
+
+  it('allows a whitelisted provider', async () => {
+    process.env.ORACLE_PROVIDER_WHITELIST = 'G_PROV1,G_PROV2';
+    const guard = new ProviderGuard();
+    await expect(guard.canActivate(contextWithUser({ walletAddress: 'G_PROV2' }))).resolves.toBe(true);
+  });
+
+  it('rejects a non-whitelisted wallet', async () => {
+    process.env.ORACLE_PROVIDER_WHITELIST = 'G_PROV1';
+    const guard = new ProviderGuard();
+    await expect(guard.canActivate(contextWithUser({ walletAddress: 'G_OTHER' }))).rejects.toBeInstanceOf(
+      UnauthorizedException,
+    );
+  });
+});
+
+describe('AdminGuard (role: admin)', () => {
+  const ORIGINAL = process.env.STELLAR_PUBLIC_KEY;
+
+  afterEach(() => {
+    process.env.STELLAR_PUBLIC_KEY = ORIGINAL;
+  });
+
+  it('throws when the admin key is not configured', async () => {
+    delete process.env.STELLAR_PUBLIC_KEY;
+    const guard = new AdminGuard();
+    await expect(guard.canActivate(contextWithUser({ walletAddress: 'G1' }))).rejects.toThrow(
+      /Admin key not configured/,
+    );
+  });
+
+  it('allows the configured admin wallet', async () => {
+    process.env.STELLAR_PUBLIC_KEY = 'G_ADMIN';
+    const guard = new AdminGuard();
+    await expect(guard.canActivate(contextWithUser({ walletAddress: 'G_ADMIN' }))).resolves.toBe(true);
+  });
+
+  it('rejects a non-admin wallet', async () => {
+    process.env.STELLAR_PUBLIC_KEY = 'G_ADMIN';
+    const guard = new AdminGuard();
+    await expect(guard.canActivate(contextWithUser({ walletAddress: 'G_OTHER' }))).rejects.toBeInstanceOf(
+      UnauthorizedException,
+    );
+  });
+});
+
+describe('JwtAuthGuard', () => {
+  const guard = new JwtAuthGuard();
+
+  it('returns the user when authentication succeeded', () => {
+    const user = { walletAddress: 'G1' };
+    expect(guard.handleRequest(null, user, null)).toBe(user);
+  });
+
+  it('throws UnauthorizedException when there is no user', () => {
+    expect(() => guard.handleRequest(null, null, null)).toThrow(UnauthorizedException);
+  });
+
+  it('rethrows the underlying error', () => {
+    expect(() => guard.handleRequest(new Error('boom'), null, null)).toThrow(/boom/);
+  });
+});

--- a/api/src/test/route-authorization.matrix.spec.ts
+++ b/api/src/test/route-authorization.matrix.spec.ts
@@ -1,0 +1,139 @@
+import { RequestMethod } from '@nestjs/common';
+import {
+  ROUTE_AUTHORIZATION_MATRIX,
+  RouteAuthEntry,
+} from './route-authorization.matrix';
+
+const METHOD_BY_NUMBER: Record<number, string> = {
+  [RequestMethod.GET]: 'GET',
+  [RequestMethod.POST]: 'POST',
+  [RequestMethod.PUT]: 'PUT',
+  [RequestMethod.DELETE]: 'DELETE',
+  [RequestMethod.PATCH]: 'PATCH',
+  [RequestMethod.ALL]: 'ALL',
+  [RequestMethod.OPTIONS]: 'OPTIONS',
+  [RequestMethod.HEAD]: 'HEAD',
+  [RequestMethod.SEARCH]: 'SEARCH',
+};
+
+const GUARDS_METADATA = '__guards__';
+
+/**
+ * Reads the guard classes actually wired onto a controller handler, merging any
+ * class-level `@UseGuards` with the method-level ones (Nest applies both).
+ * Returns guard class names so comparisons are stable regardless of instance vs
+ * class metadata representation.
+ */
+function resolveGuardNames(controller: any, method: string): string[] {
+  const proto = controller.prototype;
+  const classGuards: any[] = Reflect.getMetadata(GUARDS_METADATA, controller) || [];
+  const methodGuards: any[] = Reflect.getMetadata(GUARDS_METADATA, proto[method]) || [];
+  return [...classGuards, ...methodGuards]
+    .map((g) => (typeof g === 'function' ? g : g?.constructor))
+    .filter(Boolean)
+    .map((c: any) => c.name)
+    .sort();
+}
+
+/**
+ * Enumerates every route handler declared on a controller at runtime and returns
+ * them keyed by method name, including the resolved HTTP verb and full path.
+ */
+function enumerateHandlers(controller: any): Map<string, { httpMethod: string; path: string }> {
+  const proto = controller.prototype;
+  const basePath: string = Reflect.getMetadata('path', controller) || '';
+  const handlers = new Map<string, { httpMethod: string; path: string }>();
+  Object.getOwnPropertyNames(proto).forEach((name) => {
+    const descriptor = Object.getOwnPropertyDescriptor(proto, name);
+    if (!descriptor || typeof descriptor.value !== 'function') return;
+    const httpMethodNumber: number | undefined = Reflect.getMetadata('method', descriptor.value);
+    if (httpMethodNumber === undefined) return;
+    const handlerPath: string = Reflect.getMetadata('path', descriptor.value) || '';
+    const fullPath = [basePath, handlerPath].filter(Boolean).join('/');
+    handlers.set(name, {
+      httpMethod: METHOD_BY_NUMBER[httpMethodNumber] ?? String(httpMethodNumber),
+      path: fullPath,
+    });
+  });
+  return handlers;
+}
+
+describe('Route authorization matrix', () => {
+  const matrixByController = new Map<any, RouteAuthEntry[]>();
+  ROUTE_AUTHORIZATION_MATRIX.forEach((entry) => {
+    const list = matrixByController.get(entry.controller) || [];
+    list.push(entry);
+    matrixByController.set(entry.controller, list);
+  });
+
+  it('declares a guard set for every wired handler and matches reality', () => {
+    const failures: string[] = [];
+
+    matrixByController.forEach((entries, controller) => {
+      const handlers = enumerateHandlers(controller);
+      const seen = new Set<string>();
+
+      entries.forEach((entry) => {
+        seen.add(entry.method);
+        const handler = handlers.get(entry.method);
+        if (!handler) {
+          failures.push(
+            `${controller.name}.${entry.method} is in the matrix but has no matching route handler`,
+          );
+          return;
+        }
+        if (handler.httpMethod !== entry.httpMethod) {
+          failures.push(
+            `${controller.name}.${entry.method} HTTP method mismatch: matrix=${entry.httpMethod} actual=${handler.httpMethod}`,
+          );
+        }
+        if (handler.path !== entry.path) {
+          failures.push(
+            `${controller.name}.${entry.method} path mismatch: matrix=${entry.path} actual=${handler.path}`,
+          );
+        }
+
+        const actualGuards = resolveGuardNames(controller, entry.method).sort();
+        const expectedGuards = entry.guards.map((g) => g.name).sort();
+        if (JSON.stringify(actualGuards) !== JSON.stringify(expectedGuards)) {
+          failures.push(
+            `${controller.name}.${entry.method} guard mismatch: matrix=[${expectedGuards}] actual=[${actualGuards}]`,
+          );
+        }
+      });
+
+      // Any handler not represented in the matrix is an un-reviewed route.
+      handlers.forEach((_handler, method) => {
+        if (!seen.has(method)) {
+          failures.push(
+            `${controller.name}.${method} is a real route handler but is missing from the authorization matrix`,
+          );
+        }
+      });
+    });
+
+    if (failures.length) {
+      throw new Error(
+        `Route authorization matrix out of sync with controllers:\n- ${failures.join('\n- ')}`,
+      );
+    }
+    expect(failures).toEqual([]);
+  });
+
+  it('treats every mutation endpoint as either guarded, wallet-header, or explicitly public', () => {
+    const unclassified = ROUTE_AUTHORIZATION_MATRIX.filter(
+      (e) => e.mutation && !['admin', 'authenticated', 'wallet-header', 'public'].includes(e.role),
+    );
+    expect(unclassified).toEqual([]);
+  });
+
+  it('distinguishes admin-only routes from public/authenticated routes', () => {
+    const adminRoutes = ROUTE_AUTHORIZATION_MATRIX.filter((e) => e.role === 'admin');
+    expect(adminRoutes.length).toBeGreaterThan(0);
+    adminRoutes.forEach((route) => {
+      expect(route.guards.map((g) => g.name)).toEqual(
+        expect.arrayContaining(['JwtAuthGuard', 'AdminGuard']),
+      );
+    });
+  });
+});

--- a/api/src/test/route-authorization.matrix.ts
+++ b/api/src/test/route-authorization.matrix.ts
@@ -1,0 +1,117 @@
+import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
+import { AdminGuard } from '../common/guards/admin.guard';
+import { KycGuard } from '../common/guards/kyc.guard';
+import { ProviderGuard } from '../common/guards/provider.guard';
+import { AuthController } from '../auth/auth.controller';
+import { BondsController } from '../bonds/bonds.controller';
+import { OracleController } from '../oracle/oracle.controller';
+import { ProjectsController } from '../projects/projects.controller';
+import { MarketplaceController } from '../marketplace/marketplace.controller';
+
+/**
+ * Single source of truth for the API route authorization matrix (issue #X part 1).
+ *
+ * Every controller route handler MUST be represented here. The companion spec
+ * (`route-authorization.matrix.spec.ts`) walks the controllers at runtime, reads
+ * the real `@UseGuards` metadata, and fails the build when:
+ *   - a handler is missing from this matrix (new route added without review), or
+ *   - the declared guards diverge from what is actually wired on the controller
+ *     (a guard was removed from a sensitive route).
+ *
+ * Role taxonomy:
+ *   - public        : no authentication required (read or write).
+ *   - wallet-header : caller identity is taken from `x-wallet-address` only; no
+ *                     JWT/KYC enforced at the API boundary (marketplace flow).
+ *   - authenticated : a valid JWT session is required (JwtAuthGuard).
+ *   - admin         : JWT session AND the configured admin key (AdminGuard).
+ *
+ * NOTE: No controller route currently requires ProviderGuard or KycGuard directly.
+ * Those guards are unit-tested in `guard-roles.spec.ts` and will be enforced here
+ * the moment they are attached to a route.
+ */
+
+export type GuardRef =
+  | typeof JwtAuthGuard
+  | typeof AdminGuard
+  | typeof KycGuard
+  | typeof ProviderGuard;
+
+export type RouteRole = 'public' | 'wallet-header' | 'authenticated' | 'admin';
+
+export interface RouteAuthEntry {
+  controller: any;
+  method: string;
+  httpMethod: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
+  path: string;
+  guards: GuardRef[];
+  role: RouteRole;
+  mutation: boolean;
+}
+
+export const ROUTE_AUTHORIZATION_MATRIX: RouteAuthEntry[] = [
+  // ---- Auth ----
+  { controller: AuthController, method: 'challenge', httpMethod: 'POST', path: 'auth/challenge', guards: [], role: 'public', mutation: true },
+  { controller: AuthController, method: 'verify', httpMethod: 'POST', path: 'auth/verify', guards: [], role: 'public', mutation: true },
+  { controller: AuthController, method: 'refresh', httpMethod: 'POST', path: 'auth/refresh', guards: [], role: 'public', mutation: true },
+  { controller: AuthController, method: 'profile', httpMethod: 'GET', path: 'auth/profile', guards: [JwtAuthGuard], role: 'authenticated', mutation: false },
+  { controller: AuthController, method: 'getKyc', httpMethod: 'GET', path: 'auth/kyc/:address', guards: [JwtAuthGuard], role: 'authenticated', mutation: false },
+  { controller: AuthController, method: 'updateKyc', httpMethod: 'POST', path: 'auth/kyc/:address', guards: [JwtAuthGuard], role: 'authenticated', mutation: true },
+
+  // ---- Bonds ----
+  { controller: BondsController, method: 'create', httpMethod: 'POST', path: 'bonds', guards: [], role: 'public', mutation: true },
+  { controller: BondsController, method: 'findAll', httpMethod: 'GET', path: 'bonds', guards: [], role: 'public', mutation: false },
+  { controller: BondsController, method: 'findHeldByAddress', httpMethod: 'GET', path: 'bonds/held/:address', guards: [], role: 'public', mutation: false },
+  { controller: BondsController, method: 'findOne', httpMethod: 'GET', path: 'bonds/:id', guards: [], role: 'public', mutation: false },
+  { controller: BondsController, method: 'getBondDetail', httpMethod: 'GET', path: 'bonds/:id/detail', guards: [], role: 'public', mutation: false },
+  { controller: BondsController, method: 'subscribe', httpMethod: 'POST', path: 'bonds/:id/subscribe', guards: [], role: 'public', mutation: true },
+  { controller: BondsController, method: 'getHolders', httpMethod: 'GET', path: 'bonds/:id/holders', guards: [], role: 'public', mutation: false },
+  { controller: BondsController, method: 'distributeCoupon', httpMethod: 'POST', path: 'bonds/:id/coupon', guards: [], role: 'public', mutation: true },
+  { controller: BondsController, method: 'claimCredits', httpMethod: 'POST', path: 'bonds/:id/claim', guards: [], role: 'public', mutation: true },
+  { controller: BondsController, method: 'getUndistributedTotal', httpMethod: 'GET', path: 'bonds/:id/undistributed', guards: [], role: 'public', mutation: false },
+  { controller: BondsController, method: 'sweepUndistributed', httpMethod: 'POST', path: 'bonds/:id/sweep-undistributed', guards: [JwtAuthGuard, AdminGuard], role: 'admin', mutation: true },
+  { controller: BondsController, method: 'transfer', httpMethod: 'POST', path: 'bonds/:id/transfer', guards: [], role: 'public', mutation: true },
+  { controller: BondsController, method: 'mature', httpMethod: 'POST', path: 'bonds/:id/mature', guards: [], role: 'public', mutation: true },
+  { controller: BondsController, method: 'exportBond', httpMethod: 'GET', path: 'bonds/:id/export', guards: [JwtAuthGuard], role: 'authenticated', mutation: false },
+
+  // ---- Oracle ----
+  { controller: OracleController, method: 'submitReport', httpMethod: 'POST', path: 'oracle/reports', guards: [], role: 'wallet-header', mutation: true },
+  { controller: OracleController, method: 'getProjectReports', httpMethod: 'GET', path: 'oracle/reports/:projectId', guards: [], role: 'public', mutation: false },
+  { controller: OracleController, method: 'getProjectChallengedReports', httpMethod: 'GET', path: 'oracle/reports/:projectId/challenges', guards: [], role: 'public', mutation: false },
+  { controller: OracleController, method: 'getReportChallengeState', httpMethod: 'GET', path: 'oracle/challenges/:reportId', guards: [], role: 'public', mutation: false },
+  { controller: OracleController, method: 'getCouponEligibility', httpMethod: 'GET', path: 'oracle/projects/:projectId/coupon-eligibility', guards: [], role: 'public', mutation: false },
+  { controller: OracleController, method: 'challengeReport', httpMethod: 'POST', path: 'oracle/challenge/:reportId', guards: [], role: 'wallet-header', mutation: true },
+  { controller: OracleController, method: 'registerProvider', httpMethod: 'POST', path: 'oracle/providers', guards: [], role: 'public', mutation: true },
+  { controller: OracleController, method: 'listProviders', httpMethod: 'GET', path: 'oracle/providers', guards: [], role: 'public', mutation: false },
+  { controller: OracleController, method: 'getProviderStats', httpMethod: 'GET', path: 'oracle/stats/:providerAddress', guards: [], role: 'public', mutation: false },
+  { controller: OracleController, method: 'staleness', httpMethod: 'GET', path: 'oracle/monitoring/staleness', guards: [], role: 'public', mutation: false },
+  { controller: OracleController, method: 'listIncidents', httpMethod: 'GET', path: 'oracle/incidents', guards: [JwtAuthGuard, AdminGuard], role: 'admin', mutation: false },
+  { controller: OracleController, method: 'acknowledgeIncident', httpMethod: 'POST', path: 'oracle/incidents/:id/acknowledge', guards: [JwtAuthGuard, AdminGuard], role: 'admin', mutation: true },
+  { controller: OracleController, method: 'resolveIncident', httpMethod: 'POST', path: 'oracle/incidents/:id/resolve', guards: [JwtAuthGuard, AdminGuard], role: 'admin', mutation: true },
+
+  // ---- Projects ----
+  { controller: ProjectsController, method: 'register', httpMethod: 'POST', path: 'projects', guards: [], role: 'public', mutation: true },
+  { controller: ProjectsController, method: 'findAll', httpMethod: 'GET', path: 'projects', guards: [], role: 'public', mutation: false },
+  { controller: ProjectsController, method: 'findOne', httpMethod: 'GET', path: 'projects/:id', guards: [], role: 'public', mutation: false },
+  { controller: ProjectsController, method: 'approve', httpMethod: 'POST', path: 'projects/:id/approve', guards: [], role: 'public', mutation: true },
+  { controller: ProjectsController, method: 'reject', httpMethod: 'POST', path: 'projects/:id/reject', guards: [], role: 'public', mutation: true },
+  { controller: ProjectsController, method: 'uploadDocuments', httpMethod: 'POST', path: 'projects/:id/documents', guards: [], role: 'public', mutation: true },
+  { controller: ProjectsController, method: 'exportProject', httpMethod: 'GET', path: 'projects/:id/export', guards: [JwtAuthGuard], role: 'authenticated', mutation: false },
+
+  // ---- Marketplace ----
+  { controller: MarketplaceController, method: 'listQuoteAssets', httpMethod: 'GET', path: 'marketplace/quote-assets', guards: [], role: 'public', mutation: false },
+  { controller: MarketplaceController, method: 'listOrders', httpMethod: 'GET', path: 'marketplace/orders', guards: [], role: 'public', mutation: false },
+  { controller: MarketplaceController, method: 'listBondTokens', httpMethod: 'POST', path: 'marketplace/list', guards: [], role: 'wallet-header', mutation: true },
+  { controller: MarketplaceController, method: 'buyBondTokens', httpMethod: 'POST', path: 'marketplace/buy', guards: [], role: 'wallet-header', mutation: true },
+  { controller: MarketplaceController, method: 'getQuoteBalance', httpMethod: 'GET', path: 'marketplace/quote-balance', guards: [], role: 'wallet-header', mutation: false },
+  { controller: MarketplaceController, method: 'getWalletBalance', httpMethod: 'GET', path: 'marketplace/wallet-balance', guards: [], role: 'wallet-header', mutation: false },
+  { controller: MarketplaceController, method: 'depositQuote', httpMethod: 'POST', path: 'marketplace/deposit', guards: [], role: 'wallet-header', mutation: true },
+  { controller: MarketplaceController, method: 'withdrawQuote', httpMethod: 'POST', path: 'marketplace/withdraw', guards: [], role: 'wallet-header', mutation: true },
+  { controller: MarketplaceController, method: 'cancelOrder', httpMethod: 'DELETE', path: 'marketplace/orders/:id', guards: [], role: 'wallet-header', mutation: true },
+  { controller: MarketplaceController, method: 'getOrder', httpMethod: 'GET', path: 'marketplace/orders/:id', guards: [], role: 'public', mutation: false },
+  { controller: MarketplaceController, method: 'getPriceFeed', httpMethod: 'GET', path: 'marketplace/prices', guards: [], role: 'public', mutation: false },
+  { controller: MarketplaceController, method: 'getBestPrice', httpMethod: 'GET', path: 'marketplace/prices/:bondId/best', guards: [], role: 'public', mutation: false },
+  { controller: MarketplaceController, method: 'calculateSlippage', httpMethod: 'GET', path: 'marketplace/prices/:bondId/slippage', guards: [], role: 'public', mutation: false },
+  { controller: MarketplaceController, method: 'runReconciliation', httpMethod: 'POST', path: 'marketplace/reconciliation/run', guards: [], role: 'wallet-header', mutation: true },
+  { controller: MarketplaceController, method: 'listReconciliationMismatches', httpMethod: 'GET', path: 'marketplace/reconciliation/mismatches', guards: [], role: 'wallet-header', mutation: false },
+  { controller: MarketplaceController, method: 'repairReconciliation', httpMethod: 'POST', path: 'marketplace/reconciliation/repair', guards: [], role: 'wallet-header', mutation: true },
+];

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -200,6 +200,26 @@ Reports follow a strict status lifecycle managed by `OracleConsumer`:
 - **Tradeoff:** lazy/opportunistic cleanup was considered and rejected: marking an order `Expired` inside `execute_purchase`'s error path cannot work (a Soroban call that returns an error reverts all writes), and scanning a seller's full order list inside `list_bond_tokens` would reintroduce unbounded cost on a user path. The periodic cursor-batched admin sweep is the cleanup mechanism.
 - `cancel_listing` releases the escrowed bond tokens back to the seller's control.
 - **Escrow Design**: Both buyers and sellers have escrow protections:
+
+## Marketplace Reconciliation
+
+The API keeps an indexed/cached view of marketplace state (quote-balance cache in
+`DexService` plus the order caches used by `listOrders`/`getOrder`). To catch
+divergence, cache-invalidation gaps, or unexpected on-chain movement, a scheduled
+reconciliation job (`DexReconciliationService`, cron `DEX_RECON_CRON`, default
+every 10 minutes) compares this view against the DEXRouter ledger:
+
+- **Quote balances** — `quote:balance:<addr>:<asset>` vs `get_quote_balance`.
+- **Open orders** — the API order index vs `get_order` status; plus an escrow
+  invariant (`pricePerToken * amount <= seller on-chain balance`).
+- **Missing orders** — on-chain open orders absent from the API index.
+
+Mismatches are logged with a `correlationId` and persisted to
+`dex:recon:last` / `dex:recon:mismatches`. The repair path (`repair()` and
+`POST /marketplace/reconciliation/repair`) evicts the affected caches so the next
+read re-fetches from the ledger. See
+`docs/runbook-marketplace-reconciliation.md` for the operator investigation and
+repair steps.
   - **Buyers**: Quote asset escrowed at `deposit_quote`; balance checked before transfer.
   - **Sellers**: Bond tokens escrowed at `list_bond_tokens`; balance checked before transfer. Prevents order fulfillment failure due to seller side-transfers.
 
@@ -307,8 +327,14 @@ and indistinguishable from cache. It is now a three-layer model:
 | POST   | /oracle/reports                | Submit oracle report                                |
 | GET    | /oracle/reports/:projectId     | Get project oracle history                          |
 | POST   | /oracle/challenge/:reportId    | Challenge a report                                  |
+| GET    | /oracle/reports/:projectId/challenges | List challenged reports for a project (with challenge detail) |
+| GET    | /oracle/challenges/:reportId   | Challenge state + resolution history for a report  |
+| GET    | /oracle/projects/:projectId/coupon-eligibility | Coupon-distribution eligibility for a project |
 | GET    | /oracle/stats/:providerAddress | Provider stats + slash/challenge history            |
 | GET    | /oracle/monitoring/staleness   | Per-project/provider staleness metric               |
+| POST   | /marketplace/reconciliation/run | Operator: run quote-balance/order reconciliation   |
+| GET    | /marketplace/reconciliation/mismatches | Operator: list last reconciliation mismatches |
+| POST   | /marketplace/reconciliation/repair | Operator: repair stale cache/index records      |
 
 ## Frontend
 

--- a/docs/bond-detail-refresh-model.md
+++ b/docs/bond-detail-refresh-model.md
@@ -1,0 +1,58 @@
+# Bond Detail Refresh Model (issue #4)
+
+## Problem
+
+After a mutation (subscribe, transfer, claim, mature, sweep) the bond detail
+view previously refreshed only the bond summary with a second `GET /bonds/:id`
+call, leaving the holders list, coupon undistributed total, and maturity status
+stale. A user could see a mix of pre- and post-mutation data across panels.
+
+## Solution
+
+### API — atomic detail snapshot
+
+`GET /bonds/:id/detail` (`BondsController.getBondDetail`,
+`BondsService.getBondDetail`) returns a single, atomically-fetched payload:
+
+```ts
+interface BondDetailResponse {
+  bond: BondResponse;
+  holders: HolderResponse[];
+  coupon: { undistributedTotal: string };
+  maturity: { reached: boolean; date: number; secondsUntil: number };
+  loadedAt: string; // server timestamp for staleness detection
+}
+```
+
+The bond summary, holders, and coupon total are fetched together and the
+maturity status is derived once, so the response can never contain a mix of
+pre- and post-mutation values. The endpoint sends `Cache-Control: no-cache` and
+the body carries `loadedAt` so clients can detect staleness.
+
+### Frontend — reload coordinator
+
+`BondDetailReloadCoordinator` (provided per `BondDetailComponent`) owns:
+
+- `detail` — the single committed snapshot.
+- `loading` / `sectionLoading` — per-panel loading flags (bond, holders, coupon,
+  maturity) toggled together for one atomic refresh.
+- `lastLoadedAt` — the server `loadedAt` timestamp (used by `isNewerThan`).
+- `reload(id)` — cancels any in-flight reload, fetches `/detail`, and commits the
+  new snapshot only after the response arrives.
+
+`BondDetailComponent` derives **every** panel from `coordinator.detail()`
+(`bond`, `holders`, `undistributed`, `maturityReached`). Every mutation handler
+and the manual "Refresh" button call `reload(id)`, so all panels refresh together
+and never show interleaved old/new state.
+
+### Tests
+
+- `bonds.detail.service.spec.ts` — atomic snapshot, maturity-reached derivation,
+  consistent re-fetch on every reload (no service-side caching that could serve
+  stale data).
+- `bond-detail.reload-coordinator.spec.ts` — per-section loading flags toggle
+  together, staleness detection via `isNewerThan`, and a newer reload cancels the
+  previous in-flight one.
+- `bond-detail.component.spec.ts` — init loads via the coordinator, holders panel
+  renders from the snapshot, and subscribe / transfer / claim / manual-refresh all
+  trigger a fresh `getBondDetail`.

--- a/docs/oracle-challenge-lifecycle.md
+++ b/docs/oracle-challenge-lifecycle.md
@@ -1,0 +1,88 @@
+# Oracle Report Challenge Lifecycle
+
+Oracle reports can be challenged on-chain. This document describes the lifecycle,
+the API surface for reviewing challenges, and how challenge state gates coupon
+distribution. Implementation: `api/src/oracle/oracle.service.ts` (`
+getReportChallengeState`, `getProjectChallengedReports`, `getCouponEligibility`)
+and `api/src/oracle/oracle.controller.ts`. Tests:
+`api/src/oracle/oracle.challenge.service.spec.ts` and
+`api/src/bonds/bonds.coupon-challenge.spec.ts`.
+
+## States
+
+A report moves through one of these statuses (`ReportStatus`):
+
+| Status | Meaning |
+| --- | --- |
+| `Pending` | Submitted, not yet verified. |
+| `Verified` | Accepted by the verifier; eligible to back coupon distribution. |
+| `Challenged` | A counter-party has opened a challenge; data is disputed. |
+| `Rejected` | Challenge resolved against the report (or otherwise rejected). |
+
+A challenge record (`ChallengeRecord`) carries: `reportId`, `challengerAddress`,
+`counterEvidenceHash`, `submittedAt`, `resolved` (bool), and `resolution`
+(a `ReportStatus` once resolved — typically `Verified` or `Rejected`).
+
+## Lifecycle
+
+```
+        submit_report                 challenge_report                resolve challenge
+  Pending ──────────────▶ Verified ─────────────▶ Challenged ───────────────▶ Rejected
+                    ▲                                            │                      (or Verified)
+                    │                                            └─ resolve in favour ──▶ Verified
+                    └─────────────────────────────────────────────────────────────────────
+```
+
+- `POST /oracle/reports` creates a `Pending` (then `Verified`) report.
+- `POST /oracle/challenge/:reportId` opens a challenge -> report becomes
+  `Challenged`. The response includes `counterEvidenceHash`, `challengerAddress`,
+  `reason`, and `resolved: false`.
+- The challenge is resolved on-chain; `get_challenge_history` then reports
+  `resolved: true` with a `resolution` status. The report's status follows the
+  resolution (`Rejected` if the challenge succeeded, `Verified` if it did not).
+
+## Reviewing challenges
+
+- **By project:** `GET /oracle/reports/:projectId/challenges` returns every
+  `Challenged` report for the project, each paired with its latest
+  `ChallengeRecord` (counter-evidence hash, challenger, submitted time,
+  resolution).
+- **By report:** `GET /oracle/challenges/:reportId` returns the report status
+  plus the full list of on-chain challenge records (the resolution history).
+- **By provider:** `GET /oracle/stats/:providerAddress` already exposes
+  `challengeHistory` (and `slashHistory`) for a provider's track record.
+
+## Coupon distribution eligibility
+
+A bond coupon pays out on the carbon data in its referenced oracle report. If
+that report is `Challenged` or `Rejected`, the data is disputed and must not be
+paid on.
+
+`GET /oracle/projects/:projectId/coupon-eligibility` returns:
+
+```json
+{
+  "projectId": "…",
+  "eligible": false,
+  "reasons": ["1 report(s) are challenged or rejected and must be resolved first"],
+  "blockedByReportIds": [7]
+}
+```
+
+`BondsService.distributeCoupon` consults this when an `OracleService` is wired
+in: it fetches the referenced report and **blocks** distribution with a
+`400 Bad Request` when the report is `Challenged` or `Rejected`. The bond detail
+UI should call the eligibility endpoint and **warn** (or disable the
+distribution action) whenever `eligible` is `false`, before the operator hits
+the guarded endpoint.
+
+## Frontend
+
+- `api.getProjectChallengedReports(projectId)` / `api.getReportChallengeState(
+  reportId)` / `api.getCouponEligibility(projectId)` in `shared/services/
+  api.service.ts`.
+- The project view renders a challenged-reports panel listing each disputed
+  report with its counter-evidence hash, challenger, submitted time, and
+  resolution, sourced from `/oracle/reports/:projectId/challenges`.
+- The bond detail view calls `getCouponEligibility` for the bond's project and
+  shows a blocking warning when `eligible` is `false`.

--- a/docs/route-authorization-matrix.md
+++ b/docs/route-authorization-matrix.md
@@ -1,0 +1,120 @@
+# API Route Authorization Matrix
+
+This document is the human-readable counterpart of
+`api/src/test/route-authorization.matrix.ts`, which is enforced at test time by
+`api/src/test/route-authorization.matrix.spec.ts`. That spec fails the build if a
+controller route is added without an entry here, or if the guards wired on a
+controller diverge from what is declared below. **Keep the two in sync.**
+
+## Role taxonomy
+
+| Role | Meaning |
+| --- | --- |
+| `public` | No authentication required (read or write). |
+| `wallet-header` | Caller identity is taken from the `x-wallet-address` (or `x-provider-address`) request header only. There is **no** JWT/KYC enforcement at the API boundary. Trust in the header value is the marketplace's accepted model. |
+| `authenticated` | A valid JWT session is required (`JwtAuthGuard`). |
+| `admin` | A valid JWT session **and** the configured admin key (`JwtAuthGuard` + `AdminGuard`). |
+
+> **Gap note:** No controller route currently requires `KycGuard` (verified-KYC)
+> or `ProviderGuard` (provider allow-list) directly. Both guards are unit-tested
+> in `api/src/test/guard-roles.spec.ts` and will be reflected in this matrix the
+> moment they are attached to a route. The marketplace oracle write paths
+> (`oracle/reports`, `oracle/challenge/:reportId`) rely on the `x-provider-address`
+> / `x-wallet-address` headers instead of `ProviderGuard`.
+
+## Auth (`/auth`)
+
+| Method | Path | Role | Guards |
+| --- | --- | --- | --- |
+| POST | `/auth/challenge` | public | — |
+| POST | `/auth/verify` | public | — |
+| POST | `/auth/refresh` | public | — |
+| GET | `/auth/profile` | authenticated | `JwtAuthGuard` |
+| GET | `/auth/kyc/:address` | authenticated | `JwtAuthGuard` |
+| POST | `/auth/kyc/:address` | authenticated | `JwtAuthGuard` |
+
+## Bonds (`/bonds`)
+
+| Method | Path | Role | Guards |
+| --- | --- | --- | --- |
+| POST | `/bonds` | public | — |
+| GET | `/bonds` | public | — |
+| GET | `/bonds/held/:address` | public | — |
+| GET | `/bonds/:id` | public | — |
+| GET | `/bonds/:id/detail` | public | — | (issue #4: atomically refreshes summary, holders, coupon, and maturity) |
+| POST | `/bonds/:id/subscribe` | public | — |
+| GET | `/bonds/:id/holders` | public | — |
+| POST | `/bonds/:id/coupon` | public | — |
+| POST | `/bonds/:id/claim` | public | — |
+| GET | `/bonds/:id/undistributed` | public | — |
+| POST | `/bonds/:id/sweep-undistributed` | **admin** | `JwtAuthGuard`, `AdminGuard` |
+| POST | `/bonds/:id/transfer` | public | — |
+| POST | `/bonds/:id/mature` | public | — |
+| GET | `/bonds/:id/export` | authenticated | `JwtAuthGuard` |
+
+## Oracle (`/oracle`)
+
+| Method | Path | Role | Guards |
+| --- | --- | --- | --- |
+| POST | `/oracle/reports` | wallet-header | — |
+| GET | `/oracle/reports/:projectId` | public | — |
+| GET | `/oracle/reports/:projectId/challenges` | public | — | (issue #3: challenged reports for a project) |
+| GET | `/oracle/challenges/:reportId` | public | — | (issue #3: full challenge state + history) |
+| GET | `/oracle/projects/:projectId/coupon-eligibility` | public | — | (issue #3: coupon distribution eligibility) |
+| POST | `/oracle/challenge/:reportId` | wallet-header | — |
+| POST | `/oracle/providers` | public | — |
+| GET | `/oracle/providers` | public | — |
+| GET | `/oracle/stats/:providerAddress` | public | — |
+| GET | `/oracle/monitoring/staleness` | public | — |
+| GET | `/oracle/incidents` | **admin** | `JwtAuthGuard`, `AdminGuard` |
+| POST | `/oracle/incidents/:id/acknowledge` | **admin** | `JwtAuthGuard`, `AdminGuard` |
+| POST | `/oracle/incidents/:id/resolve` | **admin** | `JwtAuthGuard`, `AdminGuard` |
+
+## Projects (`/projects`)
+
+| Method | Path | Role | Guards |
+| --- | --- | --- | --- |
+| POST | `/projects` | public | — |
+| GET | `/projects` | public | — |
+| GET | `/projects/:id` | public | — |
+| POST | `/projects/:id/approve` | public | — |
+| POST | `/projects/:id/reject` | public | — |
+| POST | `/projects/:id/documents` | public | — |
+| GET | `/projects/:id/export` | authenticated | `JwtAuthGuard` |
+
+## Marketplace (`/marketplace`)
+
+All marketplace mutations authenticate the caller via the `x-wallet-address`
+header (`wallet-header`). No JWT/KYC guard is applied at the API boundary.
+
+| Method | Path | Role | Guards |
+| --- | --- | --- | --- |
+| GET | `/marketplace/quote-assets` | public | — |
+| GET | `/marketplace/orders` | public | — |
+| POST | `/marketplace/list` | wallet-header | — |
+| POST | `/marketplace/buy` | wallet-header | — |
+| GET | `/marketplace/quote-balance` | wallet-header | — |
+| GET | `/marketplace/wallet-balance` | wallet-header | — |
+| POST | `/marketplace/deposit` | wallet-header | — |
+| POST | `/marketplace/withdraw` | wallet-header | — |
+| DELETE | `/marketplace/orders/:id` | wallet-header | — |
+| GET | `/marketplace/orders/:id` | public | — |
+| GET | `/marketplace/prices` | public | — |
+| GET | `/marketplace/prices/:bondId/best` | public | — |
+| GET | `/marketplace/prices/:bondId/slippage` | public | — |
+| POST | `/marketplace/reconciliation/run` | wallet-header | — | (issue #2: run quote/order reconciliation) |
+| GET | `/marketplace/reconciliation/mismatches` | wallet-header | — | (issue #2: list detected mismatches) |
+| POST | `/marketplace/reconciliation/repair` | wallet-header | — | (issue #2: repair a mismatch) |
+
+## How the tests protect this contract
+
+- `route-authorization.matrix.spec.ts` walks every controller at runtime, reads
+  the real `@UseGuards` metadata, and asserts (a) every handler is present in the
+  matrix, (b) the HTTP verb and path match, and (c) the guard set matches. Remove
+  a guard from a sensitive controller and the build fails.
+- `<controller>.controller.guard.spec.ts` files exercise the role matrix
+  behaviourally: anonymous callers get `401` before the service is invoked, and
+  admin/authenticated callers reach the service. The real guards are swapped for
+  header-driven fakes so tests run without a database or passport.
+- `guard-roles.spec.ts` unit-tests the guard classes themselves (including the
+  not-yet-wired `KycGuard` and `ProviderGuard`).

--- a/docs/runbook-marketplace-reconciliation.md
+++ b/docs/runbook-marketplace-reconciliation.md
@@ -1,0 +1,96 @@
+# Runbook: Marketplace Quote Balance & Order Reconciliation
+
+The API reconciles its indexed/cached view of marketplace state against the
+authoritative on-chain DEX router ledger on a schedule (every 10 minutes by
+default, configurable via `DEX_RECON_CRON`). This runbook explains how to
+investigate a mismatch alert and repair stale cache/index records.
+
+See `api/src/marketplace/dex.reconciliation.service.ts` for the implementation
+and `api/src/marketplace/dex.reconciliation.service.spec.ts` for the covered
+scenarios (stale cache, changed balance, missing order, escrow invariant).
+
+## What is reconciled
+
+| Check | Indexed/API source | On-chain source | Mismatch type |
+| --- | --- | --- | --- |
+| Quote balance | `quote:balance:<addr>:<asset>` cache (seeded/maintained by deposits & withdrawals) | `DEXRouter.get_quote_balance()` | `balance_mismatch` |
+| Open order status | `order:<id>` + `orders:*` caches | `DEXRouter.get_order()` status | `stale_order_cache` |
+| Order presence | API order index (open orders) | on-chain order id scan | `missing_order` |
+| Seller escrow | — | `get_quote_balance(seller)` vs `pricePerToken * amount` | `order_escrow_invariant` |
+
+## Where alerts land
+
+- Every run is logged with a `correlationId` via `DexReconciliationService`.
+- On a mismatch the service logs `WARN [<correlationId>] Marketplace reconciliation found N mismatch(es): ...`.
+- The full report is persisted to Redis under `dex:recon:last` (7-day TTL).
+- The last 200 mismatches are kept under `dex:recon:mismatches`.
+
+## Investigation steps
+
+1. Pull the latest report:
+   `GET /marketplace/reconciliation/mismatches` (operator wallet-header) or read
+   `dex:recon:last` directly from Redis.
+2. Group mismatches by `type` and `correlationId`. A burst of the same type with
+   one correlation id is a single reconcile run — investigate the root cause once.
+3. For `balance_mismatch`: compare `observed` (the stale API index) vs `expected`
+   (the true on-chain balance). A positive `expected` usually means a deposit or
+   purchase was not reflected because cache invalidation did not run (a failed
+   cache invalidation). A negative `expected` can indicate an unexpected on-chain
+   movement (e.g. an off-platform withdrawal).
+4. For `stale_order_cache`: the order's cached status disagrees with the ledger.
+   Most often the order was filled/cancelled on-chain but the `order:<id>` cache
+   had not expired (60s TTL) or an `orders:*` listing was served stale.
+5. For `missing_order`: an open order exists on-chain but is absent from the API
+   index. This points at a gap in `listOrders` indexing, not a cache value.
+6. For `order_escrow_invariant`: the seller's on-chain balance no longer covers
+   the order notional. This is a data-integrity risk (a buy could fail or be
+   partially filled) and should be escalated to the seller/outreach.
+
+## Repair steps
+
+The safe, default repair is to evict the affected caches so the next read
+re-fetches from the ledger. This is exactly what `repair()` does:
+
+- `balance_mismatch` → re-syncs `quote:balance:<addr>:<asset>` to the on-chain
+  value and deletes the stale key.
+- `stale_order_cache` / `missing_order` / `order_escrow_invariant` → `DEL
+  order:<id>` and `DEL orders:*` (force a fresh re-index on next `listOrders`).
+
+Trigger repair:
+
+```
+POST /marketplace/reconciliation/repair      # repairs the last stored report
+# or send an explicit report body:
+POST /marketplace/reconciliation/repair
+{ "report": { "correlationId": "...", "mismatches": [ ... ] } }
+```
+
+The response lists the invalidated keys/actions taken (`repaired`, `actions`).
+
+### Manual Redis repair (if the service is down)
+
+```
+# balance
+DEL quote:balance:<addr>:<asset>
+# orders
+DEL order:<id>
+SCAN 0 MATCH orders:* COUNT 100   # then DEL each page
+```
+
+After eviction, confirm the next `GET /marketplace/orders/:id` and
+`GET /marketplace/quote-balance` return values matching the ledger.
+
+## Tuning
+
+- `DEX_RECON_CRON` — cron expression for the scheduled run (default every 10m).
+- `DEX_RECON_WALLETS` — comma-separated wallets to always sample (in addition to
+  every open-order seller).
+- `DEX_RECON_MAX_ORDER_SCAN` — cap on the on-chain order-id walk used for
+  missing-order detection (default 500).
+
+## False positives
+
+A `balance_mismatch` on the very first run for a wallet is expected (the index is
+being seeded) and is reported as clean, not as a mismatch. Only a *subsequent*
+divergence is flagged. If you see persistent mismatches after a repair, the
+deposit/withdraw cache-invalidation path (in `dex.service.ts`) should be audited.

--- a/frontend/src/app/bonds/bond-detail/bond-detail.component.spec.ts
+++ b/frontend/src/app/bonds/bond-detail/bond-detail.component.spec.ts
@@ -3,17 +3,17 @@ import { provideRouter } from '@angular/router';
 import { ActivatedRoute } from '@angular/router';
 import { of } from 'rxjs';
 import { BondDetailComponent } from './bond-detail.component';
-import { ApiService } from '../../shared/services/api.service';
+import { ApiService, BondDetailResponse } from '../../shared/services/api.service';
 import { WalletService } from '../../auth/wallet.service';
 import { Bond } from '../../shared/interfaces/bond.interface';
 import { environment } from '../../../environments/environment';
 
-describe('BondDetailComponent', () => {
+describe('BondDetailComponent (issue #4 refresh model)', () => {
   let fixture: ComponentFixture<BondDetailComponent>;
   let apiService: jasmine.SpyObj<ApiService>;
   let walletService: WalletService;
 
-  const bond = {
+  const bond: Bond = {
     id: 1,
     projectId: 'a1b2',
     faceValue: '1000',
@@ -27,9 +27,18 @@ describe('BondDetailComponent', () => {
     createdAt: '2026-01-01T00:00:00.000Z',
   };
 
-  const futureBond = (
-    overrides: Partial<Pick<Bond, 'maturityDate' | 'maturityStatus'>> = {},
-  ): Bond => ({
+  const detailFor = (overrides: Partial<Bond> = {}): BondDetailResponse => ({
+    bond: { ...bond, ...overrides },
+    holders: [
+      { address: 'GAAAA', balance: '100' },
+      { address: 'GBBBB', balance: '200' },
+    ],
+    coupon: { undistributedTotal: '7' },
+    maturity: { reached: overrides.maturityStatus === 'Matured', date: (overrides.maturityDate ?? bond.maturityDate), secondsUntil: 0 },
+    loadedAt: new Date().toISOString(),
+  });
+
+  const futureBond = (overrides: Partial<Bond> = {}): Bond => ({
     ...bond,
     maturityDate: Math.floor(Date.now() / 1000) + 3 * 86400,
     maturityStatus: 'Active',
@@ -38,16 +47,15 @@ describe('BondDetailComponent', () => {
 
   beforeEach(async () => {
     apiService = jasmine.createSpyObj('ApiService', [
-      'getBond', 'subscribeToBond', 'claimCredits', 'transferBond',
-      'getUndistributedTotal', 'sweepUndistributed',
+      'getBondDetail', 'subscribeToBond', 'claimCredits', 'transferBond',
+      'sweepUndistributed', 'getCouponEligibility',
     ]);
-    apiService.getBond.and.returnValue(of(bond));
-    apiService.getUndistributedTotal.and.returnValue(
-      of({ bondId: 1, undistributedTotal: '7' }),
-    );
-    apiService.sweepUndistributed.and.returnValue(
-      of({ bondId: 1, swept: '7', transactionHash: '0xabc' }),
-    );
+    apiService.getBondDetail.and.returnValue(of(detailFor()));
+    apiService.subscribeToBond.and.returnValue(of({ transactionHash: '0xsub' }));
+    apiService.claimCredits.and.returnValue(of({ credits: 5, transactionHash: '0xclaim' }));
+    apiService.transferBond.and.returnValue(of({ transactionHash: '0xtransfer' }));
+    apiService.sweepUndistributed.and.returnValue(of({ bondId: 1, swept: '7', transactionHash: '0xabc' }));
+    apiService.getCouponEligibility.and.returnValue(of({ projectId: 'a1b2', eligible: true, reasons: [], blockedByReportIds: [] }));
 
     await TestBed.configureTestingModule({
       imports: [BondDetailComponent],
@@ -81,11 +89,16 @@ describe('BondDetailComponent', () => {
   const adminSection = (): HTMLElement | null =>
     fixture.nativeElement.querySelector('.admin-section');
 
+  it('loads the full detail snapshot through the coordinator on init', fakeAsync(() => {
+    createFixture();
+    expect(apiService.getBondDetail).toHaveBeenCalledWith(1, { bustCache: true });
+    discardPeriodicTasks();
+  }));
+
   it('shows the undistributed total to the admin wallet', fakeAsync(() => {
     walletService.address.set(environment.adminAddress);
     createFixture();
 
-    expect(apiService.getUndistributedTotal).toHaveBeenCalledWith(1);
     const section = adminSection();
     expect(section).not.toBeNull();
     expect(section?.textContent).toContain('7');
@@ -94,13 +107,18 @@ describe('BondDetailComponent', () => {
   }));
 
   it('hides the admin panel from non-admin wallets', fakeAsync(() => {
-    walletService.address.set(
-      'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
-    );
+    walletService.address.set('GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF');
     createFixture();
 
-    expect(apiService.getUndistributedTotal).not.toHaveBeenCalled();
     expect(adminSection()).toBeNull();
+    discardPeriodicTasks();
+  }));
+
+  it('renders the holders panel from the committed snapshot', fakeAsync(() => {
+    createFixture();
+    const items = fixture.nativeElement.querySelectorAll('.holder-item');
+    expect(items.length).toBe(2);
+    expect(fixture.nativeElement.textContent).toContain('GAAAA');
     discardPeriodicTasks();
   }));
 
@@ -109,10 +127,7 @@ describe('BondDetailComponent', () => {
     createFixture();
 
     const confirmSpy = spyOn(window, 'confirm').and.returnValue(true);
-    const sweepBtn = fixture.nativeElement.querySelector(
-      '.sweep-btn',
-    ) as HTMLButtonElement;
-    expect(sweepBtn).not.toBeNull();
+    const sweepBtn = fixture.nativeElement.querySelector('.sweep-btn') as HTMLButtonElement;
     sweepBtn.click();
     tick();
     fixture.detectChanges();
@@ -128,9 +143,7 @@ describe('BondDetailComponent', () => {
     createFixture();
 
     spyOn(window, 'confirm').and.returnValue(false);
-    const sweepBtn = fixture.nativeElement.querySelector(
-      '.sweep-btn',
-    ) as HTMLButtonElement;
+    const sweepBtn = fixture.nativeElement.querySelector('.sweep-btn') as HTMLButtonElement;
     sweepBtn.click();
 
     expect(apiService.sweepUndistributed).not.toHaveBeenCalled();
@@ -138,12 +151,10 @@ describe('BondDetailComponent', () => {
   }));
 
   it('shows a live countdown for a bond that has not reached maturity', fakeAsync(() => {
-    apiService.getBond.and.returnValue(of(futureBond()));
+    apiService.getBondDetail.and.returnValue(of(detailFor(futureBond())));
     createFixture();
 
-    const banner = fixture.nativeElement.querySelector(
-      '.maturity-banner',
-    ) as HTMLElement;
+    const banner = fixture.nativeElement.querySelector('.maturity-banner') as HTMLElement;
     expect(banner).not.toBeNull();
     expect(banner.textContent).toContain('Matures in');
     expect(banner.textContent).toContain('d');
@@ -151,14 +162,10 @@ describe('BondDetailComponent', () => {
   }));
 
   it('shows the frozen-for-trading state and hides subscribe/transfer after maturity', fakeAsync(() => {
-    apiService.getBond.and.returnValue(
-      of(futureBond({ maturityStatus: 'Matured' })),
-    );
+    apiService.getBondDetail.and.returnValue(of(detailFor({ maturityStatus: 'Matured' })));
     createFixture();
 
-    const banner = fixture.nativeElement.querySelector(
-      '.maturity-banner.frozen',
-    ) as HTMLElement;
+    const banner = fixture.nativeElement.querySelector('.maturity-banner.frozen') as HTMLElement;
     expect(banner).not.toBeNull();
     expect(banner.textContent).toContain('Frozen for trading');
 
@@ -170,9 +177,9 @@ describe('BondDetailComponent', () => {
     discardPeriodicTasks();
   }));
 
-  it('disables subscribe/transfer once the maturity date has elapsed, even when status is still Active', fakeAsync(() => {
-    apiService.getBond.and.returnValue(
-      of(futureBond({ maturityDate: Math.floor(Date.now() / 1000) - 10 })),
+  it('disables subscribe/transfer once the maturity date has elapsed', fakeAsync(() => {
+    apiService.getBondDetail.and.returnValue(
+      of(detailFor({ maturityDate: Math.floor(Date.now() / 1000) - 10 })),
     );
     createFixture();
 
@@ -182,11 +189,64 @@ describe('BondDetailComponent', () => {
     discardPeriodicTasks();
   }));
 
+  it('reloads the full snapshot after a subscribe mutation', fakeAsync(() => {
+    createFixture();
+    expect(apiService.getBondDetail).toHaveBeenCalledTimes(1);
+
+    fixture.componentInstance.subscribeAmount = 10;
+    fixture.componentInstance.onSubscribe();
+    tick();
+    fixture.detectChanges();
+
+    expect(apiService.subscribeToBond).toHaveBeenCalledWith(1, 10);
+    expect(apiService.getBondDetail).toHaveBeenCalledTimes(2);
+    discardPeriodicTasks();
+  }));
+
+  it('reloads the full snapshot after a transfer mutation', fakeAsync(() => {
+    createFixture();
+    expect(apiService.getBondDetail).toHaveBeenCalledTimes(1);
+
+    fixture.componentInstance.transferTo = 'GDEST';
+    fixture.componentInstance.transferAmount = 5;
+    fixture.componentInstance.onTransfer();
+    tick();
+    fixture.detectChanges();
+
+    expect(apiService.transferBond).toHaveBeenCalledWith(1, 'GDEST', 5);
+    expect(apiService.getBondDetail).toHaveBeenCalledTimes(2);
+    discardPeriodicTasks();
+  }));
+
+  it('reloads the full snapshot after a claim mutation', fakeAsync(() => {
+    createFixture();
+    expect(apiService.getBondDetail).toHaveBeenCalledTimes(1);
+
+    fixture.componentInstance.onClaim();
+    tick();
+    fixture.detectChanges();
+
+    expect(apiService.claimCredits).toHaveBeenCalledWith(1);
+    expect(apiService.getBondDetail).toHaveBeenCalledTimes(2);
+    discardPeriodicTasks();
+  }));
+
+  it('reloads via the manual refresh button (maturity/refresh path)', fakeAsync(() => {
+    createFixture();
+    expect(apiService.getBondDetail).toHaveBeenCalledTimes(1);
+
+    const refreshBtn = fixture.nativeElement.querySelector('.refresh-btn') as HTMLButtonElement;
+    refreshBtn.click();
+    tick();
+    fixture.detectChanges();
+
+    expect(apiService.getBondDetail).toHaveBeenCalledTimes(2);
+    discardPeriodicTasks();
+  }));
+
   it('formats the countdown in days, hours, minutes and seconds', () => {
     const component = TestBed.createComponent(BondDetailComponent).componentInstance;
-    expect(component.formatCountdown(2 * 86400000 + 3 * 3600000 + 4 * 60000 + 5000)).toBe(
-      '2d 3h 4m 5s',
-    );
+    expect(component.formatCountdown(2 * 86400000 + 3 * 3600000 + 4 * 60000 + 5000)).toBe('2d 3h 4m 5s');
     expect(component.formatCountdown(5 * 1000)).toBe('5s');
     expect(component.formatCountdown(0)).toBe('');
   });

--- a/frontend/src/app/bonds/bond-detail/bond-detail.component.ts
+++ b/frontend/src/app/bonds/bond-detail/bond-detail.component.ts
@@ -2,10 +2,11 @@ import { Component, inject, OnInit, OnDestroy, ChangeDetectionStrategy, signal, 
 import { CommonModule } from '@angular/common';
 import { RouterModule, ActivatedRoute } from '@angular/router';
 import { FormsModule } from '@angular/forms';
-import { ApiService } from '../../shared/services/api.service';
+import { ApiService, CouponEligibility } from '../../shared/services/api.service';
 import { WalletService } from '../../auth/wallet.service';
 import { StatusBadgeComponent } from '../../shared/components/status-badge/status-badge.component';
 import { LoadingSpinnerComponent } from '../../shared/components/loading-spinner/loading-spinner.component';
+import { BondDetailReloadCoordinator } from './bond-detail.reload-coordinator';
 import { Bond } from '../../shared/interfaces/bond.interface';
 import { environment } from '../../../environments/environment';
 
@@ -13,9 +14,14 @@ import { environment } from '../../../environments/environment';
   selector: 'app-bond-detail',
   standalone: true,
   imports: [CommonModule, RouterModule, FormsModule, StatusBadgeComponent, LoadingSpinnerComponent],
+  providers: [BondDetailReloadCoordinator],
   template: `
     <div class="detail-page">
       <a class="back-link" routerLink="/bonds">← Back to Bonds</a>
+
+      @if (refreshing()) {
+        <div class="refresh-banner">Refreshing bond data…</div>
+      }
 
       @if (bond(); as b) {
         <div class="detail-grid">
@@ -34,6 +40,16 @@ import { environment } from '../../../environments/environment';
                 <strong>Matures in:</strong> {{ countdown() }}
               }
             </div>
+
+            @if (couponEligibility() && !couponEligibility()!.eligible) {
+              <div class="coupon-warning">
+                <strong>Coupon distribution blocked.</strong>
+                The referenced oracle report is disputed or rejected.
+                @for (reason of couponEligibility()!.reasons; track reason) {
+                  <div class="coupon-reason">• {{ reason }}</div>
+                }
+              </div>
+            }
 
             <div class="detail-body">
               <div class="detail-field">
@@ -127,6 +143,24 @@ import { environment } from '../../../environments/environment';
               </a>
             </div>
 
+            <div class="holders-section">
+              <h3 class="section-title">Holders ({{ holders().length }})</h3>
+              @if (sectionLoading().holders) {
+                <div class="muted">Loading holders…</div>
+              } @else if (holders().length === 0) {
+                <div class="muted">No holders yet.</div>
+              } @else {
+                <ul class="holders-list">
+                  @for (h of holders(); track h.address) {
+                    <li class="holder-item">
+                      <span class="mono">{{ h.address }}</span>
+                      <span class="holder-balance">{{ h.balance | number }}</span>
+                    </li>
+                  }
+                </ul>
+              }
+            </div>
+
             <div class="claim-section">
               <h3 class="section-title">Claim Credits</h3>
               <button
@@ -148,6 +182,13 @@ import { environment } from '../../../environments/environment';
 
             <div class="transfer-section">
               <h3 class="section-title">Transfer Tokens</h3>
+              <button
+                class="btn btn-outline refresh-btn"
+                [disabled]="refreshing()"
+                (click)="onRefresh()"
+              >
+                {{ refreshing() ? 'Refreshing…' : 'Refresh' }}
+              </button>
               @if (maturityReached()) {
                 <p class="status-notice">Transfers are disabled after the maturity date.</p>
               } @else {
@@ -243,6 +284,8 @@ import { environment } from '../../../environments/environment';
     .detail-title { font-size: 1.5rem; font-weight: 700; }
     .maturity-banner { display: flex; gap: 8px; padding: 12px 16px; border-radius: 8px; background: #fffbeb; border: 1px solid #fde68a; color: #92400e; font-size: 0.875rem; margin-bottom: 24px; }
     .maturity-banner.frozen { background: #fef2f2; border-color: #fecaca; color: #991b1b; }
+    .coupon-warning { display: flex; flex-direction: column; gap: 4px; padding: 12px 16px; border-radius: 8px; background: #fef2f2; border: 1px solid #fecaca; color: #991b1b; font-size: 0.875rem; margin-bottom: 24px; }
+    .coupon-reason { font-size: 0.8125rem; }
     .detail-body { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; }
     .detail-field { display: flex; flex-direction: column; }
     .field-label { font-size: 0.75rem; color: #6b7280; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 4px; }
@@ -279,6 +322,13 @@ import { environment } from '../../../environments/environment';
     .admin-section { margin-top: 20px; padding-top: 20px; border-top: 1px solid #e5e7eb; }
     .admin-note { font-size: 0.8125rem; color: #6b7280; padding: 8px 0; }
     .undistributed-total { display: flex; flex-direction: column; margin-bottom: 12px; }
+    .refresh-banner { padding: 10px 16px; border-radius: 8px; background: #eff6ff; border: 1px solid #bfdbfe; color: #1d4ed8; font-size: 0.8125rem; margin-bottom: 16px; }
+    .refresh-btn { width: 100%; margin-top: 16px; }
+    .holders-section { margin-top: 20px; padding-top: 20px; border-top: 1px solid #e5e7eb; }
+    .holders-list { list-style: none; padding: 0; display: flex; flex-direction: column; gap: 6px; }
+    .holder-item { display: flex; justify-content: space-between; gap: 8px; font-size: 0.8125rem; padding: 6px 10px; background: #f9fafb; border-radius: 6px; }
+    .holder-balance { font-family: monospace; }
+    .muted { font-size: 0.8125rem; color: #6b7280; }
   `],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -286,10 +336,24 @@ export class BondDetailComponent implements OnInit, OnDestroy {
   private readonly route = inject(ActivatedRoute);
   private readonly apiService = inject(ApiService);
   private readonly walletService = inject(WalletService);
+  private readonly coordinator = inject(BondDetailReloadCoordinator);
 
-  readonly bond = signal<Bond | null>(null);
-  readonly loading = signal(true);
+  /**
+   * Every panel (summary, holders, coupon, maturity) is derived from the single
+   * snapshot the coordinator commits after each `reload()`, so the view can never
+   * show a mix of pre- and post-mutation data. See issue #4.
+   */
+  readonly bond = computed<Bond | null>(() => this.coordinator.detail()?.bond ?? null);
+  readonly holders = computed(() => this.coordinator.detail()?.holders ?? []);
+  readonly undistributed = computed<number | null>(() => {
+    const d = this.coordinator.detail();
+    return d ? Number(d.coupon.undistributedTotal) : null;
+  });
+  readonly loading = this.coordinator.loading;
+  readonly refreshing = this.coordinator.loading;
+  readonly sectionLoading = this.coordinator.sectionLoading;
   readonly error = signal('');
+  readonly couponEligibility = signal<CouponEligibility | null>(null);
   readonly now = signal(Date.now());
   readonly subscribeSubmitting = signal(false);
   readonly subscribeSuccess = signal(false);
@@ -304,8 +368,7 @@ export class BondDetailComponent implements OnInit, OnDestroy {
   readonly transferSuccess = signal(false);
   readonly transferTx = signal('');
   readonly transferError = signal('');
-  readonly undistributed = signal<number | null>(null);
-  readonly undistributedError = signal('');
+  readonly undistributedError = computed(() => this.coordinator.error() ?? '');
   readonly sweepSubmitting = signal(false);
   readonly sweepSuccess = signal(false);
   readonly sweepSwept = signal(0);
@@ -329,20 +392,21 @@ export class BondDetailComponent implements OnInit, OnDestroy {
 
   private maturityTimer?: ReturnType<typeof setInterval>;
 
-  private undistributedLoaded = false;
-
-  private readonly loadUndistributedEffect = effect(() => {
-    const b = this.bond();
-    if (b && this.isAdmin() && !this.undistributedLoaded) {
-      this.undistributedLoaded = true;
-      this.apiService.getUndistributedTotal(b.id).subscribe({
-        next: (res) => this.undistributed.set(Number(res.undistributedTotal)),
-        error: (err) =>
-          this.undistributedError.set(
-            err.error?.detail || err.message || 'Failed to load undistributed total',
-          ),
-      });
+  /**
+   * Load coupon eligibility whenever the committed bond snapshot changes. The
+   * projectId is only known after the detail loads, so we react to the snapshot
+   * rather than firing it inline in `reload()`.
+   */
+  private readonly couponEligibilityEffect = effect(() => {
+    const projectId = this.coordinator.detail()?.bond.projectId;
+    if (!projectId) {
+      this.couponEligibility.set(null);
+      return;
     }
+    this.apiService.getCouponEligibility(projectId).subscribe({
+      next: (eligibility) => this.couponEligibility.set(eligibility),
+      error: () => this.couponEligibility.set(null),
+    });
   }, { allowSignalWrites: true });
 
   subscribeAmount = 0;
@@ -379,16 +443,18 @@ export class BondDetailComponent implements OnInit, OnDestroy {
       return;
     }
     this.maturityTimer = setInterval(() => this.now.set(Date.now()), 1000);
-    this.apiService.getBond(id).subscribe({
-      next: (bond) => {
-        this.bond.set(bond);
-        this.loading.set(false);
-      },
-      error: (err) => {
-        this.error.set(err.status === 404 ? 'Bond not found' : 'Failed to load bond');
-        this.loading.set(false);
-      },
-    });
+    this.reload(id);
+  }
+
+  /** Atomically refresh every panel of this bond (issue #4 refresh model). */
+  reload(id: number): void {
+    this.coordinator.reload(id);
+  }
+
+  /** Manual refresh triggered by the UI button. */
+  onRefresh(): void {
+    const b = this.bond();
+    if (b) this.reload(b.id);
   }
 
   ngOnDestroy(): void {
@@ -409,9 +475,7 @@ export class BondDetailComponent implements OnInit, OnDestroy {
         this.subscribeSuccess.set(true);
         this.subscribeTx.set(res.transactionHash);
         this.subscribeSubmitting.set(false);
-        this.apiService.getBond(b.id).subscribe({
-          next: (updated) => this.bond.set(updated),
-        });
+        this.reload(b.id);
       },
       error: (err) => {
         this.subscribeError.set(err.error?.detail || err.message || 'Subscription failed');
@@ -433,6 +497,7 @@ export class BondDetailComponent implements OnInit, OnDestroy {
         this.claimCredits.set(Number(res.credits));
         this.claimTx.set(res.transactionHash);
         this.claimSubmitting.set(false);
+        this.reload(b.id);
       },
       error: (err) => {
         this.claimError.set(err.error?.detail || err.message || 'Claim failed');
@@ -455,6 +520,7 @@ export class BondDetailComponent implements OnInit, OnDestroy {
         this.transferSubmitting.set(false);
         this.transferTo = '';
         this.transferAmount = 0;
+        this.reload(b.id);
       },
       error: (err) => {
         this.transferError.set(err.error?.detail || err.message || 'Transfer failed');
@@ -483,7 +549,7 @@ export class BondDetailComponent implements OnInit, OnDestroy {
         this.sweepSwept.set(Number(res.swept));
         this.sweepTx.set(res.transactionHash);
         this.sweepSubmitting.set(false);
-        this.undistributed.set(0);
+        this.reload(b.id);
       },
       error: (err) => {
         this.sweepError.set(err.error?.detail || err.message || 'Sweep failed');

--- a/frontend/src/app/bonds/bond-detail/bond-detail.reload-coordinator.spec.ts
+++ b/frontend/src/app/bonds/bond-detail/bond-detail.reload-coordinator.spec.ts
@@ -1,0 +1,73 @@
+import { BondDetailReloadCoordinator } from './bond-detail.reload-coordinator';
+import { ApiService, BondDetailResponse } from '../../shared/services/api.service';
+import { of, Subject } from 'rxjs';
+import { fakeAsync, tick } from '@angular/core/testing';
+
+describe('BondDetailReloadCoordinator (issue #4 refresh model)', () => {
+  let coordinator: BondDetailReloadCoordinator;
+  let apiService: jasmine.SpyObj<ApiService>;
+
+  const detail = (overrides: Partial<BondDetailResponse> = {}): BondDetailResponse => ({
+    bond: { id: 1 } as any,
+    holders: [{ address: 'G', balance: '1' }],
+    coupon: { undistributedTotal: '0' },
+    maturity: { reached: false, date: 0, secondsUntil: 0 },
+    loadedAt: new Date().toISOString(),
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    apiService = jasmine.createSpyObj('ApiService', ['getBondDetail']);
+    apiService.getBondDetail.and.returnValue(of(detail()));
+    coordinator = new BondDetailReloadCoordinator(apiService);
+  });
+
+  it('toggles per-section loading flags together and commits one atomic snapshot', fakeAsync(() => {
+    coordinator.reload(1);
+    expect(coordinator.loading()).toBe(true);
+    expect(coordinator.sectionLoading().bond).toBe(true);
+    expect(coordinator.sectionLoading().holders).toBe(true);
+    expect(coordinator.sectionLoading().coupon).toBe(true);
+    expect(coordinator.sectionLoading().maturity).toBe(true);
+
+    tick();
+    expect(coordinator.loading()).toBe(false);
+    expect(coordinator.sectionLoading().bond).toBe(false);
+    expect(coordinator.detail()?.bond.id).toBe(1);
+    expect(coordinator.detail()?.holders.length).toBe(1);
+  }));
+
+  it('records the server timestamp for staleness detection', fakeAsync(() => {
+    coordinator.reload(1);
+    tick();
+    expect(typeof coordinator.lastLoadedAt()).toBe('string');
+    expect(Number.isNaN(Date.parse(coordinator.lastLoadedAt()!))).toBe(false);
+  }));
+
+  it('reports a newer server snapshot via isNewerThan', fakeAsync(() => {
+    const older = new Date(Date.now() - 1000).toISOString();
+    const newer = new Date(Date.now() + 1000).toISOString();
+
+    apiService.getBondDetail.and.returnValue(of(detail({ loadedAt: newer })));
+    coordinator.reload(1);
+    tick();
+
+    expect(coordinator.isNewerThan(older)).toBe(true);
+    expect(coordinator.isNewerThan(newer)).toBe(false);
+  }));
+
+  it('cancels an in-flight reload when a new one starts', fakeAsync(() => {
+    const first = new Subject<BondDetailResponse>();
+    const second = new Subject<BondDetailResponse>();
+    apiService.getBondDetail.and.returnValues(first.asObservable(), second.asObservable());
+
+    coordinator.reload(1);
+    coordinator.reload(1);
+
+    expect(apiService.getBondDetail).toHaveBeenCalledTimes(2);
+    // Only the second (latest) emission commits.
+    second.next(detail({ bond: { id: 99 } as any }));
+    tick();
+    expect(coordinator.detail()?.bond.id).toBe(99);
+  }));
+});

--- a/frontend/src/app/bonds/bond-detail/bond-detail.reload-coordinator.ts
+++ b/frontend/src/app/bonds/bond-detail/bond-detail.reload-coordinator.ts
@@ -1,0 +1,73 @@
+import { Injectable, signal, Subscription } from '@angular/core';
+import { ApiService, BondDetailResponse } from '../../shared/services/api.service';
+
+export type BondDetailSection = 'bond' | 'holders' | 'coupon' | 'maturity';
+
+export interface SectionLoading {
+  bond: boolean;
+  holders: boolean;
+  coupon: boolean;
+  maturity: boolean;
+}
+
+const IDLE_SECTIONS: SectionLoading = { bond: false, holders: false, coupon: false, maturity: false };
+
+/**
+ * Reload coordinator for the bond detail view (issue #4). Every mutation
+ * (subscribe, transfer, claim, mature, sweep) and the initial load go through
+ * `reload()`, which fetches the consolidated `bond/:id/detail` payload once and
+ * commits the bond summary, holders, coupon, and maturity together. Because the
+ * component derives every panel from this single committed snapshot, the UI
+ * never renders a mix of pre- and post-mutation data. Per-section loading flags
+ * let each panel show its own spinner, and `lastLoadedAt` (the server timestamp)
+ * supports staleness checks.
+ */
+@Injectable()
+export class BondDetailReloadCoordinator {
+  readonly detail = signal<BondDetailResponse | null>(null);
+  readonly loading = signal(false);
+  readonly sectionLoading = signal<SectionLoading>(IDLE_SECTIONS);
+  readonly lastLoadedAt = signal<string | null>(null);
+  readonly error = signal<string | null>(null);
+
+  private active: Subscription | null = null;
+
+  constructor(private readonly api: ApiService) {}
+
+  reload(id: number): void {
+    if (this.active) {
+      this.active.unsubscribe();
+    }
+    this.loading.set(true);
+    this.sectionLoading.set({ bond: true, holders: true, coupon: true, maturity: true });
+    this.error.set(null);
+
+    this.active = this.api.getBondDetail(id, { bustCache: true }).subscribe({
+      next: (detail) => {
+        this.detail.set(detail);
+        this.lastLoadedAt.set(detail.loadedAt);
+        this.commitIdle();
+      },
+      error: (err: any) => {
+        this.error.set(err?.error?.detail || err?.message || 'Failed to refresh bond data');
+        this.commitIdle();
+      },
+    });
+  }
+
+  private commitIdle(): void {
+    this.loading.set(false);
+    this.sectionLoading.set(IDLE_SECTIONS);
+  }
+
+  /** True if a newer server snapshot is known than the given client timestamp. */
+  isNewerThan(clientLoadedAt: string | null): boolean {
+    const server = this.lastLoadedAt();
+    if (!clientLoadedAt || !server) return false;
+    return Date.parse(server) > Date.parse(clientLoadedAt);
+  }
+
+  ngOnDestroy(): void {
+    this.active?.unsubscribe();
+  }
+}

--- a/frontend/src/app/projects/challenged-reports/challenged-reports.component.ts
+++ b/frontend/src/app/projects/challenged-reports/challenged-reports.component.ts
@@ -1,0 +1,95 @@
+import { Component, inject, OnInit, input, signal, ChangeDetectionStrategy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ApiService, ChallengedReportSummary } from '../../shared/services/api.service';
+
+/**
+ * Shows the challenged reports for a project (issue #3). Each entry links to the
+ * full challenge state via the API; this panel surfaces the counter-evidence
+ * hash, challenger, submitted time, and resolution so reviewers can act.
+ */
+@Component({
+  selector: 'app-challenged-reports',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <div class="challenged-card">
+      <h3 class="section-title">Challenged Reports</h3>
+
+      @if (loading()) {
+        <p class="muted">Loading challenge review…</p>
+      } @else if (error()) {
+        <p class="error-msg">{{ error() }}</p>
+      } @else if (reports().length === 0) {
+        <p class="muted">No active challenges for this project.</p>
+      } @else {
+        <ul class="challenged-list">
+          @for (entry of reports(); track entry.report.id) {
+            <li class="challenged-item">
+              <div class="row">
+                <span class="report-id">Report #{{ entry.report.id }}</span>
+                <span class="status" [class.challenged]="entry.report.status === 'Challenged'">
+                  {{ entry.report.status }}
+                </span>
+              </div>
+              @if (entry.challenge; as c) {
+                <div class="meta">
+                  <div><span class="label">Challenger</span> <span class="mono">{{ c.challengerAddress }}</span></div>
+                  <div><span class="label">Counter-evidence</span> <span class="mono">{{ c.counterEvidenceHash }}</span></div>
+                  <div><span class="label">Submitted</span> {{ c.submittedAt | date: 'medium' }}</div>
+                  <div>
+                    <span class="label">Resolution</span>
+                    {{ c.resolved ? (c.resolution || 'Resolved') : 'Pending' }}
+                  </div>
+                </div>
+              } @else {
+                <div class="meta"><span class="muted">No challenge record available.</span></div>
+              }
+            </li>
+          }
+        </ul>
+      }
+    </div>
+  `,
+  styles: [`
+    .challenged-card { background: #fff; border-radius: 12px; padding: 24px; box-shadow: 0 1px 4px rgba(0,0,0,0.08); }
+    .section-title { font-size: 1rem; font-weight: 600; margin-bottom: 12px; }
+    .muted { font-size: 0.8125rem; color: #6b7280; }
+    .error-msg { font-size: 0.8125rem; color: #ef4444; padding: 8px; background: #fef2f2; border-radius: 6px; }
+    .challenged-list { list-style: none; padding: 0; display: flex; flex-direction: column; gap: 12px; }
+    .challenged-item { border: 1px solid #fecaca; background: #fef2f2; border-radius: 8px; padding: 12px 14px; }
+    .row { display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px; }
+    .report-id { font-weight: 600; }
+    .status { font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.5px; padding: 2px 8px; border-radius: 999px; background: #fee2e2; color: #991b1b; }
+    .status.challenged { background: #fee2e2; color: #991b1b; }
+    .meta { display: flex; flex-direction: column; gap: 4px; font-size: 0.8125rem; }
+    .label { color: #6b7280; text-transform: uppercase; font-size: 0.7rem; margin-right: 6px; }
+    .mono { font-family: monospace; word-break: break-all; }
+  `],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ChallengedReportsComponent implements OnInit {
+  readonly projectId = input.required<string>();
+  private readonly api = inject(ApiService);
+
+  readonly reports = signal<ChallengedReportSummary[]>([]);
+  readonly loading = signal(true);
+  readonly error = signal('');
+
+  ngOnInit(): void {
+    const projectId = this.projectId();
+    if (!projectId) {
+      this.loading.set(false);
+      return;
+    }
+    this.api.getProjectChallengedReports(projectId).subscribe({
+      next: (reports) => {
+        this.reports.set(reports);
+        this.loading.set(false);
+      },
+      error: () => {
+        this.error.set('Failed to load challenged reports');
+        this.loading.set(false);
+      },
+    });
+  }
+}

--- a/frontend/src/app/projects/project-detail/project-detail.component.ts
+++ b/frontend/src/app/projects/project-detail/project-detail.component.ts
@@ -4,12 +4,13 @@ import { RouterModule, ActivatedRoute } from '@angular/router';
 import { ApiService } from '../../shared/services/api.service';
 import { StatusBadgeComponent } from '../../shared/components/status-badge/status-badge.component';
 import { LoadingSpinnerComponent } from '../../shared/components/loading-spinner/loading-spinner.component';
+import { ChallengedReportsComponent } from '../challenged-reports/challenged-reports.component';
 import { Project } from '../../shared/interfaces/bond.interface';
 
 @Component({
   selector: 'app-project-detail',
   standalone: true,
-  imports: [CommonModule, RouterModule, StatusBadgeComponent, LoadingSpinnerComponent],
+  imports: [CommonModule, RouterModule, StatusBadgeComponent, LoadingSpinnerComponent, ChallengedReportsComponent],
   template: `
     <div class="detail-page">
       <a class="back-link" routerLink="/projects">← Back to Projects</a>
@@ -56,6 +57,8 @@ import { Project } from '../../shared/interfaces/bond.interface';
             </div>
           </div>
         </div>
+
+        <app-challenged-reports [projectId]="p.id" />
       } @else if (loading()) {
         <div class="loading-section"><app-loading-spinner size="lg" /></div>
       } @else if (error()) {

--- a/frontend/src/app/shared/interfaces/bond.interface.ts
+++ b/frontend/src/app/shared/interfaces/bond.interface.ts
@@ -25,6 +25,12 @@ export interface HeldBond extends Bond {
   balance: string;
 }
 
+/** A single bond holder and their token balance (issue #4 detail refresh). */
+export interface HolderResponse {
+  address: string;
+  balance: string;
+}
+
 export interface Project {
   id: number;
   name: string;

--- a/frontend/src/app/shared/services/api.service.ts
+++ b/frontend/src/app/shared/services/api.service.ts
@@ -9,7 +9,7 @@ import {
   ClaimCreditsResponse, TransferResponse,
   UndistributedTotalResponse, SweepUndistributedResponse,
   QuoteBalanceResponse, QuoteTransactionResponse,
-  QuoteAsset, DepositQuoteDto, WithdrawQuoteDto,
+  QuoteAsset, DepositQuoteDto, WithdrawQuoteDto, HolderResponse,
 } from '../interfaces/bond.interface';
 
 export interface ProblemDetails {
@@ -28,6 +28,58 @@ export class ApiProblemError extends Error {
   constructor(readonly problem: ProblemDetails) {
     super(problem.detail || problem.title);
   }
+}
+
+/** Lifecycle status of an oracle report (see docs/oracle-challenge-lifecycle.md). */
+export type OracleReportStatus = 'Pending' | 'Verified' | 'Challenged' | 'Rejected';
+
+export interface ChallengeRecord {
+  reportId: number;
+  challengerAddress: string;
+  counterEvidenceHash: string;
+  submittedAt: string;
+  resolved: boolean;
+  resolution: OracleReportStatus | null;
+}
+
+export interface ChallengeStateResponse {
+  reportId: number;
+  status: OracleReportStatus;
+  challenged: boolean;
+  challenges: ChallengeRecord[];
+}
+
+export interface ChallengedReportSummary {
+  report: {
+    id: number;
+    projectId: string;
+    status: OracleReportStatus;
+    providerAddress: string;
+    createdAt: string;
+  };
+  challenge: ChallengeRecord | null;
+}
+
+export interface CouponEligibility {
+  projectId: string;
+  eligible: boolean;
+  reasons: string[];
+  blockedByReportIds: number[];
+}
+
+/**
+ * Consolidated, atomically-fetched bond detail (issue #4). A single call returns
+ * the bond summary, holders, coupon undistributed total, and maturity status so
+ * the frontend can refresh every panel together and never render a mix of
+ * pre- and post-mutation data. `loadedAt` is the server timestamp used by the
+ * client refresh model to detect staleness.
+ */
+export interface BondDetailResponse {
+  bond: Bond;
+  holders: HolderResponse[];
+  coupon: { undistributedTotal: string };
+  maturity: { reached: boolean; date: number; secondsUntil: number };
+  loadedAt: string;
 }
 
 @Injectable({ providedIn: 'root' })
@@ -182,5 +234,38 @@ export class ApiService {
 
   withdrawQuote(data: WithdrawQuoteDto): Observable<QuoteTransactionResponse> {
     return this.withProblemDetails(this.http.post<QuoteTransactionResponse>('/api/marketplace/withdraw', data, { headers: this.headers() }));
+  }
+
+  /** Challenge review (#oracle-challenge): challenged reports for a project. */
+  getProjectChallengedReports(projectId: string): Observable<ChallengedReportSummary[]> {
+    return this.withProblemDetails(
+      this.http.get<ChallengedReportSummary[]>(`/api/oracle/reports/${projectId}/challenges`),
+    );
+  }
+
+  /** Challenge review (#oracle-challenge): full challenge state + history for a report. */
+  getReportChallengeState(reportId: number): Observable<ChallengeStateResponse> {
+    return this.withProblemDetails(
+      this.http.get<ChallengeStateResponse>(`/api/oracle/challenges/${reportId}`),
+    );
+  }
+
+  /** Coupon-distribution eligibility for a project, gated by challenge state. */
+  getCouponEligibility(projectId: string): Observable<CouponEligibility> {
+    return this.withProblemDetails(
+      this.http.get<CouponEligibility>(`/api/oracle/projects/${projectId}/coupon-eligibility`),
+    );
+  }
+
+  /**
+   * Atomically refresh every panel of a bond's detail (issue #4). `_t` busts any
+   * HTTP cache so the client sees fresh post-mutation data; the response carries
+   * a server `loadedAt` timestamp the client uses for staleness detection.
+   */
+  getBondDetail(id: number, opts?: { bustCache?: boolean }): Observable<BondDetailResponse> {
+    const params = opts?.bustCache === false ? undefined : new HttpParams().set('_t', Date.now().toString());
+    return this.withProblemDetails(
+      this.http.get<BondDetailResponse>(`/api/bonds/${id}/detail`, { params }),
+    );
   }
 }


### PR DESCRIPTION
closes #120 
closes #118 
closes #121 
closes #90 

## Description: Guard tests & route matrix, marketplace reconciliation, oracle challenge review, bond-detail refresh


#### 1. Controller-level guard tests + route authorization matrix 
- `ROUTE_AUTHORIZATION_MATRIX` is now the single source of truth listing every controller route handler with its guards, role, and mutation flag.
- A runtime spec (`route-authorization.matrix.spec.ts`) walks each controller, reads the real `@UseGuards` metadata, and **fails the build** when a route is missing from the matrix or its guard set diverges.
- Behavioral guard specs per controller (bonds, auth, oracle, projects, marketplace) assert anonymous callers get `401` and authorized callers reach the service using header-driven fake guards.
- `guard-roles.spec.ts` unit-tests Jwt/Admin/Kyc/Provider guard logic and documents the gap that `ProviderGuard`/`KycGuard` are not yet attached to any route.

#### 2. Marketplace reconciliation job
- `DexReconciliationService` + `DexReconciliationScheduler` (every 10 min, configurable via `DEX_RECON_CRON`) compare on-chain quote balances and open orders against the ledger, report mismatches, and can repair them.
- `DexService` gained a quote-balance index invalidated on deposit/withdraw; reconciliation endpoints `POST/GET marketplace/reconciliation/{run,mismatches,repair}` added.
- Ships `docs/runbook-marketplace-reconciliation.md` and architecture updates.

#### 3. Oracle challenge review API + frontend 
- New oracle endpoints: `GET /oracle/reports/:projectId/challenges`, `GET /oracle/challenges/:reportId`, `GET /oracle/projects/:projectId/coupon-eligibility`.
- `BondService.distributeCoupon` now **blocks** when the referenced oracle report is `Challenged`/`Rejected` (optional `OracleService` dependency, wired via `OracleModule`).
- Frontend: 3 API methods, a `ChallengedReportsComponent` on project detail, and a coupon-eligibility warning on bond detail. Includes `docs/oracle-challenge-lifecycle.md`.

#### 4. Bond detail refresh model after mutations 
- New `GET /bonds/:id/detail` returns one atomically-fetched snapshot (bond, holders, coupon, maturity) plus a server `loadedAt` timestamp, with `Cache-Control: no-cache`.
- `BondDetailReloadCoordinator` coordinates per-panel loading and commits a single snapshot so the UI never shows mixed pre/post-mutation data. Used for subscribe, transfer, claim, mature, sweep, and a manual refresh.
- Includes API, coordinator, and component tests covering all refresh paths.

### Test plan
- `apps/api`: `npm test` — guard-matrix, guard-role, reconciliation, oracle-challenge, coupon-challenge, and bond-detail service specs.
- `apps/frontend`: `ng test` — coordinator and bond-detail component specs.
