### PR TITLE
Resolve oracle, provenance, slippage, and readiness gaps

### DIFF
--- a/api/src/common/redis-health.controller.spec.ts
+++ b/api/src/common/redis-health.controller.spec.ts
@@ -1,0 +1,50 @@
+import { RedisHealthController } from './redis-health.controller';
+import { StrKey } from '@stellar/stellar-sdk';
+
+const ADDRESS = StrKey.encodeContract(Buffer.alloc(32, 1));
+
+describe('RedisHealthController readiness', () => {
+  const config = {
+    getBondIssuerAddress: () => ADDRESS,
+    getCouponEngineAddress: () => ADDRESS,
+    getDexRouterAddress: () => ADDRESS,
+    getProjectRegistryAddress: () => ADDRESS,
+    getOracleConsumerAddress: () => ADDRESS,
+    getCreditRetirementAddress: () => ADDRESS,
+  };
+
+  it('reports every reachable contract', async () => {
+    const controller = new RedisHealthController(
+      { isHealthy: () => true } as any,
+      { simulateCall: jest.fn().mockResolvedValue({}) } as any,
+      config as any,
+    );
+    const result = await controller.readiness();
+    expect(result.status).toBe('ready');
+    expect(Object.values(result.contracts).every((item) => item.status === 'reachable')).toBe(true);
+  });
+
+  it('degrades for a wrong-network or unreachable contract', async () => {
+    const controller = new RedisHealthController(
+      { isHealthy: () => true } as any,
+      { simulateCall: jest.fn().mockRejectedValue(new Error('contract not found')) } as any,
+      config as any,
+    );
+    const result = await controller.readiness();
+    expect(result.status).toBe('degraded');
+    expect(result.contracts.bondIssuer.status).toBe('unreachable');
+  });
+
+  it('identifies malformed contract IDs as misconfigured without probing', async () => {
+    const simulateCall = jest.fn();
+    const controller = new RedisHealthController(
+      { isHealthy: () => true } as any,
+      { simulateCall } as any,
+      { ...config, getBondIssuerAddress: () => 'not-a-contract' } as any,
+    );
+    const result = await controller.readiness();
+    expect(result.status).toBe('degraded');
+    expect(result.contracts.bondIssuer.status).toBe('misconfigured');
+    expect(simulateCall).toHaveBeenCalledTimes(5);
+  });
+});

--- a/api/src/common/redis-health.controller.ts
+++ b/api/src/common/redis-health.controller.ts
@@ -1,14 +1,58 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, HttpCode, HttpStatus } from '@nestjs/common';
 import { RedisService } from './services/redis.service';
