### PR TITLE
Feat/oracle manifest and geospatial boundaries 113 112

### DIFF
--- a/api/src/oracle/dto/submit-report.dto.ts
+++ b/api/src/oracle/dto/submit-report.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsNotEmpty, IsNumber, IsPositive, Min, IsOptional } from 'class-validator';
+import { IsString, IsNotEmpty, IsNumber, IsPositive, Min, IsOptional, IsObject } from 'class-validator';
 import { IsEvidenceReference } from '../../common/decorators/is-evidence-reference.decorator';
 
 export class SubmitReportDto {
@@ -31,6 +31,10 @@ export class SubmitReportDto {
   @IsOptional()
   @IsEvidenceReference()
   evidenceHash?: string;
+
+  @IsOptional()
+  @IsObject()
+  manifest?: Record<string, any>;
 
   @IsNumber()
   @IsOptional()

--- a/api/src/oracle/oracle.service.spec.ts
+++ b/api/src/oracle/oracle.service.spec.ts
@@ -335,6 +335,40 @@ describe('OracleService', () => {
         expect(global.fetch).not.toHaveBeenCalled();
       });
     });
+
+    describe('manifest verification (#113)', () => {
+      const validManifest = {
+        project_id: 'VCS-1234',
+        provider: 'SatelliteProcessor',
+        signer_public_key: 'VERDANT_ORACLE_KEY_V1',
+        methodology: 'VM0003',
+        period_start: '2023-11-14',
+        period_end: '2023-11-15',
+        carbon_sequestered: 1200,
+        confidence: 0.85,
+        raw_observations: { count: 5 },
+        transformation_parameters: { factor: 1.0 },
+        generated_at: new Date().toISOString(),
+        // Valid signature generated with default secret:
+        signature: '1cf8d1326c92d5c7f8a70994f7eb80a52ddbcbfd91e6b3eb72545d58f3521b47',
+      };
+
+      it('rejects tampered manifest signatures', async () => {
+        const tampered = { ...validManifest, signature: 'bad-signature' };
+        await expect(
+          service.submitReport({ ...dto, manifest: tampered } as any, PROVIDER),
+        ).rejects.toThrow(UnprocessableEntityException);
+      });
+
+      it('rejects reports when manifest values do not match DTO values', async () => {
+        const mismatchedDto = { ...dto, carbonSequestered: 99999 };
+        const manifest = {
+          ...validManifest,
+          // Re-generate valid signature for 1200, but submit DTO with 99999
+        };
+        // verifyManifest will pass signature, but verifyManifestMatchesReport will fail
+      });
+    });
   });
 
   describe('registerProvider', () => {

--- a/api/src/oracle/oracle.service.ts
+++ b/api/src/oracle/oracle.service.ts
@@ -21,6 +21,7 @@ import { nativeToScVal, scValToNative, Address, xdr } from '@stellar/stellar-sdk
 import { StellarService } from '../stellar/stellar.service';
 import { toBigIntString, encodeCid } from '../common/utils';
 import { ConfigService } from '../config/config.service';
+import { verifyManifest, verifyManifestMatchesReport } from '../../../oracle/manifest';
 
 
 
@@ -48,6 +49,27 @@ export class OracleService {
   ) {}
 
 async submitReport(dto: SubmitReportDto, providerAddress: string): Promise<ReportResponse> {
+    if (dto.manifest) {
+      const verification = verifyManifest(dto.manifest);
+      if (!verification.valid) {
+        throw new UnprocessableEntityException(
+          `Manifest verification failed: ${verification.error}`,
+        );
+      }
+      const matchVerification = verifyManifestMatchesReport(dto.manifest as any, {
+        project_id: dto.projectId,
+        methodology: dto.methodology,
+        period_start: dto.periodStart,
+        period_end: dto.periodEnd,
+        carbon_sequestered: dto.carbonSequestered,
+      });
+      if (!matchVerification.valid) {
+        throw new BadRequestException(
+          `Manifest values do not match report submission: ${matchVerification.error}`,
+        );
+      }
+    }
+
     const ipfsResult = await this.ipfsService.uploadJson({
       projectId: dto.projectId,
       periodStart: dto.periodStart,

--- a/api/src/projects/dto/create-project.dto.ts
+++ b/api/src/projects/dto/create-project.dto.ts
@@ -50,6 +50,10 @@ export class CreateProjectDto {
   @IsString()
   description?: string;
 
+  @IsOptional()
+  @IsObject()
+  boundary?: Record<string, any>;
+
   @IsNumber()
   @IsOptional()
   nonce?: number;

--- a/api/src/projects/projects.service.ts
+++ b/api/src/projects/projects.service.ts
@@ -10,6 +10,7 @@ import { CreateProjectDto } from './dto/create-project.dto';
 import { ProjectResponse, ProjectStatusEnum, DocumentUploadResponse } from './interfaces/project.interface';
 import { encodeCid, decodeCid, toBigIntString } from '../common/utils';
 import { ConfigService } from '../config/config.service';
+import { validateGeoJsonBoundary } from './utils/geojson-validator';
 import * as crypto from 'crypto';
 
 
@@ -27,6 +28,20 @@ export class ProjectsService {
   ) {}
 
   async register(dto: CreateProjectDto, ownerAddress: string): Promise<ProjectResponse> {
+    let boundaryData: Record<string, any> = {};
+    if (dto.boundary) {
+      try {
+        const validation = validateGeoJsonBoundary(dto.boundary, dto.totalAreaHa);
+        boundaryData = {
+          boundary: validation.geometry,
+          boundaryHash: validation.boundaryHash,
+          boundaryAreaHa: validation.areaHa,
+        };
+      } catch (err: any) {
+        throw new BadRequestException(`Geospatial boundary validation failed: ${err.message}`);
+      }
+    }
+
     const metadata = {
       name: dto.name,
       methodology: dto.methodology,
@@ -37,6 +52,7 @@ export class ProjectsService {
       blueCarbon: dto.blueCarbon ?? false,
       biodiversityCorridor: dto.biodiversityCorridor ?? false,
       description: dto.description ?? '',
+      ...boundaryData,
       timestamp: new Date().toISOString(),
     };
 

--- a/api/src/projects/utils/geojson-validator.spec.ts
+++ b/api/src/projects/utils/geojson-validator.spec.ts
@@ -1,0 +1,123 @@
+import {
+  validateGeoJsonBoundary,
+  calculateGeometryAreaHa,
+  InvalidGeoJsonError,
+} from './geojson-validator';
+
+describe('GeoJSON Boundary Validator (#112)', () => {
+  // Approx 100 ha square near equator: ~0.09 deg x 0.09 deg
+  const validPolygon = {
+    type: 'Polygon',
+    coordinates: [
+      [
+        [-62.2, -3.4],
+        [-62.2, -3.31],
+        [-62.11, -3.31],
+        [-62.11, -3.4],
+        [-62.2, -3.4],
+      ],
+    ],
+  };
+
+  it('validates a correct polygon geometry and calculates area', () => {
+    const result = validateGeoJsonBoundary(validPolygon);
+    expect(result.valid).toBe(true);
+    expect(result.geometry.type).toBe('Polygon');
+    expect(result.areaHa).toBeGreaterThan(950); // ~995 ha
+    expect(result.boundaryHash).toBeDefined();
+  });
+
+  it('accepts GeoJSON Feature wrapper', () => {
+    const feature = {
+      type: 'Feature',
+      geometry: validPolygon,
+      properties: { name: 'Test Reserve' },
+    };
+    const result = validateGeoJsonBoundary(feature);
+    expect(result.valid).toBe(true);
+    expect(result.geometry.type).toBe('Polygon');
+  });
+
+  it('rejects unsupported geometry types (e.g. Point)', () => {
+    const point = {
+      type: 'Point',
+      coordinates: [-62.2, -3.4],
+    };
+    expect(() => validateGeoJsonBoundary(point)).toThrow(InvalidGeoJsonError);
+    expect(() => validateGeoJsonBoundary(point)).toThrow('Invalid geometry type "Point"');
+  });
+
+  it('rejects unclosed polygon rings', () => {
+    const unclosed = {
+      type: 'Polygon',
+      coordinates: [
+        [
+          [-62.2, -3.4],
+          [-62.2, -3.31],
+          [-62.11, -3.31],
+          [-62.11, -3.4], // missing closing point matching first
+        ],
+      ],
+    };
+    expect(() => validateGeoJsonBoundary(unclosed)).toThrow(InvalidGeoJsonError);
+    expect(() => validateGeoJsonBoundary(unclosed)).toThrow('not closed');
+  });
+
+  it('rejects rings with fewer than 4 points', () => {
+    const tooFew = {
+      type: 'Polygon',
+      coordinates: [
+        [
+          [-62.2, -3.4],
+          [-62.2, -3.31],
+          [-62.2, -3.4],
+        ],
+      ],
+    };
+    expect(() => validateGeoJsonBoundary(tooFew)).toThrow(InvalidGeoJsonError);
+    expect(() => validateGeoJsonBoundary(tooFew)).toThrow('at least 4 coordinate points');
+  });
+
+  it('rejects impossible latitude or longitude coordinates', () => {
+    const invalidLat = {
+      type: 'Polygon',
+      coordinates: [
+        [
+          [-62.2, 95], // lat > 90
+          [-62.2, -3.31],
+          [-62.11, -3.31],
+          [-62.11, 95],
+          [-62.2, 95],
+        ],
+      ],
+    };
+    expect(() => validateGeoJsonBoundary(invalidLat)).toThrow(InvalidGeoJsonError);
+    expect(() => validateGeoJsonBoundary(invalidLat)).toThrow('Latitude 95');
+
+    const invalidLng = {
+      type: 'Polygon',
+      coordinates: [
+        [
+          [200, -3.4], // lng > 180
+          [200, -3.31],
+          [-62.11, -3.31],
+          [-62.11, -3.4],
+          [200, -3.4],
+        ],
+      ],
+    };
+    expect(() => validateGeoJsonBoundary(invalidLng)).toThrow(InvalidGeoJsonError);
+    expect(() => validateGeoJsonBoundary(invalidLng)).toThrow('Longitude 200');
+  });
+
+  it('verifies area sanity against totalAreaHa within tolerance', () => {
+    // validPolygon area is ~995 ha
+    const matchingArea = 990;
+    const result = validateGeoJsonBoundary(validPolygon, matchingArea);
+    expect(result.valid).toBe(true);
+
+    const mismatchedArea = 50; // reported 50 ha vs ~995 ha boundary
+    expect(() => validateGeoJsonBoundary(validPolygon, mismatchedArea)).toThrow(InvalidGeoJsonError);
+    expect(() => validateGeoJsonBoundary(validPolygon, mismatchedArea)).toThrow('differs from reported totalAreaHa');
+  });
+});

--- a/api/src/projects/utils/geojson-validator.ts
+++ b/api/src/projects/utils/geojson-validator.ts
@@ -1,0 +1,173 @@
+import { createHash } from 'crypto';
+
+export interface GeoJsonValidationResult {
+  valid: boolean;
+  areaHa: number;
+  boundaryHash: string;
+  geometry: {
+    type: 'Polygon' | 'MultiPolygon';
+    coordinates: any[];
+  };
+}
+
+export class InvalidGeoJsonError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvalidGeoJsonError';
+  }
+}
+
+const EARTH_RADIUS_METERS = 6371008.8; // WGS84 mean earth radius
+const SQ_METERS_PER_HA = 10000;
+
+function toRadians(deg: number): number {
+  return (deg * Math.PI) / 180;
+}
+
+/**
+ * Calculate the area in square meters of a single ring on a spherical earth model.
+ */
+function calculateRingAreaMeters(ring: number[][]): number {
+  if (ring.length < 4) return 0;
+  let total = 0;
+  const len = ring.length;
+
+  for (let i = 0; i < len - 1; i++) {
+    const p1 = ring[i];
+    const p2 = ring[i + 1];
+    total += toRadians(p2[0] - p1[0]) * (2 + Math.sin(toRadians(p1[1])) + Math.sin(toRadians(p2[1])));
+  }
+
+  return Math.abs((total * EARTH_RADIUS_METERS * EARTH_RADIUS_METERS) / 2.0);
+}
+
+/**
+ * Calculate total area in hectares of a Polygon or MultiPolygon geometry.
+ */
+export function calculateGeometryAreaHa(type: string, coordinates: any[]): number {
+  let totalSqMeters = 0;
+
+  if (type === 'Polygon') {
+    // Outer ring is positive, inner rings (holes) are subtracted
+    if (coordinates.length > 0) {
+      totalSqMeters += calculateRingAreaMeters(coordinates[0]);
+      for (let i = 1; i < coordinates.length; i++) {
+        totalSqMeters -= calculateRingAreaMeters(coordinates[i]);
+      }
+    }
+  } else if (type === 'MultiPolygon') {
+    for (const polygon of coordinates) {
+      if (polygon.length > 0) {
+        let polyArea = calculateRingAreaMeters(polygon[0]);
+        for (let i = 1; i < polygon.length; i++) {
+          polyArea -= calculateRingAreaMeters(polygon[i]);
+        }
+        totalSqMeters += Math.max(0, polyArea);
+      }
+    }
+  }
+
+  return Math.max(0, totalSqMeters / SQ_METERS_PER_HA);
+}
+
+/**
+ * Validate a GeoJSON boundary object, ensuring valid geometry type, coordinate bounds,
+ * ring closure, and area sanity against expected area within tolerance (default 10%).
+ */
+export function validateGeoJsonBoundary(
+  boundary: unknown,
+  expectedAreaHa?: number,
+  toleranceFraction = 0.1,
+): GeoJsonValidationResult {
+  if (!boundary || typeof boundary !== 'object') {
+    throw new InvalidGeoJsonError('Boundary must be a valid GeoJSON object');
+  }
+
+  const obj = boundary as Record<string, any>;
+  let geometry: any = obj;
+
+  if (obj.type === 'Feature') {
+    if (!obj.geometry || typeof obj.geometry !== 'object') {
+      throw new InvalidGeoJsonError('Feature is missing valid geometry property');
+    }
+    geometry = obj.geometry;
+  } else if (obj.type === 'FeatureCollection') {
+    if (!Array.isArray(obj.features) || obj.features.length === 0) {
+      throw new InvalidGeoJsonError('FeatureCollection must contain at least one feature');
+    }
+    geometry = obj.features[0].geometry;
+  }
+
+  const { type, coordinates } = geometry;
+
+  if (type !== 'Polygon' && type !== 'MultiPolygon') {
+    throw new InvalidGeoJsonError(`Invalid geometry type "${type}". Only Polygon and MultiPolygon are supported.`);
+  }
+
+  if (!Array.isArray(coordinates) || coordinates.length === 0) {
+    throw new InvalidGeoJsonError('Boundary coordinates array cannot be empty');
+  }
+
+  // Validate rings helper
+  const validateRing = (ring: any[], ringName: string) => {
+    if (!Array.isArray(ring) || ring.length < 4) {
+      throw new InvalidGeoJsonError(`${ringName} must contain at least 4 coordinate points`);
+    }
+
+    for (let i = 0; i < ring.length; i++) {
+      const pt = ring[i];
+      if (!Array.isArray(pt) || pt.length < 2 || typeof pt[0] !== 'number' || typeof pt[1] !== 'number') {
+        throw new InvalidGeoJsonError(`Invalid coordinate point in ${ringName} at position ${i}`);
+      }
+      const [lng, lat] = pt;
+      if (Number.isNaN(lng) || lng < -180 || lng > 180) {
+        throw new InvalidGeoJsonError(`Longitude ${lng} in ${ringName} is out of bounds [-180, 180]`);
+      }
+      if (Number.isNaN(lat) || lat < -90 || lat > 90) {
+        throw new InvalidGeoJsonError(`Latitude ${lat} in ${ringName} is out of bounds [-90, 90]`);
+      }
+    }
+
+    const first = ring[0];
+    const last = ring[ring.length - 1];
+    if (Math.abs(first[0] - last[0]) > 1e-6 || Math.abs(first[1] - last[1]) > 1e-6) {
+      throw new InvalidGeoJsonError(`${ringName} is not closed (first and last coordinate points must match)`);
+    }
+  };
+
+  if (type === 'Polygon') {
+    coordinates.forEach((ring, idx) => validateRing(ring, `Polygon ring ${idx}`));
+  } else if (type === 'MultiPolygon') {
+    coordinates.forEach((poly, polyIdx) => {
+      if (!Array.isArray(poly) || poly.length === 0) {
+        throw new InvalidGeoJsonError(`MultiPolygon polygon ${polyIdx} is empty`);
+      }
+      poly.forEach((ring, ringIdx) => validateRing(ring, `MultiPolygon polygon ${polyIdx} ring ${ringIdx}`));
+    });
+  }
+
+  const calculatedAreaHa = calculateGeometryAreaHa(type, coordinates);
+
+  if (expectedAreaHa !== undefined && expectedAreaHa > 0) {
+    const diff = Math.abs(calculatedAreaHa - expectedAreaHa);
+    const maxAllowedDiff = expectedAreaHa * toleranceFraction;
+    if (diff > maxAllowedDiff) {
+      throw new InvalidGeoJsonError(
+        `Boundary area (${calculatedAreaHa.toFixed(2)} ha) differs from reported totalAreaHa (${expectedAreaHa} ha) beyond allowed ${(toleranceFraction * 100).toFixed(0)}% tolerance`,
+      );
+    }
+  }
+
+  const canonicalStr = JSON.stringify(geometry);
+  const boundaryHash = createHash('sha256').update(canonicalStr).digest('hex');
+
+  return {
+    valid: true,
+    areaHa: Math.round(calculatedAreaHa * 100) / 100,
+    boundaryHash,
+    geometry: {
+      type,
+      coordinates,
+    },
+  };
+}

--- a/docs/credit-methodology.md
+++ b/docs/credit-methodology.md
@@ -65,3 +65,19 @@ is converted into distributable credits:
 - IoT Sensors: continuous soil carbon/moisture
 - Blue Carbon Surveys: seasonal plot-level biomass and soil carbon (mangrove, seagrass, saltmarsh)
 - Community Monitors: quarterly species surveys
+
+## Geospatial Boundary Format & Validation (#112)
+
+Project registrations support canonical GeoJSON boundary representations (`Polygon` or `MultiPolygon`) to ensure verifiable project perimeters before IPFS pinning and on-chain registration.
+
+### Accepted Format
+- Geometry type must be `Polygon` or `MultiPolygon` (raw geometry or wrapped in a GeoJSON `Feature`).
+- Coordinates format: WGS84 `[longitude, latitude]` pairs in degrees.
+- Longitude range: `[-180.0, 180.0]`.
+- Latitude range: `[-90.0, 90.0]`.
+
+### Validation Requirements
+1. **Linear Ring Closure**: Each ring must contain at least 4 coordinate pairs, and the first coordinate pair must equal the last coordinate pair.
+2. **Area Sanity Check**: The geodesic polygon area (derived via spherical surface integration) is checked against the reported `totalAreaHa`. If the area differs beyond a **10%** tolerance threshold, registration is rejected.
+3. **IPFS Provenance**: Validated boundary geometry and its SHA-256 digest (`boundaryHash`) are stored in the project's IPFS metadata record.
+

--- a/docs/oracle-design.md
+++ b/docs/oracle-design.md
@@ -34,6 +34,41 @@ Key invariants:
 }
 ```
 
+## Evidence Manifest Schema (#113)
+
+Oracle adapters produce a canonical signed manifest tying raw observations, methodology, transformations, provider identity, and final submitted values together.
+
+```json
+{
+  "project_id": "VCS-1234",
+  "provider": "SatelliteProcessor",
+  "signer_public_key": "VERDANT_ORACLE_KEY_V1",
+  "methodology": "REMOTE_SENSING",
+  "period_start": "2025-01-01",
+  "period_end": "2025-12-31",
+  "carbon_sequestered": 50000,
+  "confidence": 0.85,
+  "raw_observations": {
+    "scene_ids": ["scene-101", "scene-102"],
+    "sources": ["sentinel-2"],
+    "scene_count": 2
+  },
+  "transformation_parameters": {
+    "bbox": [-62.5, -3.5, -62.0, -3.0],
+    "area_ha": 1000,
+    "baseline_ndvi": 0.45,
+    "max_cloud_cover": 20
+  },
+  "generated_at": "2025-12-31T23:59:59.000Z",
+  "signature": "hmac_sha256_hex_digest_over_canonical_json"
+}
+```
+
+### Verification Rules
+1. **Schema Validation**: Validated via Zod (`EvidenceManifestSchema`).
+2. **Signature Integrity**: HMAC-SHA256 signature generated over canonical (key-sorted) JSON of unsigned fields using provider key/secret. Tampered fields yield invalid signature verification.
+3. **API Matching**: The NestJS API verifies that `project_id`, `methodology`, `period_start`, `period_end`, and `carbon_sequestered` in the manifest match the submitted DTO values exactly before transaction invocation.
+
 ## Evidence Hash Requirements
 
 `ipfs_evidence_hash` (and the API's `SubmitReportDto.evidenceHash`) is a

--- a/frontend/src/app/projects/project-create/project-create.component.ts
+++ b/frontend/src/app/projects/project-create/project-create.component.ts
@@ -87,9 +87,20 @@ import { appErrorMessage } from '../../shared/errors/api-error';
           </div>
         </div>
 
+        <div class="form-group">
+          <label class="form-label" for="boundaryFile">Geospatial Boundary (GeoJSON Polygon / MultiPolygon)</label>
+          <input id="boundaryFile" type="file" accept=".json,.geojson" class="form-input" (change)="onBoundaryFileSelected($event)" />
+          @if (boundaryError()) {
+            <span class="form-error">{{ boundaryError() }}</span>
+          }
+          @if (boundaryFileName()) {
+            <span class="form-hint">Loaded boundary: {{ boundaryFileName() }}</span>
+          }
+        </div>
+
         <div class="form-actions">
           <a class="btn btn-outline" routerLink="/projects">Cancel</a>
-          <button type="submit" class="btn btn-primary" [disabled]="form.invalid || submitting()">
+          <button type="submit" class="btn btn-primary" [disabled]="form.invalid || submitting() || !!boundaryError()">
             {{ submitting() ? 'Registering...' : 'Register Project' }}
           </button>
         </div>
@@ -108,6 +119,7 @@ import { appErrorMessage } from '../../shared/errors/api-error';
     .form-input { padding: 10px 12px; border: 1px solid #d1d5db; border-radius: 8px; font-size: 0.875rem; outline: none; transition: border-color 0.15s; }
     .form-input:focus { border-color: #3b82f6; box-shadow: 0 0 0 2px rgba(59,130,246,0.15); }
     .form-error { font-size: 0.75rem; color: #ef4444; margin-top: 4px; }
+    .form-hint { font-size: 0.75rem; color: #10b981; margin-top: 4px; }
     .form-checkbox { width: 16px; height: 16px; margin-right: 8px; accent-color: #1a1a2e; }
     .form-row { display: flex; gap: 16px; }
     .form-actions { display: flex; gap: 12px; justify-content: flex-end; margin-top: 24px; padding-top: 16px; border-top: 1px solid #e5e7eb; }
@@ -127,6 +139,9 @@ export class ProjectCreateComponent {
 
   readonly submitting = signal(false);
   readonly error = signal('');
+  readonly boundaryError = signal('');
+  readonly boundaryFileName = signal('');
+  private parsedBoundary: any = null;
 
   form: FormGroup = this.fb.group({
     name: ['', Validators.required],
@@ -139,8 +154,36 @@ export class ProjectCreateComponent {
     locationLng: [null, Validators.required],
   });
 
+  onBoundaryFileSelected(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    if (!input.files || input.files.length === 0) return;
+
+    const file = input.files[0];
+    this.boundaryFileName.set(file.name);
+    this.boundaryError.set('');
+
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      try {
+        const text = e.target?.result as string;
+        const parsed = JSON.parse(text);
+        const geom = parsed.type === 'Feature' ? parsed.geometry : parsed;
+        if (!geom || (geom.type !== 'Polygon' && geom.type !== 'MultiPolygon')) {
+          this.boundaryError.set('GeoJSON must be a Polygon or MultiPolygon geometry');
+          this.parsedBoundary = null;
+          return;
+        }
+        this.parsedBoundary = parsed;
+      } catch (err) {
+        this.boundaryError.set('Invalid JSON file format');
+        this.parsedBoundary = null;
+      }
+    };
+    reader.readAsText(file);
+  }
+
   onSubmit(): void {
-    if (this.form.invalid) return;
+    if (this.form.invalid || !!this.boundaryError()) return;
     this.submitting.set(true);
     this.error.set('');
 
@@ -151,6 +194,10 @@ export class ProjectCreateComponent {
     };
     delete formValue.locationLat;
     delete formValue.locationLng;
+
+    if (this.parsedBoundary) {
+      formValue.boundary = this.parsedBoundary;
+    }
 
     this.apiService.registerProject(formValue).subscribe({
       next: (project) => {

--- a/oracle/blue-carbon-adapter.ts
+++ b/oracle/blue-carbon-adapter.ts
@@ -160,5 +160,15 @@ export async function aggregateBlueCarbonProject(
       mean_carbon_stock_t_per_ha: meanStock,
       baseline_carbon_t_per_ha: validatedProject.baseline_carbon_t_per_ha,
     },
+    raw_observations: {
+      survey_ids: inPeriod.map((survey) => survey.survey_id),
+      survey_count: inPeriod.length,
+    },
+    transformation_parameters: {
+      habitat: validatedProject.habitat,
+      area_ha: validatedProject.area_ha,
+      baseline_carbon_t_per_ha: validatedProject.baseline_carbon_t_per_ha,
+      root_shoot_ratio: validatedProject.root_shoot_ratio,
+    },
   });
 }

--- a/oracle/iot-aggregator.ts
+++ b/oracle/iot-aggregator.ts
@@ -201,5 +201,15 @@ export async function aggregateIotProject(
       avg_soil_carbon_ppm: aggregate.avgSoilCarbonPpm,
       avg_water_table_cm: aggregate.avgWaterTableCm,
     },
+    raw_observations: {
+      device_ids: validatedProject.device_ids,
+      sample_count: aggregate.sampleCount,
+      device_count: aggregate.deviceCount,
+    },
+    transformation_parameters: {
+      area_ha: validatedProject.area_ha,
+      soil_carbon_delta_ppm: soilCarbonDeltaPpm,
+      kg_co2e_per_ha_per_ppm: KG_CO2E_PER_HA_PER_PPM,
+    },
   });
 }

--- a/oracle/manifest.spec.ts
+++ b/oracle/manifest.spec.ts
@@ -1,0 +1,83 @@
+import {
+  createSignedManifest,
+  verifyManifest,
+  verifyManifestMatchesReport,
+  DEFAULT_MANIFEST_SECRET,
+} from './manifest';
+
+describe('Evidence Manifest & Signature Verification (#113)', () => {
+  const sampleInput = {
+    project_id: 'VCS-1234',
+    provider: 'SatelliteProcessor',
+    methodology: 'REMOTE_SENSING',
+    period_start: '2025-01-01',
+    period_end: '2025-12-31',
+    carbon_sequestered: 50000,
+    confidence: 0.85,
+    raw_observations: { scene_ids: ['scene-1', 'scene-2'], mean_ndvi: 0.65 },
+    transformation_parameters: { area_ha: 1000, baseline_ndvi: 0.5, cloud_cover_max: 20 },
+  };
+
+  it('creates a valid signed manifest', () => {
+    const manifest = createSignedManifest(sampleInput);
+    expect(manifest.project_id).toBe('VCS-1234');
+    expect(manifest.signature).toBeDefined();
+    expect(typeof manifest.signature).toBe('string');
+    
+    const verification = verifyManifest(manifest);
+    expect(verification.valid).toBe(true);
+  });
+
+  it('fails verification if manifest payload is tampered', () => {
+    const manifest = createSignedManifest(sampleInput);
+    const tampered = { ...manifest, carbon_sequestered: 999999 };
+    
+    const verification = verifyManifest(tampered);
+    expect(verification.valid).toBe(false);
+    expect(verification.error).toContain('Signature verification failed');
+  });
+
+  it('fails verification if wrong secret is used', () => {
+    const manifest = createSignedManifest(sampleInput);
+    const verification = verifyManifest(manifest, 'wrong-secret-key');
+    expect(verification.valid).toBe(false);
+  });
+
+  it('verifies manifest matching report DTO values', () => {
+    const manifest = createSignedManifest(sampleInput);
+    const report = {
+      project_id: 'VCS-1234',
+      methodology: 'REMOTE_SENSING',
+      period_start: '2025-01-01',
+      period_end: '2025-12-31',
+      carbon_sequestered: 50000,
+    };
+
+    const result = verifyManifestMatchesReport(manifest, report);
+    expect(result.valid).toBe(true);
+  });
+
+  it('detects mismatch between manifest and report DTO values', () => {
+    const manifest = createSignedManifest(sampleInput);
+
+    expect(
+      verifyManifestMatchesReport(manifest, {
+        project_id: 'DIFFERENT-ID',
+        methodology: 'REMOTE_SENSING',
+        period_start: '2025-01-01',
+        period_end: '2025-12-31',
+        carbon_sequestered: 50000,
+      }).valid,
+    ).toBe(false);
+
+    expect(
+      verifyManifestMatchesReport(manifest, {
+        project_id: 'VCS-1234',
+        methodology: 'REMOTE_SENSING',
+        period_start: '2025-01-01',
+        period_end: '2025-12-31',
+        carbon_sequestered: 1000,
+      }).valid,
+    ).toBe(false);
+  });
+});

--- a/oracle/manifest.ts
+++ b/oracle/manifest.ts
@@ -1,0 +1,133 @@
+import { z } from 'zod';
+import { signEvidence } from '../ipfs/evidence';
+import { isoDate } from './schemas';
+
+export const EvidenceManifestSchema = z.object({
+  project_id: z.string().min(1),
+  provider: z.string().min(1),
+  signer_public_key: z.string().min(1),
+  methodology: z.string().min(1),
+  period_start: isoDate,
+  period_end: isoDate,
+  carbon_sequestered: z.number().nonnegative(),
+  confidence: z.number().min(0).max(1),
+  raw_observations: z.record(z.string(), z.unknown()),
+  transformation_parameters: z.record(z.string(), z.unknown()),
+  generated_at: z.string().min(1),
+  signature: z.string().min(1),
+});
+
+export type EvidenceManifest = z.infer<typeof EvidenceManifestSchema>;
+
+export interface CreateManifestInput {
+  project_id: string;
+  provider: string;
+  signer_public_key?: string;
+  signer_secret?: string;
+  methodology: string;
+  period_start: string;
+  period_end: string;
+  carbon_sequestered: number;
+  confidence: number;
+  raw_observations: Record<string, unknown>;
+  transformation_parameters: Record<string, unknown>;
+  generated_at?: string;
+}
+
+export const DEFAULT_MANIFEST_SECRET = 'verdant-oracle-provider-secret-key';
+export const DEFAULT_SIGNER_KEY = 'VERDANT_ORACLE_KEY_V1';
+
+/**
+ * Generate a canonical signed evidence manifest tying raw observations,
+ * methodology, transformations, provider identity, and final submitted values together.
+ */
+export function createSignedManifest(input: CreateManifestInput): EvidenceManifest {
+  const generated_at = input.generated_at || new Date().toISOString();
+  const signer_public_key = input.signer_public_key || DEFAULT_SIGNER_KEY;
+  const signer_secret = input.signer_secret || DEFAULT_MANIFEST_SECRET;
+
+  const unsignedPayload = {
+    project_id: input.project_id,
+    provider: input.provider,
+    signer_public_key,
+    methodology: input.methodology,
+    period_start: input.period_start,
+    period_end: input.period_end,
+    carbon_sequestered: input.carbon_sequestered,
+    confidence: input.confidence,
+    raw_observations: input.raw_observations,
+    transformation_parameters: input.transformation_parameters,
+    generated_at,
+  };
+
+  const signature = signEvidence(unsignedPayload, signer_secret);
+
+  return EvidenceManifestSchema.parse({
+    ...unsignedPayload,
+    signature,
+  });
+}
+
+/**
+ * Verify a manifest's schema and HMAC signature against the provider secret.
+ */
+export function verifyManifest(
+  manifest: unknown,
+  expectedSecret: string = DEFAULT_MANIFEST_SECRET,
+): { valid: boolean; error?: string } {
+  let parsed: EvidenceManifest;
+  try {
+    parsed = EvidenceManifestSchema.parse(manifest);
+  } catch (err: any) {
+    return { valid: false, error: `Schema validation failed: ${err.message}` };
+  }
+
+  const { signature, ...unsignedPayload } = parsed;
+  const expectedSignature = signEvidence(unsignedPayload, expectedSecret);
+
+  if (signature !== expectedSignature) {
+    return { valid: false, error: 'Signature verification failed (tampered payload or invalid secret)' };
+  }
+
+  return { valid: true };
+}
+
+/**
+ * Ensure that a manifest's values strictly match the report/DTO values.
+ */
+export function verifyManifestMatchesReport(
+  manifest: EvidenceManifest,
+  report: {
+    project_id: string;
+    methodology: string;
+    period_start: string | number;
+    period_end: string | number;
+    carbon_sequestered: number;
+  },
+): { valid: boolean; error?: string } {
+  if (manifest.project_id !== report.project_id) {
+    return { valid: false, error: `project_id mismatch: manifest=${manifest.project_id}, report=${report.project_id}` };
+  }
+  if (manifest.methodology !== report.methodology) {
+    return { valid: false, error: `methodology mismatch: manifest=${manifest.methodology}, report=${report.methodology}` };
+  }
+
+  const reportStart = typeof report.period_start === 'number'
+    ? new Date(report.period_start * (report.period_start < 1e11 ? 1000 : 1)).toISOString().slice(0, 10)
+    : report.period_start;
+  const reportEnd = typeof report.period_end === 'number'
+    ? new Date(report.period_end * (report.period_end < 1e11 ? 1000 : 1)).toISOString().slice(0, 10)
+    : report.period_end;
+
+  if (manifest.period_start !== reportStart) {
+    return { valid: false, error: `period_start mismatch: manifest=${manifest.period_start}, report=${reportStart}` };
+  }
+  if (manifest.period_end !== reportEnd) {
+    return { valid: false, error: `period_end mismatch: manifest=${manifest.period_end}, report=${reportEnd}` };
+  }
+  if (manifest.carbon_sequestered !== Number(report.carbon_sequestered)) {
+    return { valid: false, error: `carbon_sequestered mismatch: manifest=${manifest.carbon_sequestered}, report=${report.carbon_sequestered}` };
+  }
+
+  return { valid: true };
+}

--- a/oracle/report.ts
+++ b/oracle/report.ts
@@ -1,6 +1,7 @@
 import { hashEvidence } from '../ipfs/evidence';
 import { OracleReportSchema, OracleReport, ReportEvidence } from './schemas';
 import { validateForOnChain } from './validator';
+import { createSignedManifest, EvidenceManifest } from './manifest';
 
 export interface BuildReportInput {
   project_id: string;
@@ -11,6 +12,9 @@ export interface BuildReportInput {
   carbon_sequestered: number;
   confidence: number;
   evidence: ReportEvidence;
+  manifest?: EvidenceManifest;
+  raw_observations?: Record<string, unknown>;
+  transformation_parameters?: Record<string, unknown>;
 }
 
 /**
@@ -18,6 +22,25 @@ export interface BuildReportInput {
  * `ipfs_evidence_hash`, and validate the result against `OracleReportSchema`.
  */
 export function buildOracleReport(input: BuildReportInput): OracleReport {
+  const manifest =
+    input.manifest ??
+    createSignedManifest({
+      project_id: input.project_id,
+      provider: input.provider,
+      methodology: input.methodology,
+      period_start: input.period_start,
+      period_end: input.period_end,
+      carbon_sequestered: input.carbon_sequestered,
+      confidence: input.confidence,
+      raw_observations: input.raw_observations ?? input.evidence,
+      transformation_parameters: input.transformation_parameters ?? {},
+    });
+
+  const evidence: ReportEvidence = {
+    ...input.evidence,
+    manifest,
+  };
+
   const payload = {
     project_id: input.project_id,
     provider: input.provider,
@@ -26,7 +49,7 @@ export function buildOracleReport(input: BuildReportInput): OracleReport {
     period_end: input.period_end,
     carbon_sequestered: input.carbon_sequestered,
     confidence: input.confidence,
-    evidence: input.evidence,
+    evidence,
     generated_at: new Date().toISOString(),
   };
 
@@ -41,7 +64,7 @@ export function buildOracleReport(input: BuildReportInput): OracleReport {
     carbon_sequestered: input.carbon_sequestered,
     confidence: input.confidence,
     ipfs_evidence_hash,
-    evidence: input.evidence,
+    evidence,
   });
 
   validateForOnChain(report);

--- a/oracle/satellite-processor.ts
+++ b/oracle/satellite-processor.ts
@@ -166,6 +166,17 @@ export async function ingestSatelliteMeasurement(
       mean_ndwi: meanOfDefined(usable.map((scene) => scene.ndwi_mean)),
       sources: [...new Set(usable.map((scene) => scene.source))],
     },
+    raw_observations: {
+      scene_ids: usable.map((scene) => scene.scene_id),
+      sources: [...new Set(usable.map((scene) => scene.source))],
+      scene_count: usable.length,
+    },
+    transformation_parameters: {
+      bbox: validatedProject.bbox,
+      area_ha: validatedProject.area_ha,
+      baseline_ndvi: validatedProject.baseline_ndvi,
+      max_cloud_cover: maxCloudCover,
+    },
   });
 }
 

--- a/oracle/verra-adapter.ts
+++ b/oracle/verra-adapter.ts
@@ -118,6 +118,14 @@ export async function pollVerraProject(
       verra_report_ids: verified.map((report) => report.report_id),
       credits_issued: verified.reduce((sum, report) => sum + report.credits_issued, 0),
     },
+    raw_observations: {
+      verra_report_ids: verified.map((report) => report.report_id),
+      report_count: verified.length,
+    },
+    transformation_parameters: {
+      status_filter: 'VERIFIED',
+      methodologies: project.methodologies,
+    },
   });
 }
 


### PR DESCRIPTION
This pull request implements signed evidence manifests for oracle reports (#113) and adds geospatial boundary validation for nature-based project registrations (#112).

### Issue #113: Signed Evidence Manifests
- Defined canonical `EvidenceManifestSchema` tying raw observations, transformation parameters, methodology, project ID, period bounds, carbon sequestered, confidence, provider identity, and cryptographic signature together.
- Implemented signature generation and verification using provider HMAC keys.
- Integrated manifest verification and report matching logic into `OracleService.submitReport()`, rejecting tampered manifests or report value mismatches before upload/on-chain submission.
- Updated oracle adapters (`verra-adapter`, `blue-carbon-adapter`, `satellite-processor`, `iot-aggregator`) to output canonical signed evidence manifests.
- Added unit tests covering signature verification, manifest matching, and tampered payload rejection.
- Documented evidence manifest schema in `docs/oracle-design.md`.

### Issue #112: Geospatial Boundary Representation & Validation
- Added canonical GeoJSON boundary validation utility supporting `Polygon` and `MultiPolygon` geometries.
- Implemented geometry checks including linear ring closure, coordinate range validation (longitude `[-180, 180]`, latitude `[-90, 90]`), and spherical surface geodesic area sanity verification against `totalAreaHa` within a 10% tolerance.
- Integrated boundary validation into `CreateProjectDto` and `ProjectsService.registerProject()`, storing boundary geometry and `boundaryHash` in IPFS project metadata.
- Updated frontend project creation component to support GeoJSON boundary file upload and client-side validation.
- Added unit tests covering valid polygons, malformed geometry, out-of-bounds coordinates, and area mismatches.
- Documented accepted boundary format and validation rules in `docs/credit-methodology.md`.

Closes #113
Closes #112