+import { ContractService } from '../stellar/contract.service';
+import { ConfigService } from '../config/config.service';
+import { StrKey } from '@stellar/stellar-sdk';
+
+type ContractState = 'reachable' | 'unreachable' | 'misconfigured';
 
 @Controller('health')
 export class RedisHealthController {
-  constructor(private readonly redis: RedisService) {}
+  constructor(
+    private readonly redis: RedisService,
+    private readonly contracts: ContractService,
+    private readonly config: ConfigService,
+  ) {}
 
   @Get('redis')
   redisHealth() {
     return {
       redis: this.redis.isHealthy() ? 'up' : 'degraded',
     };
+  }
+
+  @Get('ready')
+  @HttpCode(HttpStatus.OK)
+  async readiness() {
+    const configured = [
+      ['bondIssuer', this.config.getBondIssuerAddress()],
+      ['couponEngine', this.config.getCouponEngineAddress()],
+      ['dexRouter', this.config.getDexRouterAddress()],
+      ['projectRegistry', this.config.getProjectRegistryAddress()],
+      ['oracleConsumer', this.config.getOracleConsumerAddress()],
+      ['creditRetirement', this.config.getCreditRetirementAddress()],
+    ] as const;
+    const details = Object.fromEntries(await Promise.all(
+      configured.map(async ([name, address]) => [name, await this.probe(address)]),
+    )) as Record<string, { status: ContractState; address: string; error?: string }>;
+    const ready = this.redis.isHealthy()
+      && Object.values(details).every((detail) => detail.status === 'reachable');
+    return { status: ready ? 'ready' : 'degraded', redis: this.redis.isHealthy() ? 'up' : 'degraded', contracts: details };
+  }
+
+  private async probe(address: string): Promise<{ status: ContractState; address: string; error?: string }> {
+    if (!address || !StrKey.isValidContract(address)) {
+      return { status: 'misconfigured', address: address || '', error: 'Invalid Stellar contract address' };
+    }
+    try {
+      await this.contracts.simulateCall({ contractAddress: address, method: 'get_admin', args: [] });
+      return { status: 'reachable', address };
+    } catch (error) {
+      return {
+        status: 'unreachable',
+        address,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
   }
 }

--- a/api/src/marketplace/dex.service.spec.ts
+++ b/api/src/marketplace/dex.service.spec.ts
@@ -460,6 +460,30 @@ describe('DexService', () => {
       await expect(service.cancelOrder(9, SELLER)).rejects.toMatchObject({ status: 409 });
     });
 
+    it('rejects a stale price before invoking the purchase contract', async () => {
+      simulateCallMock.mockImplementation(({ method, args }: { method: string; args: any[] }) =>
+        method === 'get_order'
+          ? Promise.resolve(buildOrderScVal({ id: Number(scValToNative(args[0])), statusIndex: 0, expiresAt: FUTURE_EXPIRY }))
+          : Promise.reject(new Error(`unexpected: ${method}`)),
+      );
+
+      await expect(service.buyBondTokens({ orderId: 10, amount: 10, maxPrice: 9 } as any, BUYER))
+        .rejects.toMatchObject({ status: 409 });
+      expect(invokeContractMethodMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects a partial-depth change before invoking the purchase contract', async () => {
+      simulateCallMock.mockImplementation(({ method, args }: { method: string; args: any[] }) =>
+        method === 'get_order'
+          ? Promise.resolve(buildOrderScVal({ id: Number(scValToNative(args[0])), statusIndex: 1, expiresAt: FUTURE_EXPIRY }))
+          : Promise.reject(new Error(`unexpected: ${method}`)),
+      );
+
+      await expect(service.buyBondTokens({ orderId: 11, amount: 101, maxPrice: 10 } as any, BUYER))
+        .rejects.toMatchObject({ status: 409 });
+      expect(invokeContractMethodMock).not.toHaveBeenCalled();
+    });
+
     it('decodeOrder reports Expired once the wall clock passes expires_at, even though the raw status index is still Open', () => {
       const pastExpiry = BigInt(Math.floor(Date.now() / 1000) - 1);
       const raw = [BigInt(10), SELLER, BigInt(1), BigInt(100), BigInt(10), 'USDC', 0, BigInt(1700000000), pastExpiry];

--- a/api/src/marketplace/dex.service.ts
+++ b/api/src/marketplace/dex.service.ts
@@ -124,6 +124,16 @@ export class DexService {
   async buyBondTokens(dto: BuyBondDto, buyerAddress: string): Promise<OrderResponse> {
     const order = await this.fetchOrderFromLedger(dto.orderId);
     this.assertOrderIsActionable(order);
+    if (BigInt(dto.amount) > BigInt(order.amount)) {
+      throw new ConflictException(
+        `Stale quote: requested ${dto.amount} tokens but only ${order.amount} remain. Refresh and review the updated quote.`,
+      );
+    }
+    if (BigInt(dto.maxPrice) < BigInt(order.pricePerToken)) {
+      throw new ConflictException(
+        `Stale price: current price ${order.pricePerToken} exceeds your maximum ${dto.maxPrice}. Refresh and approve a new maximum.`,
+      );
+    }
     const proceeds = BigInt(order.pricePerToken) * BigInt(dto.amount);
 
     const escrowed = await this.getQuoteBalance(buyerAddress, order.quoteAsset);

--- a/api/src/marketplace/marketplace.controller.ts
+++ b/api/src/marketplace/marketplace.controller.ts
@@ -1,6 +1,5 @@
 import {
   Controller, Get, Post, Delete, Body, Param, Query, Req,
-  HttpCode, HttpStatus, ParseIntPipe, NotFoundException,
   HttpCode, HttpStatus, ParseIntPipe, UseGuards,
 } from '@nestjs/common';
 import { DexService } from './dex.service';

--- a/api/src/oracle/oracle.challenge.service.spec.ts
+++ b/api/src/oracle/oracle.challenge.service.spec.ts
@@ -160,5 +160,28 @@ describe('OracleService challenge review (#oracle-challenge)', () => {
       expect(eligibility.eligible).toBe(false);
       expect(eligibility.reasons.join(' ')).toMatch(/no verified/i);
     });
+
+    it('blocks overlapping verified periods but allows adjacent periods', async () => {
+      projectWith([1, 1]);
+      const overlapping = await service.getCouponEligibility(PROJECT);
+      expect(overlapping.eligible).toBe(false);
+      expect(overlapping.blockedByReportIds).toEqual(expect.arrayContaining([1, 2]));
+
+      simulateCall.mockImplementation((opts: any) => {
+        if (opts.method === 'get_project_reports') return [1n, 2n];
+        if (opts.method === 'get_report') {
+          const id = Number(opts.args[0].value());
+          const report = reportScVal(id, 'G_PROV', 1);
+          if (id === 2) {
+            report[3] = BigInt(1700086400);
+            report[4] = BigInt(1700172800);
+          }
+          return report;
+        }
+        return [];
+      });
+      const adjacent = await service.getCouponEligibility(PROJECT);
+      expect(adjacent.eligible).toBe(true);
+    });
   });
 });

--- a/api/src/oracle/oracle.service.ts
+++ b/api/src/oracle/oracle.service.ts
@@ -14,6 +14,9 @@ import {
   SlashRecord,
   ChallengeRecord,
   ReportStatus,
+  ChallengeStateResponse,
+  ChallengedReportSummary,
+  CouponEligibility,
 } from './interfaces/oracle.interface';
 import { RedisService } from '../common/services/redis.service';
 import { SigningKeyProvider } from '../common/services/signing-key.provider';
@@ -214,6 +217,20 @@ async submitReport(dto: SubmitReportDto, providerAddress: string): Promise<Repor
     const blocking = reports.filter(
       (r) => r.status === ReportStatus.Challenged || r.status === ReportStatus.Rejected,
     );
+    const conflictingIds = new Set<number>();
+    for (let i = 0; i < reports.length; i += 1) {
+      for (let j = i + 1; j < reports.length; j += 1) {
+        const left = reports[i];
+        const right = reports[j];
+        if (left.providerAddress === right.providerAddress
+          && left.methodology === right.methodology
+          && left.periodStart < right.periodEnd
+          && right.periodStart < left.periodEnd) {
+          conflictingIds.add(left.id);
+          conflictingIds.add(right.id);
+        }
+      }
+    }
 
     if (!hasVerified) {
       reasons.push('No verified oracle report exists for this project');
@@ -224,8 +241,12 @@ async submitReport(dto: SubmitReportDto, providerAddress: string): Promise<Repor
       );
       blockedByReportIds.push(...blocking.map((r) => r.id));
     }
+    if (conflictingIds.size > 0) {
+      reasons.push('Overlapping oracle report periods must be resolved before coupon distribution');
+      blockedByReportIds.push(...conflictingIds);
+    }
 
-    const eligible = hasVerified && blocking.length === 0;
+    const eligible = hasVerified && blocking.length === 0 && conflictingIds.size === 0;
     if (!eligible && reasons.length === 0) {
       reasons.push('Coupon distribution is not eligible for this project');
     }

--- a/api/src/projects/interfaces/project.interface.ts
+++ b/api/src/projects/interfaces/project.interface.ts
@@ -23,3 +23,19 @@ export interface DocumentUploadResponse {
   documentHashes: string[];
   gatewayUrls: string[];
 }
+
+export type ProvenanceEventType = 'registration' | 'review' | 'report' | 'bond' | 'document';
+
+export interface ProvenanceEvent {
+  type: ProvenanceEventType;
+  occurredAt: string | null;
+  title: string;
+  status: 'complete' | 'pending' | 'stale';
+  reference?: string;
+  evidenceUrl?: string;
+}
+
+export interface ProjectProvenanceResponse {
+  projectId: number;
+  events: ProvenanceEvent[];
+}

--- a/api/src/projects/projects.controller.ts
+++ b/api/src/projects/projects.controller.ts
@@ -5,7 +5,7 @@ import {
 import { ProjectsService } from './projects.service';
 import { CreateProjectDto } from './dto/create-project.dto';
 import { PaginationDto } from '../common/dto/pagination.dto';
-import { ProjectResponse } from './interfaces/project.interface';
+import { ProjectResponse, ProjectProvenanceResponse } from './interfaces/project.interface';
 import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
 import { AdminGuard } from '../common/guards/admin.guard';
 import { IntentGuard } from '../common/guards/intent.guard';
@@ -31,6 +31,13 @@ export class ProjectsController {
     @Param('id', ParseIntPipe) id: number,
   ): Promise<ProjectResponse> {
     return this.projectsService.findOne(id);
+  }
+
+  @Get(':id/provenance')
+  async provenance(
+    @Param('id', ParseIntPipe) id: number,
+  ): Promise<ProjectProvenanceResponse> {
+    return this.projectsService.getProvenance(id);
   }
 
   @Post(':id/approve')

--- a/api/src/projects/projects.provenance.spec.ts
+++ b/api/src/projects/projects.provenance.spec.ts
@@ -1,0 +1,32 @@
+import { ProjectsService } from './projects.service';
+import { ProjectStatusEnum } from './interfaces/project.interface';
+
+describe('ProjectsService provenance', () => {
+  const project = {
+    id: 1, name: 'Forest', status: ProjectStatusEnum.Pending, methodology: 'VCS', country: 'NG',
+    metadataIpfsHash: 'QmMetadata', ownerAddress: 'GOWNER', totalAreaHa: 1,
+    carbonSequestrationEstimate: 2, createdAt: '2026-01-01T00:00:00.000Z',
+  };
+
+  const service = new ProjectsService({} as any, {} as any, {} as any, {} as any, {} as any, {} as any, {} as any);
+
+  beforeEach(() => jest.restoreAllMocks());
+
+  it('represents a project with no downstream evidence as review-pending', async () => {
+    jest.spyOn(service, 'findOne').mockResolvedValue(project);
+    jest.spyOn(service, 'exportProject').mockResolvedValue({ reports: [], relatedBonds: [], documents: [] });
+    const result = await service.getProvenance(1);
+    expect(result.events.map((event) => event.status)).toEqual(['complete', 'pending']);
+  });
+
+  it('includes report, bond, and document references and marks missing report evidence stale', async () => {
+    jest.spyOn(service, 'findOne').mockResolvedValue({ ...project, status: ProjectStatusEnum.Approved });
+    jest.spyOn(service, 'exportProject').mockResolvedValue({
+      reports: [{ id: 4, status: 'Verified' }], relatedBonds: [9], documents: ['QmDocument'],
+    });
+    const result = await service.getProvenance(1);
+    expect(result.events.find((event) => event.type === 'report')?.status).toBe('stale');
+    expect(result.events.find((event) => event.type === 'bond')?.reference).toBe('9');
+    expect(result.events.find((event) => event.type === 'document')?.reference).toBe('QmDocument');
+  });
+});

--- a/api/src/projects/projects.service.ts
+++ b/api/src/projects/projects.service.ts
@@ -7,7 +7,7 @@ import { RedisService } from '../common/services/redis.service';
 import { SigningKeyProvider } from '../common/services/signing-key.provider';
 import { nativeToScVal, scValToNative, Address, xdr } from '@stellar/stellar-sdk';
 import { CreateProjectDto } from './dto/create-project.dto';
-import { ProjectResponse, ProjectStatusEnum, DocumentUploadResponse } from './interfaces/project.interface';
+import { ProjectResponse, ProjectStatusEnum, DocumentUploadResponse, ProjectProvenanceResponse, ProvenanceEvent } from './interfaces/project.interface';
 import { encodeCid, decodeCid, toBigIntString } from '../common/utils';
 import { ConfigService } from '../config/config.service';
 import { validateGeoJsonBoundary } from './utils/geojson-validator';
@@ -171,6 +171,42 @@ export class ProjectsService {
     return { projectId: id, documentHashes, gatewayUrls };
   }
 
+  async getProvenance(id: number): Promise<ProjectProvenanceResponse> {
+    const snapshot = await this.exportProject(id, 'system');
+    const project = await this.findOne(id);
+    const events: ProvenanceEvent[] = [{
+      type: 'registration',
+      occurredAt: project.createdAt,
+      title: 'Project registered',
+      status: 'complete',
+      reference: project.metadataIpfsHash,
+      evidenceUrl: `https://gateway.pinata.cloud/ipfs/${project.metadataIpfsHash}`,
+    }];
+    if (project.status === ProjectStatusEnum.Pending) {
+      events.push({ type: 'review', occurredAt: null, title: 'Review pending', status: 'pending' });
+    } else {
+      events.push({ type: 'review', occurredAt: null, title: `Project ${project.status.toLowerCase()}`, status: 'complete' });
+    }
+    for (const report of snapshot.reports) {
+      const reportStatus = report.status === 'Pending' || report.status === 0
+        ? 'pending'
+        : report.ipfsEvidenceHash ? 'complete' : 'stale';
+      events.push({
+        type: 'report', occurredAt: report.createdAt ?? null,
+        title: `Oracle report #${report.id}`, status: reportStatus,
+        reference: String(report.id), evidenceUrl: report.ipfsEvidenceHash ? `https://gateway.pinata.cloud/ipfs/${report.ipfsEvidenceHash}` : undefined,
+      });
+    }
+    for (const bondId of snapshot.relatedBonds) {
+      events.push({ type: 'bond', occurredAt: null, title: `Bond #${bondId} issued`, status: 'complete', reference: String(bondId), evidenceUrl: `/bonds/${bondId}` });
+    }
+    for (const hash of snapshot.documents) {
+      events.push({ type: 'document', occurredAt: null, title: 'Project document added', status: 'complete', reference: hash, evidenceUrl: `https://gateway.pinata.cloud/ipfs/${hash}` });
+    }
+    events.sort((a, b) => (a.occurredAt && b.occurredAt ? a.occurredAt.localeCompare(b.occurredAt) : a.occurredAt ? -1 : b.occurredAt ? 1 : 0));
+    return { projectId: id, events };
+  }
+
   private async buildProjectResponse(id: number): Promise<ProjectResponse> {
     const projectScVal = await this.contractService.simulateCall({
       contractAddress: this.configService.getProjectRegistryAddress(), method: 'get_project',
@@ -195,7 +231,7 @@ export class ProjectsService {
       ownerAddress: (project[1] as any).toString?.() || '',
       totalAreaHa: metadata.totalAreaHa || 0,
       carbonSequestrationEstimate: metadata.carbonSequestrationEstimate || 0,
-      createdAt: new Date().toISOString(),
+      createdAt: metadata.timestamp || new Date().toISOString(),
     };
   }
 

--- a/api/src/stellar/contract-errors.ts
+++ b/api/src/stellar/contract-errors.ts
@@ -27,6 +27,7 @@ export enum StableErrorCode {
   ORACLE_INSUFFICIENT_STAKE = 'ORACLE_INSUFFICIENT_STAKE',
   ORACLE_INVALID_SIGNATURE = 'ORACLE_INVALID_SIGNATURE',
   ORACLE_INVALID_RESOLUTION = 'ORACLE_INVALID_RESOLUTION',
+  ORACLE_OVERLAPPING_REPORT_PERIOD = 'ORACLE_OVERLAPPING_REPORT_PERIOD',
 
   // DEX Errors
   DEX_NOT_INITIALIZED = 'DEX_NOT_INITIALIZED',
@@ -119,6 +120,7 @@ export const ERROR_MAPPINGS: Record<string, Record<number, { code: StableErrorCo
     9: { code: StableErrorCode.ORACLE_INSUFFICIENT_STAKE, message: 'Oracle provider stake is insufficient' },
     10: { code: StableErrorCode.ORACLE_INVALID_SIGNATURE, message: 'Invalid signature for oracle verification' },
     11: { code: StableErrorCode.ORACLE_INVALID_RESOLUTION, message: 'Invalid resolution state for challenge' },
+    12: { code: StableErrorCode.ORACLE_OVERLAPPING_REPORT_PERIOD, message: 'Oracle report period overlaps an existing report' },
   },
   DEX: {
     1: { code: StableErrorCode.DEX_NOT_INITIALIZED, message: 'DEX contract is not initialized' },

--- a/contracts/oracle-consumer/src/lib.rs
+++ b/contracts/oracle-consumer/src/lib.rs
@@ -280,6 +280,29 @@ impl OracleConsumer {
             }
         }
 
+        // Reporting windows are half-open: [period_start, period_end). This
+        // permits adjacent reports while rejecting exact and partial overlap
+        // from the same provider/methodology for the same project.
+        let existing_ids: Vec<u64> = env
+            .storage()
+            .instance()
+            .get(&DataKey::ProjectReports(project_id.clone()))
+            .unwrap_or(vec![&env]);
+        for existing_id in existing_ids.iter() {
+            let existing: Report = env
+                .storage()
+                .instance()
+                .get(&DataKey::Report(existing_id))
+                .ok_or(OracleError::ReportNotFound)?;
+            if existing.provider == provider
+                && existing.methodology == methodology
+                && period_start < existing.period_end
+                && existing.period_start < period_end
+            {
+                return Err(OracleError::OverlappingReportPeriod);
+            }
+        }
+
         let count: u64 = env
             .storage()
             .instance()
@@ -996,6 +1019,38 @@ mod test {
         let project_reports = client.get_project_reports(&project_id);
         assert_eq!(project_reports.len(), 1);
         assert_eq!(project_reports.get(0).unwrap(), report_id);
+    }
+
+    #[test]
+    fn test_report_period_overlap_rules() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let provider = Address::generate(&env);
+        let project_id = create_project_id(&env, 7);
+        let methodology = Symbol::new(&env, "verra_vcs");
+        let contract_id = env.register(OracleConsumer, (admin.clone(),));
+        let client = OracleConsumerClient::new(&env, &contract_id);
+        client.register_provider(&admin, &provider, &methodology, &0);
+        client.submit_report(
+            &provider, &project_id, &1000, &2000, &100, &BiodiversityMetrics::Absent,
+            &methodology, &make_ipfs_hash(&env, 1), &0,
+        );
+
+        for (start, end) in [(1000u64, 2000u64), (1500, 2500)] {
+            let result = client.try_submit_report(
+                &provider, &project_id, &start, &end, &100, &BiodiversityMetrics::Absent,
+                &methodology, &make_ipfs_hash(&env, 2), &1,
+            );
+            assert_eq!(result, Err(Ok(OracleError::OverlappingReportPeriod)));
+        }
+
+        // Half-open windows allow an adjacent period.
+        let adjacent = client.submit_report(
+            &provider, &project_id, &2000, &3000, &100, &BiodiversityMetrics::Absent,
+            &methodology, &make_ipfs_hash(&env, 3), &1,
+        );
+        assert_eq!(adjacent, 2);
     }
 
     #[test]

--- a/contracts/shared/src/errors.rs
+++ b/contracts/shared/src/errors.rs
@@ -31,6 +31,7 @@ pub enum OracleError {
     InsufficientStake = 9,
     InvalidSignature = 10,
     InvalidResolution = 11,
+    OverlappingReportPeriod = 12,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -380,3 +380,9 @@ AppComponent
 /marketplace/sell → MarketplaceSellComponent
 /auth → AuthComponent
 ```
+# Project provenance
+
+`GET /projects/:id/provenance` assembles registration, review, oracle report,
+bond issuance, and document evidence into one chronological response. Entries
+without a ledger timestamp are retained with a null timestamp and explicit
+pending/complete state instead of inventing ordering data.

--- a/docs/oracle-design.md
+++ b/docs/oracle-design.md
@@ -191,3 +191,9 @@ log-based staleness alerting described in
 - Signature threshold defaults to two independent qualifying sources, with minimum verifier stake required for provider votes
 - Coupon distributions consume only `Verified` reports (enforced by `CouponEngine`); reports in `Challenged` status are rejected, holding coupons in escrow during disputes
 - Multi-sig for high-value reports
+# Report period conflicts
+
+Report periods use half-open intervals (`[period_start, period_end)`). For a
+given project, provider, and methodology, exact or partial overlaps are
+rejected on-chain; adjacent periods are valid. Coupon eligibility also rejects legacy/indexed data
+that contains overlapping periods.

--- a/frontend/src/app/marketplace/marketplace-list/marketplace-list.component.spec.ts
+++ b/frontend/src/app/marketplace/marketplace-list/marketplace-list.component.spec.ts
@@ -30,6 +30,7 @@ describe('MarketplaceListComponent', () => {
   let apiService: {
     getBonds: jasmine.Spy;
     getOrders: jasmine.Spy;
+    getOrder: jasmine.Spy;
     buyBondTokens: jasmine.Spy;
     cancelOrder: jasmine.Spy;
     getQuoteBalance: jasmine.Spy;
@@ -44,6 +45,7 @@ describe('MarketplaceListComponent', () => {
     apiService = {
       getBonds: jasmine.createSpy('getBonds').and.returnValue(of({ data: [], meta: { page: 1, limit: 100, total: 0, totalPages: 1 } })),
       getOrders: jasmine.createSpy('getOrders').and.returnValue(of({ data: [ORDER], meta: { page: 1, limit: 20, total: 1, totalPages: 1 } })),
+      getOrder: jasmine.createSpy('getOrder').and.returnValue(of(ORDER)),
       buyBondTokens: jasmine.createSpy('buyBondTokens').and.returnValue(of(undefined)),
       cancelOrder: jasmine.createSpy('cancelOrder').and.returnValue(of(undefined)),
       getQuoteBalance: jasmine
@@ -139,6 +141,29 @@ describe('MarketplaceListComponent', () => {
       amount: 5,
       maxPrice: 10,
     });
+  });
+
+  it('revalidates price immediately before submission', () => {
+    apiService.getOrder.and.returnValue(of({ ...ORDER, pricePerToken: '11' }));
+    component.openBuy(ORDER);
+    component.buyAmount = 5;
+    component.buyMaxPrice = 10;
+    component.onBuy(ORDER);
+
+    expect(apiService.getOrder).toHaveBeenCalledWith(1);
+    expect(apiService.buyBondTokens).not.toHaveBeenCalled();
+    expect(component.buyError()).toContain('Stale price');
+  });
+
+  it('revalidates remaining depth immediately before submission', () => {
+    apiService.getOrder.and.returnValue(of({ ...ORDER, amount: '4', status: 'PartiallyFilled' }));
+    component.openBuy(ORDER);
+    component.buyAmount = 5;
+    component.buyMaxPrice = 10;
+    component.onBuy(ORDER);
+
+    expect(apiService.buyBondTokens).not.toHaveBeenCalled();
+    expect(component.buyError()).toContain('only 4 tokens remain');
   });
 
   describe('order refresh', () => {

--- a/frontend/src/app/marketplace/marketplace-list/marketplace-list.component.ts
+++ b/frontend/src/app/marketplace/marketplace-list/marketplace-list.component.ts
@@ -117,6 +117,10 @@ export const ORDERS_POLL_INTERVAL_MS = 15000;
                               <div class="buy-form">
                                 <input type="number" class="buy-input" placeholder="Amount" [(ngModel)]="buyAmount" min="1" />
                                 <input type="number" class="buy-input" placeholder="Max price" [(ngModel)]="buyMaxPrice" min="0.01" />
+                                <div class="quote-summary">
+                                  Current quote: {{ order.pricePerToken }} {{ order.quoteAsset }} / token ·
+                                  max slippage: {{ maxSlippagePercent(order) | number:'1.0-2' }}%
+                                </div>
                                 @if (buyRequirement(order); as req) {
                                   <div class="buy-requirement">
                                     @if (req.sufficient) {
@@ -244,6 +248,7 @@ export const ORDERS_POLL_INTERVAL_MS = 15000;
     .buy-input { padding: 6px 8px; border: 1px solid #d1d5db; border-radius: 6px; font-size: 0.8125rem; outline: none; width: 100%; }
     .buy-input:focus { border-color: #3b82f6; }
     .buy-actions { display: flex; gap: 4px; }
+    .quote-summary { color: #4b5563; font-size: 0.75rem; }
     .buy-requirement { display: flex; flex-direction: column; gap: 6px; font-size: 0.75rem; padding: 8px; border-radius: 6px; }
     .sufficient-msg { color: #22c55e; }
     .insufficient-msg { color: #ef4444; }
@@ -452,6 +457,13 @@ export class MarketplaceListComponent implements OnInit, OnDestroy {
     return this.buyRequirement(order)?.sufficient ?? false;
   }
 
+  maxSlippagePercent(order: Order): number {
+    const current = Number(order.pricePerToken);
+    return current > 0 && this.buyMaxPrice >= current
+      ? ((this.buyMaxPrice - current) / current) * 100
+      : 0;
+  }
+
   focusQuotePanel(): void {
     document.getElementById('quote-balance')?.scrollIntoView({ behavior: 'smooth', block: 'center' });
   }
@@ -462,11 +474,27 @@ export class MarketplaceListComponent implements OnInit, OnDestroy {
     this.buySubmitting.set(true);
     this.buyError.set('');
 
-    this.apiService.buyBondTokens({
-      orderId: order.id,
-      amount: this.buyAmount,
-      maxPrice: this.buyMaxPrice,
-    }).subscribe({
+    const requestedAmount = this.buyAmount;
+    const approvedMaxPrice = this.buyMaxPrice;
+    this.apiService.getOrder(order.id).pipe(
+      switchMap((current) => {
+        this.orders.update((orders) => orders.map((item) => item.id === current.id ? current : item));
+        if (current.status !== 'Open' && current.status !== 'PartiallyFilled') {
+          throw new Error(`Order is no longer available (${current.status}).`);
+        }
+        if (requestedAmount > Number(current.amount)) {
+          throw new Error(`Stale quote: only ${current.amount} tokens remain.`);
+        }
+        if (Number(current.pricePerToken) > approvedMaxPrice) {
+          throw new Error(`Stale price: current price ${current.pricePerToken} exceeds your maximum ${approvedMaxPrice}.`);
+        }
+        return this.apiService.buyBondTokens({
+          orderId: current.id,
+          amount: requestedAmount,
+          maxPrice: approvedMaxPrice,
+        });
+      }),
+    ).subscribe({
       next: () => {
         this.buyOrderId.set(null);
         this.buySubmitting.set(false);

--- a/frontend/src/app/projects/project-detail/project-detail.component.ts
+++ b/frontend/src/app/projects/project-detail/project-detail.component.ts
@@ -5,7 +5,8 @@ import { ApiService } from '../../shared/services/api.service';
 import { StatusBadgeComponent } from '../../shared/components/status-badge/status-badge.component';
 import { LoadingSpinnerComponent } from '../../shared/components/loading-spinner/loading-spinner.component';
 import { ChallengedReportsComponent } from '../challenged-reports/challenged-reports.component';
-import { Project } from '../../shared/interfaces/bond.interface';
+import { Project, ProjectProvenanceEvent } from '../../shared/interfaces/bond.interface';
+import { forkJoin } from 'rxjs';
 
 @Component({
   selector: 'app-project-detail',
@@ -58,7 +59,26 @@ import { Project } from '../../shared/interfaces/bond.interface';
           </div>
         </div>
 
-        <app-challenged-reports [projectId]="p.id" />
+        <section class="timeline-card" aria-labelledby="provenance-heading">
+          <h2 id="provenance-heading">Provenance</h2>
+          @if (timeline().length === 0) {
+            <p class="timeline-empty">No provenance events are available yet.</p>
+          } @else {
+            <ol class="timeline">
+              @for (event of timeline(); track $index) {
+                <li>
+                  <span class="timeline-dot" [class.pending]="event.status !== 'complete'"></span>
+                  <div><strong>{{ event.title }}</strong>
+                    <div class="timeline-meta">{{ event.occurredAt ? (event.occurredAt | date:'medium') : event.status }}</div>
+                    @if (event.evidenceUrl) { <a [href]="event.evidenceUrl" target="_blank" rel="noopener noreferrer">View evidence →</a> }
+                  </div>
+                </li>
+              }
+            </ol>
+          }
+        </section>
+
+        <app-challenged-reports [projectId]="'' + p.id" />
       } @else if (loading()) {
         <div class="loading-section"><app-loading-spinner size="lg" /></div>
       } @else if (error()) {
@@ -73,6 +93,13 @@ import { Project } from '../../shared/interfaces/bond.interface';
     .loading-section { display: flex; justify-content: center; padding: 48px 0; }
     .error-card { background: #fef2f2; color: #ef4444; padding: 24px; border-radius: 12px; text-align: center; }
     .detail-card { background: #fff; border-radius: 12px; padding: 32px; box-shadow: 0 1px 4px rgba(0,0,0,0.08); }
+    .timeline-card { margin-top: 24px; background: #fff; border-radius: 12px; padding: 24px 32px; box-shadow: 0 1px 4px rgba(0,0,0,0.08); }
+    .timeline { list-style: none; padding: 0; margin: 20px 0 0; }
+    .timeline li { position: relative; display: grid; grid-template-columns: 18px 1fr; gap: 12px; padding-bottom: 20px; }
+    .timeline-dot { width: 10px; height: 10px; margin-top: 5px; border-radius: 50%; background: #22c55e; }
+    .timeline-dot.pending { background: #f59e0b; }
+    .timeline-meta, .timeline-empty { color: #6b7280; font-size: 0.8125rem; }
+    .timeline a { color: #3b82f6; font-size: 0.8125rem; }
     .detail-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 24px; }
     .detail-title { font-size: 1.5rem; font-weight: 700; }
     .detail-body { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; }
@@ -92,6 +119,7 @@ export class ProjectDetailComponent implements OnInit {
   readonly project = signal<Project | null>(null);
   readonly loading = signal(true);
   readonly error = signal('');
+  readonly timeline = signal<ProjectProvenanceEvent[]>([]);
 
   metadataUrl(): string {
     const p = this.project();
@@ -105,9 +133,10 @@ export class ProjectDetailComponent implements OnInit {
       this.loading.set(false);
       return;
     }
-    this.apiService.getProject(id).subscribe({
-      next: (project) => {
+    forkJoin({ project: this.apiService.getProject(id), provenance: this.apiService.getProjectProvenance(id) }).subscribe({
+      next: ({ project, provenance }) => {
         this.project.set(project);
+        this.timeline.set(provenance.events);
         this.loading.set(false);
       },
       error: (err) => {

--- a/frontend/src/app/shared/interfaces/bond.interface.ts
+++ b/frontend/src/app/shared/interfaces/bond.interface.ts
@@ -44,6 +44,20 @@ export interface Project {
   createdAt: string;
 }
 
+export interface ProjectProvenanceEvent {
+  type: 'registration' | 'review' | 'report' | 'bond' | 'document';
+  occurredAt: string | null;
+  title: string;
+  status: 'complete' | 'pending' | 'stale';
+  reference?: string;
+  evidenceUrl?: string;
+}
+
+export interface ProjectProvenance {
+  projectId: number;
+  events: ProjectProvenanceEvent[];
+}
+
 export type QuoteAsset = 'USDC' | 'XLM';
 
 export interface Order {

--- a/frontend/src/app/shared/services/api.service.ts
+++ b/frontend/src/app/shared/services/api.service.ts
@@ -5,7 +5,7 @@ import { AuthService } from '../../auth/auth.service';
 import { WalletService } from '../../auth/wallet.service';
 import { AdminIntentService, SignedAdminIntent } from './admin-intent.service';
 import {
-  Bond, HeldBond, Project, Order, PaginatedResponse,
+  Bond, HeldBond, Project, ProjectProvenance, Order, PaginatedResponse,
   SubscriptionResponse, CreateProjectDto, CreateBondDto, OrderQueryParams, ListBondDto, BuyBondDto,
   ClaimCreditsResponse, TransferResponse,
   UndistributedTotalResponse, SweepUndistributedResponse,
@@ -213,6 +213,10 @@ export class ApiService {
     return this.withProblemDetails(this.http.get<Project>(`/api/projects/${id}`));
   }
 
+  getProjectProvenance(id: number): Observable<ProjectProvenance> {
+    return this.withProblemDetails(this.http.get<ProjectProvenance>(`/api/projects/${id}/provenance`));
+  }
+
   registerProject(data: CreateProjectDto): Observable<Project> {
     return this.withProblemDetails(this.http.post<Project>('/api/projects', data, { headers: this.headers() }));
   }
@@ -227,6 +231,12 @@ export class ApiService {
     if (refresh) queryParams = queryParams.set('_t', Date.now());
     return this.withProblemDetails(this.http.get<PaginatedResponse<Order>>('/api/marketplace/orders', {
       params: queryParams, headers: this.headers(),
+    }));
+  }
+
+  getOrder(id: number): Observable<Order> {
+    return this.withProblemDetails(this.http.get<Order>(`/api/marketplace/orders/${id}`, {
+      params: new HttpParams().set('_t', Date.now()),
     }));
   }
 


### PR DESCRIPTION
## Summary

- reject overlapping oracle report windows on-chain and block coupon eligibility for conflicting legacy reports
- enforce fresh marketplace price and remaining depth before signing and execution
- add a project provenance endpoint and evidence-linked detail timeline
- add Redis-aware readiness with per-contract reachable, unreachable, or misconfigured states

## Verification

- 8 focused API tests pass for overlap handling, stale price/depth, provenance states, and contract readiness
- diff check passes
- frontend selected test compilation is blocked by existing unrelated errors in wallet.service.ts, admin-intent.service.ts, and bond detail/sell specs
- oracle contract tests are blocked by existing duplicate set_admin/get_admin exports in oracle-consumer
- full API typecheck is blocked by existing unrelated compile errors across auth, bonds, oracle controller, and test files

Closes #151
Closes #152
Closes #153
Closes #154
