### PR TITLE
fix(frontend): repair wallet connect, gate private routes, and wire the admin step-up intent

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -22,7 +22,13 @@
             "scripts": []
           },
           "configurations": {
-            "production": { "budgets": [{"type": "initial", "maximumWarning": "500kb", "maximumError": "1mb"}], "outputHashing": "all" },
+            "production": {
+              "budgets": [{"type": "initial", "maximumWarning": "500kb", "maximumError": "1mb"}],
+              "outputHashing": "all",
+              "fileReplacements": [
+                { "replace": "src/environments/environment.ts", "with": "src/environments/environment.prod.ts" }
+              ]
+            },
             "development": { "optimization": false, "sourceMap": true }
           },
           "defaultConfiguration": "production"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,8 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
+    "check:env": "node scripts/check-environments.mjs",
+    "prebuild": "npm run check:env",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",

--- a/frontend/scripts/check-environments.mjs
+++ b/frontend/scripts/check-environments.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+/**
+ * Build-time guard for the environment files (issue #167).
+ *
+ * `adminAddress` used to ship as the literal 'G...', which is not a valid
+ * Stellar account. Every admin comparison against it silently failed. This
+ * check runs as `prebuild`, so a placeholder or malformed address can never
+ * reach a production bundle.
+ *
+ * Exit codes: 0 = ok (warnings allowed), 1 = a value that must not ship.
+ */
+import { readFileSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { StrKey } from '@stellar/stellar-sdk';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const PLACEHOLDER = 'G...';
+
+const FILES = [
+  { path: join(ROOT, 'src/environments/environment.ts'), production: false },
+  { path: join(ROOT, 'src/environments/environment.prod.ts'), production: true },
+];
+
+/**
+ * Read a string literal assigned to `key` in an environment file. The files are
+ * flat object literals by convention, so a regex avoids pulling a TS parser in.
+ */
+function readStringField(source, key) {
+  const match = source.match(new RegExp(`\\b${key}\\s*:\\s*(['"\`])([\\s\\S]*?)\\1`));
+  return match ? match[2] : undefined;
+}
+
+const errors = [];
+const warnings = [];
+
+for (const { path, production } of FILES) {
+  const label = relative(ROOT, path);
+  let source;
+  try {
+    source = readFileSync(path, 'utf8');
+  } catch {
+    errors.push(`${label}: environment file is missing.`);
+    continue;
+  }
+
+  const adminAddress = readStringField(source, 'adminAddress');
+
+  if (adminAddress === undefined) {
+    // Removing the field entirely is a valid resolution of #167.
+    continue;
+  }
+
+  if (adminAddress === PLACEHOLDER) {
+    errors.push(
+      `${label}: adminAddress is still the '${PLACEHOLDER}' placeholder. ` +
+        'Set the deployment\'s admin Stellar public key (the API\'s STELLAR_PUBLIC_KEY), or leave it empty to disable admin features.',
+    );
+    continue;
+  }
+
+  if (adminAddress === '') {
+    warnings.push(
+      `${label}: adminAddress is empty — admin-only UI (issue bond, sweep undistributed) will be hidden in this build.`,
+    );
+    continue;
+  }
+
+  if (!StrKey.isValidEd25519PublicKey(adminAddress)) {
+    errors.push(
+      `${label}: adminAddress '${adminAddress}' is not a valid Stellar ed25519 public key.`,
+    );
+  }
+}
+
+for (const warning of warnings) {
+  console.warn(`⚠ ${warning}`);
+}
+
+if (errors.length > 0) {
+  console.error('✖ Environment check failed:');
+  for (const error of errors) {
+    console.error(`  - ${error}`);
+  }
+  process.exit(1);
+}
+
+console.log('✓ Environment check passed.');

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -1,9 +1,21 @@
 import { Routes } from '@angular/router';
+import { authGuard } from './auth/guards/auth.guard';
 
+/**
+ * Route gating (issue #168).
+ *
+ * Public: `projects` (browse and register — the API leaves POST /projects
+ * open), plus the read-only bond and marketplace listings, which render a
+ * contextual `<app-connect-prompt>` over their write affordances.
+ *
+ * Private: `dashboard` (wallet-scoped portfolio behind JwtAuthGuard) and the
+ * write flows nested under `bonds` and `marketplace`.
+ */
 export const routes: Routes = [
   { path: '', redirectTo: '/dashboard', pathMatch: 'full' },
   {
     path: 'dashboard',
+    canActivate: [authGuard],
     loadComponent: () => import('./dashboard/dashboard.component').then(m => m.DashboardComponent),
   },
   {

--- a/frontend/src/app/auth/auth.component.ts
+++ b/frontend/src/app/auth/auth.component.ts
@@ -1,8 +1,26 @@
-import { Component, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject, ChangeDetectionStrategy, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { WalletService } from './wallet.service';
 import { AuthService } from './auth.service';
+import { AUTH_REASON_PARAM, AuthDenialReason, RETURN_URL_PARAM } from './guards/auth.guard';
+
+/** Why the guard sent the visitor here (issue #168). */
+const DENIAL_MESSAGES: Record<AuthDenialReason, string> = {
+  wallet: 'Connect your Stellar wallet to continue to that page.',
+  session: 'Sign in with your wallet to continue to that page.',
+  admin: 'That page is restricted to the protocol admin wallet.',
+};
+
+/**
+ * Only ever return to an in-app path. `//host` and `/\host` are browser-legal
+ * protocol-relative URLs, so they are rejected along with absolute ones.
+ */
+function sanitizeReturnUrl(candidate: string | null): string {
+  if (!candidate || !candidate.startsWith('/')) return '/dashboard';
+  if (candidate.startsWith('//') || candidate.startsWith('/\\')) return '/dashboard';
+  return candidate;
+}
 
 @Component({
   selector: 'app-auth',
@@ -13,6 +31,8 @@ import { AuthService } from './auth.service';
       <div class="auth-card">
         <h1>Verdant Bond Protocol</h1>
         <p class="subtitle">Sign in with your Stellar wallet</p>
+
+        <p *ngIf="denialMessage()" class="notice" role="status">{{ denialMessage() }}</p>
 
         <ng-container *ngIf="!walletService.isConnected()">
           <button class="btn btn-primary" (click)="walletService.connect()" [disabled]="walletService.isConnecting()">
@@ -30,6 +50,7 @@ import { AuthService } from './auth.service';
         </ng-container>
 
         <p *ngIf="error" class="error">{{ error }}</p>
+        <p *ngIf="!error && walletService.errorMessage()" class="error">{{ walletService.errorMessage() }}</p>
       </div>
     </div>
   `,
@@ -38,6 +59,7 @@ import { AuthService } from './auth.service';
     .auth-card { background: #fff; border-radius: 12px; padding: 40px; text-align: center; box-shadow: 0 2px 8px rgba(0,0,0,0.1); max-width: 400px; width: 100%; }
     h1 { font-size: 1.5rem; margin-bottom: 8px; }
     .subtitle { color: #666; margin-bottom: 24px; }
+    .notice { background: #eff6ff; border: 1px solid #bfdbfe; color: #1d4ed8; padding: 10px 14px; border-radius: 8px; margin-bottom: 16px; font-size: 0.8125rem; }
     .wallet-address { background: #f0f2f5; padding: 8px 16px; border-radius: 8px; margin-bottom: 16px; font-family: monospace; font-size: 0.875rem; }
     .btn { padding: 12px 24px; border: none; border-radius: 8px; font-size: 1rem; cursor: pointer; width: 100%; }
     .btn-primary { background: #1a1a2e; color: #fff; }
@@ -48,16 +70,27 @@ import { AuthService } from './auth.service';
 })
 export class AuthComponent {
   private readonly router = inject(Router);
+  private readonly route = inject(ActivatedRoute);
   readonly walletService = inject(WalletService);
   readonly authService = inject(AuthService);
 
   error = '';
 
+  /** Route the guard bounced the visitor away from, if any (issue #168). */
+  private readonly returnUrl = signal(
+    sanitizeReturnUrl(this.route.snapshot.queryParamMap.get(RETURN_URL_PARAM)),
+  );
+
+  readonly denialMessage = signal<string | null>(
+    DENIAL_MESSAGES[this.route.snapshot.queryParamMap.get(AUTH_REASON_PARAM) as AuthDenialReason] ?? null,
+  );
+
   async signIn(): Promise<void> {
     this.error = '';
     try {
       await this.authService.login();
-      await this.router.navigate(['/dashboard']);
+      // Send the visitor back to what they originally asked for.
+      await this.router.navigateByUrl(this.returnUrl());
     } catch (e: any) {
       this.error = e.message || 'Sign in failed';
     }

--- a/frontend/src/app/auth/freighter-api.token.ts
+++ b/frontend/src/app/auth/freighter-api.token.ts
@@ -1,0 +1,33 @@
+import { InjectionToken } from '@angular/core';
+import { isConnected, getAddress, getNetwork, signTransaction } from '@stellar/freighter-api';
+
+/**
+ * The slice of `@stellar/freighter-api` the app actually uses.
+ *
+ * Every call resolves to an object that may carry an `error` field instead of a
+ * result (Freighter locked, extension missing, user rejected), so callers must
+ * check `error` before trusting the payload.
+ */
+export interface FreighterApi {
+  isConnected(): Promise<{ isConnected: boolean; error?: unknown }>;
+  getAddress(): Promise<{ address: string; error?: unknown }>;
+  getNetwork(): Promise<{ network: string; networkPassphrase: string; error?: unknown }>;
+  signTransaction(
+    xdr: string,
+    opts?: { networkPassphrase?: string },
+  ): Promise<{ signedTxXdr: string; error?: unknown }>;
+}
+
+/**
+ * Injectable boundary around the Freighter browser extension.
+ *
+ * The library exports plain module-level functions, which cannot be spied on
+ * once bundled. Routing them through a token keeps `WalletService` unit
+ * testable — see `wallet.service.spec.ts`, which covers the missing-import
+ * regression from issue #165.
+ */
+export const FREIGHTER_API = new InjectionToken<FreighterApi>('FREIGHTER_API', {
+  providedIn: 'root',
+  factory: () =>
+    ({ isConnected, getAddress, getNetwork, signTransaction }) as unknown as FreighterApi,
+});

--- a/frontend/src/app/auth/guards/auth.guard.spec.ts
+++ b/frontend/src/app/auth/guards/auth.guard.spec.ts
@@ -1,0 +1,104 @@
+import { TestBed } from '@angular/core/testing';
+import { Router, RouterStateSnapshot, UrlTree, provideRouter } from '@angular/router';
+import { Keypair } from '@stellar/stellar-sdk';
+import { adminGuard, authGuard, AUTH_REASON_PARAM, RETURN_URL_PARAM } from './auth.guard';
+import { WalletService } from '../wallet.service';
+import { AuthService } from '../auth.service';
+import { FREIGHTER_API } from '../freighter-api.token';
+import { AdminAccessService } from '../../shared/services/admin-access.service';
+
+const ADMIN_ADDRESS = Keypair.random().publicKey();
+const OTHER_ADDRESS = Keypair.random().publicKey();
+
+describe('route guards (issue #168)', () => {
+  let wallet: WalletService;
+  let auth: AuthService;
+  let adminAccess: AdminAccessService;
+
+  const stateFor = (url: string) => ({ url }) as RouterStateSnapshot;
+
+  const run = (guard: typeof authGuard, url: string) =>
+    TestBed.runInInjectionContext(() => guard({} as never, stateFor(url)));
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter([]),
+        { provide: FREIGHTER_API, useValue: {} },
+        {
+          provide: AuthService,
+          useValue: { isAuthenticated: () => authenticated },
+        },
+      ],
+    });
+
+    wallet = TestBed.inject(WalletService);
+    auth = TestBed.inject(AuthService);
+    adminAccess = TestBed.inject(AdminAccessService);
+    adminAccess.adminAddress.set(ADMIN_ADDRESS);
+  });
+
+  let authenticated = false;
+  beforeEach(() => {
+    authenticated = false;
+    wallet.isConnected.set(false);
+    wallet.address.set(null);
+  });
+
+  const expectRedirect = (result: boolean | UrlTree, url: string, reason: string) => {
+    expect(result instanceof UrlTree).toBeTrue();
+    const tree = result as UrlTree;
+    expect(TestBed.inject(Router).serializeUrl(tree)).toContain('/auth');
+    expect(tree.queryParams[RETURN_URL_PARAM]).toBe(url);
+    expect(tree.queryParams[AUTH_REASON_PARAM]).toBe(reason);
+  };
+
+  it('redirects an anonymous visitor away from a private route', () => {
+    expectRedirect(run(authGuard, '/dashboard'), '/dashboard', 'wallet');
+  });
+
+  it('redirects a connected but unauthenticated wallet to sign in', () => {
+    wallet.isConnected.set(true);
+    wallet.address.set(OTHER_ADDRESS);
+
+    expectRedirect(run(authGuard, '/marketplace/sell'), '/marketplace/sell', 'session');
+  });
+
+  it('admits a connected and authenticated wallet', () => {
+    wallet.isConnected.set(true);
+    wallet.address.set(OTHER_ADDRESS);
+    authenticated = true;
+
+    expect(run(authGuard, '/dashboard')).toBeTrue();
+    expect(auth.isAuthenticated()).toBeTrue();
+  });
+
+  it('refuses a non-admin wallet on an admin route', () => {
+    wallet.isConnected.set(true);
+    wallet.address.set(OTHER_ADDRESS);
+    authenticated = true;
+
+    expectRedirect(run(adminGuard, '/bonds/issue'), '/bonds/issue', 'admin');
+  });
+
+  it('admits the configured admin wallet', () => {
+    wallet.isConnected.set(true);
+    wallet.address.set(ADMIN_ADDRESS);
+    authenticated = true;
+
+    expect(run(adminGuard, '/bonds/issue')).toBeTrue();
+  });
+
+  it('refuses every wallet when no admin address is configured (#167)', () => {
+    adminAccess.adminAddress.set(null);
+    wallet.isConnected.set(true);
+    wallet.address.set(ADMIN_ADDRESS);
+    authenticated = true;
+
+    expectRedirect(run(adminGuard, '/bonds/issue'), '/bonds/issue', 'admin');
+  });
+
+  it('asks an anonymous visitor to connect before mentioning admin access', () => {
+    expectRedirect(run(adminGuard, '/bonds/issue'), '/bonds/issue', 'wallet');
+  });
+});

--- a/frontend/src/app/auth/guards/auth.guard.ts
+++ b/frontend/src/app/auth/guards/auth.guard.ts
@@ -1,0 +1,58 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router, UrlTree } from '@angular/router';
+import { WalletService } from '../wallet.service';
+import { AuthService } from '../auth.service';
+import { AdminAccessService } from '../../shared/services/admin-access.service';
+
+/** Query param carrying the route to return to after a successful sign-in. */
+export const RETURN_URL_PARAM = 'returnUrl';
+
+/** Query param naming why access was refused, so /auth can explain itself. */
+export const AUTH_REASON_PARAM = 'reason';
+
+export type AuthDenialReason = 'wallet' | 'session' | 'admin';
+
+function redirectToAuth(router: Router, returnUrl: string, reason: AuthDenialReason): UrlTree {
+  return router.createUrlTree(['/auth'], {
+    queryParams: { [RETURN_URL_PARAM]: returnUrl, [AUTH_REASON_PARAM]: reason },
+  });
+}
+
+/**
+ * Gate for private flows (issue #168).
+ *
+ * The API guards these flows with `JwtAuthGuard` (+ `KycGuard`), so reaching
+ * them without a connected wallet and a verified session only ever produces
+ * empty states and 401s. Anonymous visitors are sent to /auth with the route
+ * they wanted, and land back on it once signed in.
+ */
+export const authGuard: CanActivateFn = (_route, state) => {
+  const router = inject(Router);
+  const wallet = inject(WalletService);
+  const auth = inject(AuthService);
+
+  if (!wallet.isConnected()) {
+    return redirectToAuth(router, state.url, 'wallet');
+  }
+  if (!auth.isAuthenticated()) {
+    return redirectToAuth(router, state.url, 'session');
+  }
+  return true;
+};
+
+/**
+ * Gate for admin-only flows (bond issuance, coupon distribution, sweeps).
+ *
+ * Mirrors the API's `AdminGuard`, which only accepts the wallet matching
+ * `STELLAR_PUBLIC_KEY`. Runs the `authGuard` checks first so an anonymous
+ * visitor gets the connect prompt rather than an "admin only" dead end.
+ */
+export const adminGuard: CanActivateFn = (route, state) => {
+  const router = inject(Router);
+  const adminAccess = inject(AdminAccessService);
+
+  const authResult = authGuard(route, state);
+  if (authResult !== true) return authResult;
+
+  return adminAccess.isAdmin() ? true : redirectToAuth(router, state.url, 'admin');
+};

--- a/frontend/src/app/auth/wallet.service.spec.ts
+++ b/frontend/src/app/auth/wallet.service.spec.ts
@@ -1,0 +1,141 @@
+import { TestBed } from '@angular/core/testing';
+import { WalletService } from './wallet.service';
+import { FREIGHTER_API, FreighterApi } from './freighter-api.token';
+import { environment } from '../../environments/environment';
+
+const ADDRESS = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+const OTHER_PASSPHRASE = 'Public Global Stellar Network ; September 2015';
+
+describe('WalletService (issue #165: getNetwork is not defined)', () => {
+  let freighter: jasmine.SpyObj<FreighterApi>;
+  let service: WalletService;
+
+  const onExpectedNetwork = () =>
+    Promise.resolve({ network: 'TESTNET', networkPassphrase: environment.networkPassphrase });
+
+  beforeEach(() => {
+    freighter = jasmine.createSpyObj<FreighterApi>('FreighterApi', [
+      'isConnected',
+      'getAddress',
+      'getNetwork',
+      'signTransaction',
+    ]);
+    freighter.isConnected.and.resolveTo({ isConnected: true });
+    freighter.getAddress.and.resolveTo({ address: ADDRESS });
+    freighter.getNetwork.and.callFake(onExpectedNetwork);
+    freighter.signTransaction.and.resolveTo({ signedTxXdr: 'signed-xdr' });
+
+    TestBed.configureTestingModule({
+      providers: [{ provide: FREIGHTER_API, useValue: freighter }],
+    });
+    service = TestBed.inject(WalletService);
+  });
+
+  afterEach(() => {
+    service.disconnect();
+  });
+
+  it('connects and reaches the connected status without a ReferenceError', async () => {
+    // Before the fix, `getNetwork` was called but never imported, so this line
+    // threw `ReferenceError: getNetwork is not defined` and the status was
+    // stuck on 'connecting'.
+    await expectAsync(service.connect()).toBeResolved();
+
+    expect(freighter.getNetwork).toHaveBeenCalled();
+    expect(service.status()).toBe('connected');
+    expect(service.isConnected()).toBeTrue();
+    expect(service.address()).toBe(ADDRESS);
+    expect(service.networkPassphrase()).toBe(environment.networkPassphrase);
+    expect(service.errorMessage()).toBeNull();
+  });
+
+  it('records the active network passphrase when verifyNetwork succeeds', async () => {
+    await service.connect();
+    expect(service.networkPassphrase()).toBe(environment.networkPassphrase);
+  });
+
+  it('surfaces a testnet/mainnet mismatch with an actionable message', async () => {
+    freighter.getNetwork.and.resolveTo({
+      network: 'PUBLIC',
+      networkPassphrase: OTHER_PASSPHRASE,
+    });
+
+    await expectAsync(service.connect()).toBeRejectedWithError(/network mismatch/i);
+
+    expect(service.status()).toBe('network_mismatch');
+    expect(service.errorMessage()).toContain('PUBLIC');
+    expect(service.errorMessage()).toContain(environment.stellarNetwork);
+    expect(service.isConnected()).toBeFalse();
+  });
+
+  it('reports an unreadable network instead of silently trusting an empty passphrase', async () => {
+    freighter.getNetwork.and.resolveTo({
+      network: '',
+      networkPassphrase: '',
+      error: { code: -1, message: 'User declined access' },
+    });
+
+    await expectAsync(service.connect()).toBeRejectedWithError(/read the Freighter network/i);
+    expect(service.status()).toBe('error');
+  });
+
+  it('verifies the network before signing a challenge', async () => {
+    freighter.getNetwork.and.resolveTo({
+      network: 'PUBLIC',
+      networkPassphrase: OTHER_PASSPHRASE,
+    });
+
+    await expectAsync(service.signChallenge('challenge-xdr')).toBeRejectedWithError(/network mismatch/i);
+    expect(freighter.signTransaction).not.toHaveBeenCalled();
+  });
+
+  it('signs the challenge once the network matches', async () => {
+    await expectAsync(service.signChallenge('challenge-xdr')).toBeResolvedTo('signed-xdr');
+    expect(freighter.signTransaction).toHaveBeenCalledWith('challenge-xdr', {
+      networkPassphrase: environment.networkPassphrase,
+    });
+  });
+
+  it('detects a network switch made in Freighter after connecting', async () => {
+    await service.connect();
+    expect(service.status()).toBe('connected');
+
+    freighter.getNetwork.and.resolveTo({
+      network: 'PUBLIC',
+      networkPassphrase: OTHER_PASSPHRASE,
+    });
+    await service.refreshAccountState();
+
+    expect(service.status()).toBe('network_mismatch');
+    expect(service.errorMessage()).toContain('Switch networks in Freighter');
+  });
+
+  it('clears the mismatch banner when the user switches back', async () => {
+    await service.connect();
+    freighter.getNetwork.and.resolveTo({ network: 'PUBLIC', networkPassphrase: OTHER_PASSPHRASE });
+    await service.refreshAccountState();
+    expect(service.status()).toBe('network_mismatch');
+
+    freighter.getNetwork.and.callFake(onExpectedNetwork);
+    await service.refreshAccountState();
+
+    expect(service.status()).toBe('connected');
+    expect(service.errorMessage()).toBeNull();
+  });
+
+  it('reports a missing extension without reaching the network check', async () => {
+    freighter.isConnected.and.resolveTo({ isConnected: false });
+
+    await expectAsync(service.connect()).toBeRejectedWithError(/Freighter not detected/i);
+    expect(service.status()).toBe('missing');
+    expect(freighter.getNetwork).not.toHaveBeenCalled();
+  });
+
+  it('reports a locked wallet without reaching the network check', async () => {
+    freighter.getAddress.and.resolveTo({ address: '' });
+
+    await expectAsync(service.connect()).toBeRejectedWithError(/locked/i);
+    expect(service.status()).toBe('locked');
+    expect(freighter.getNetwork).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/auth/wallet.service.ts
+++ b/frontend/src/app/auth/wallet.service.ts
@@ -1,9 +1,30 @@
-import { Injectable, signal } from '@angular/core';
-import { isConnected, getAddress, signTransaction } from '@stellar/freighter-api';
+import { Injectable, inject, signal } from '@angular/core';
 import { environment } from '../../environments/environment';
+import { FREIGHTER_API } from './freighter-api.token';
+
+/**
+ * Lifecycle of the Freighter connection. `network_mismatch` and
+ * `account_changed` are recoverable states: the wallet is reachable but the
+ * session cannot be trusted until the user acts.
+ */
+export type WalletStatus =
+  | 'idle'
+  | 'connecting'
+  | 'connected'
+  | 'missing'
+  | 'locked'
+  | 'rejected'
+  | 'network_mismatch'
+  | 'account_changed'
+  | 'error';
+
+/** Human-readable label for the network this build talks to. */
+const EXPECTED_NETWORK_LABEL = environment.stellarNetwork;
 
 @Injectable({ providedIn: 'root' })
 export class WalletService {
+  private readonly freighter = inject(FREIGHTER_API);
+
   readonly address = signal<string | null>(null);
   readonly isConnected = signal(false);
   readonly isConnecting = signal(false);
@@ -18,13 +39,13 @@ export class WalletService {
     this.status.set('connecting');
     this.errorMessage.set(null);
     try {
-      const connected = await isConnected();
+      const connected = await this.freighter.isConnected();
       if (!connected.isConnected) {
         this.status.set('missing');
         this.errorMessage.set('Freighter is not installed or is unavailable.');
         throw new Error('Freighter not detected');
       }
-      const { address } = await getAddress();
+      const { address } = await this.freighter.getAddress();
       if (!address) {
         this.status.set('locked');
         this.errorMessage.set('Unlock Freighter and try again.');
@@ -49,7 +70,7 @@ export class WalletService {
 
   async signChallenge(challenge: string): Promise<string> {
     await this.verifyNetwork();
-    const { signedTxXdr } = await signTransaction(challenge, {
+    const { signedTxXdr } = await this.freighter.signTransaction(challenge, {
       networkPassphrase: environment.networkPassphrase,
     });
     return signedTxXdr;
@@ -67,7 +88,7 @@ export class WalletService {
   async refreshAccountState(): Promise<void> {
     if (!this.isConnected()) return;
     try {
-      const { address } = await getAddress();
+      const { address } = await this.freighter.getAddress();
       if (address && address !== this.address()) {
         this.address.set(address);
         this.status.set('account_changed');
@@ -75,20 +96,44 @@ export class WalletService {
       }
       await this.verifyNetwork();
     } catch {
+      // `verifyNetwork` already reports a mismatch precisely; do not flatten it
+      // into the generic "locked" message.
+      if (this.status() === 'network_mismatch') return;
       this.status.set('locked');
       this.errorMessage.set('Freighter is locked or unavailable.');
       this.isConnected.set(false);
     }
   }
 
+  /**
+   * Confirm Freighter is pointed at the same Stellar network this build talks
+   * to. Signing against the wrong network produces transactions the API will
+   * reject, so every connect and every signature goes through here first.
+   */
   private async verifyNetwork(): Promise<void> {
-    const network = await getNetwork();
-    const passphrase = typeof network === 'string' ? network : network.networkPassphrase;
+    const network = await this.freighter.getNetwork();
+    if (network?.error) {
+      this.status.set('error');
+      this.errorMessage.set('Could not read the active Freighter network. Unlock Freighter and try again.');
+      throw new Error('Unable to read the Freighter network');
+    }
+
+    const passphrase = network?.networkPassphrase ?? '';
     this.networkPassphrase.set(passphrase);
     if (passphrase !== this.expectedNetworkPassphrase) {
+      const actual = network?.network || 'an unknown network';
       this.status.set('network_mismatch');
-      this.errorMessage.set('Switch Freighter to the configured Stellar network before continuing.');
+      this.errorMessage.set(
+        `Freighter is connected to ${actual}, but this app runs on ${EXPECTED_NETWORK_LABEL}. ` +
+          'Switch networks in Freighter and reconnect.',
+      );
       throw new Error('Freighter network mismatch');
+    }
+
+    // The network is good again: clear a stale mismatch banner.
+    if (this.status() === 'network_mismatch') {
+      this.status.set(this.isConnected() ? 'connected' : 'idle');
+      this.errorMessage.set(null);
     }
   }
 

--- a/frontend/src/app/bonds/bond-detail/bond-detail.component.spec.ts
+++ b/frontend/src/app/bonds/bond-detail/bond-detail.component.spec.ts
@@ -2,11 +2,18 @@ import { ComponentFixture, TestBed, fakeAsync, tick, discardPeriodicTasks } from
 import { provideRouter } from '@angular/router';
 import { ActivatedRoute } from '@angular/router';
 import { of } from 'rxjs';
+import { Keypair } from '@stellar/stellar-sdk';
 import { BondDetailComponent } from './bond-detail.component';
 import { ApiService, BondDetailResponse } from '../../shared/services/api.service';
 import { WalletService } from '../../auth/wallet.service';
+import { AdminAccessService } from '../../shared/services/admin-access.service';
+import { AdminIntentService } from '../../shared/services/admin-intent.service';
 import { Bond } from '../../shared/interfaces/bond.interface';
-import { environment } from '../../../environments/environment';
+
+// `environment.adminAddress` now defaults to empty (#167), so the admin account
+// under test is configured explicitly rather than read from the environment.
+const adminKeypair = Keypair.random();
+const ADMIN_ADDRESS = adminKeypair.publicKey();
 
 describe('BondDetailComponent (issue #4 refresh model)', () => {
   let fixture: ComponentFixture<BondDetailComponent>;
@@ -71,6 +78,11 @@ describe('BondDetailComponent (issue #4 refresh model)', () => {
     }).compileComponents();
 
     walletService = TestBed.inject(WalletService);
+
+    TestBed.inject(AdminAccessService).adminAddress.set(ADMIN_ADDRESS);
+    // The sweep route requires a signed step-up intent (#166); unlock the admin
+    // session so the existing sweep expectations still exercise the request.
+    TestBed.inject(AdminIntentService).setAdminSecret(adminKeypair.secret());
   });
 
   afterEach(() => {
@@ -96,7 +108,7 @@ describe('BondDetailComponent (issue #4 refresh model)', () => {
   }));
 
   it('shows the undistributed total to the admin wallet', fakeAsync(() => {
-    walletService.address.set(environment.adminAddress);
+    walletService.address.set(ADMIN_ADDRESS);
     createFixture();
 
     const section = adminSection();
@@ -123,7 +135,7 @@ describe('BondDetailComponent (issue #4 refresh model)', () => {
   }));
 
   it('sweeps undistributed credits only after confirmation', fakeAsync(() => {
-    walletService.address.set(environment.adminAddress);
+    walletService.address.set(ADMIN_ADDRESS);
     createFixture();
 
     const confirmSpy = spyOn(window, 'confirm').and.returnValue(true);
@@ -139,7 +151,7 @@ describe('BondDetailComponent (issue #4 refresh model)', () => {
   }));
 
   it('does not sweep when confirmation is declined', fakeAsync(() => {
-    walletService.address.set(environment.adminAddress);
+    walletService.address.set(ADMIN_ADDRESS);
     createFixture();
 
     spyOn(window, 'confirm').and.returnValue(false);

--- a/frontend/src/app/bonds/bond-detail/bond-detail.component.ts
+++ b/frontend/src/app/bonds/bond-detail/bond-detail.component.ts
@@ -7,17 +7,25 @@ import { WalletService } from '../../auth/wallet.service';
 import { StatusBadgeComponent } from '../../shared/components/status-badge/status-badge.component';
 import { LoadingSpinnerComponent } from '../../shared/components/loading-spinner/loading-spinner.component';
 import { BondDetailReloadCoordinator } from './bond-detail.reload-coordinator';
+import { ConnectPromptComponent } from '../../shared/components/connect-prompt/connect-prompt.component';
+import { AdminSecretPromptComponent } from '../../shared/components/admin-secret-prompt/admin-secret-prompt.component';
+import { AdminAccessService } from '../../shared/services/admin-access.service';
+import { AdminIntentService } from '../../shared/services/admin-intent.service';
 import { Bond } from '../../shared/interfaces/bond.interface';
-import { environment } from '../../../environments/environment';
 
 @Component({
   selector: 'app-bond-detail',
   standalone: true,
-  imports: [CommonModule, RouterModule, FormsModule, StatusBadgeComponent, LoadingSpinnerComponent],
+  imports: [
+    CommonModule, RouterModule, FormsModule, StatusBadgeComponent, LoadingSpinnerComponent,
+    ConnectPromptComponent, AdminSecretPromptComponent,
+  ],
   providers: [BondDetailReloadCoordinator],
   template: `
     <div class="detail-page">
       <a class="back-link" routerLink="/bonds">← Back to Bonds</a>
+
+      <app-connect-prompt action="Subscribing, claiming credits, and transferring tokens need a signed-in wallet." />
 
       @if (refreshing()) {
         <div class="refresh-banner">Refreshing bond data…</div>
@@ -247,6 +255,11 @@ import { environment } from '../../../environments/environment';
                   >
                     {{ sweepSubmitting() ? 'Sweeping...' : 'Sweep Undistributed' }}
                   </button>
+                  @if (adminIntent.hasSecret()) {
+                    <button type="button" class="btn btn-outline lock-btn" (click)="adminIntent.clearAdminSecret()">
+                      Lock admin session
+                    </button>
+                  }
                 } @else if (undistributedError()) {
                   <div class="error-msg">{{ undistributedError() }}</div>
                 } @else {
@@ -261,6 +274,14 @@ import { environment } from '../../../environments/environment';
                   <div class="error-msg">{{ sweepError() }}</div>
                 }
               </div>
+            }
+            @if (secretPromptOpen()) {
+              <app-admin-secret-prompt
+                action="Sweep undistributed coupons"
+                [description]="'Bond #' + b.id + ' — this action is signed and single-use.'"
+                (unlocked)="onSecretUnlocked()"
+                (cancelled)="secretPromptOpen.set(false)"
+              />
             }
           </div>
         </div>
@@ -321,6 +342,7 @@ import { environment } from '../../../environments/environment';
     .transfer-section { margin-top: 20px; padding-top: 20px; border-top: 1px solid #e5e7eb; }
     .admin-section { margin-top: 20px; padding-top: 20px; border-top: 1px solid #e5e7eb; }
     .admin-note { font-size: 0.8125rem; color: #6b7280; padding: 8px 0; }
+    .lock-btn { margin-top: 8px; }
     .undistributed-total { display: flex; flex-direction: column; margin-bottom: 12px; }
     .refresh-banner { padding: 10px 16px; border-radius: 8px; background: #eff6ff; border: 1px solid #bfdbfe; color: #1d4ed8; font-size: 0.8125rem; margin-bottom: 16px; }
     .refresh-btn { width: 100%; margin-top: 16px; }
@@ -336,6 +358,8 @@ export class BondDetailComponent implements OnInit, OnDestroy {
   private readonly route = inject(ActivatedRoute);
   private readonly apiService = inject(ApiService);
   private readonly walletService = inject(WalletService);
+  private readonly adminAccess = inject(AdminAccessService);
+  readonly adminIntent = inject(AdminIntentService);
   private readonly coordinator = inject(BondDetailReloadCoordinator);
 
   /**
@@ -374,10 +398,14 @@ export class BondDetailComponent implements OnInit, OnDestroy {
   readonly sweepSwept = signal(0);
   readonly sweepTx = signal('');
   readonly sweepError = signal('');
+  readonly secretPromptOpen = signal(false);
 
-  readonly isAdmin = computed(
-    () => this.walletService.address() === environment.adminAddress,
-  );
+  /**
+   * Admin detection now goes through `AdminAccessService`, which validates the
+   * configured address instead of comparing against the old 'G...' placeholder
+   * (issue #167).
+   */
+  readonly isAdmin = this.adminAccess.isAdmin;
 
   readonly maturityReached = computed(() => {
     const b = this.bond();
@@ -538,6 +566,27 @@ export class BondDetailComponent implements OnInit, OnDestroy {
       `Sweep ${total} undistributed credits from Bond #${b.id}? This will reset the undistributed balance to zero.`,
     );
     if (!confirmed) return;
+
+    // The sweep route is behind the API's IntentGuard: without a signed intent
+    // it is a guaranteed 401, so collect the secret first (#166).
+    if (!this.adminIntent.hasSecret()) {
+      this.sweepError.set('');
+      this.secretPromptOpen.set(true);
+      return;
+    }
+
+    this.submitSweep();
+  }
+
+  /** The admin unlocked the session from the prompt: continue the sweep. */
+  onSecretUnlocked(): void {
+    this.secretPromptOpen.set(false);
+    this.submitSweep();
+  }
+
+  private submitSweep(): void {
+    const b = this.bond();
+    if (!b) return;
 
     this.sweepSubmitting.set(true);
     this.sweepSuccess.set(false);

--- a/frontend/src/app/bonds/bonds-list/bonds-list.component.ts
+++ b/frontend/src/app/bonds/bonds-list/bonds-list.component.ts
@@ -4,18 +4,24 @@ import { RouterModule, Router } from '@angular/router';
 import { ApiService } from '../../shared/services/api.service';
 import { BondCardComponent } from '../../shared/components/bond-card/bond-card.component';
 import { LoadingSpinnerComponent } from '../../shared/components/loading-spinner/loading-spinner.component';
+import { ConnectPromptComponent } from '../../shared/components/connect-prompt/connect-prompt.component';
+import { AdminAccessService } from '../../shared/services/admin-access.service';
 import { Bond } from '../../shared/interfaces/bond.interface';
 
 @Component({
   selector: 'app-bonds-list',
   standalone: true,
-  imports: [CommonModule, RouterModule, BondCardComponent, LoadingSpinnerComponent],
+  imports: [CommonModule, RouterModule, BondCardComponent, LoadingSpinnerComponent, ConnectPromptComponent],
   template: `
     <div class="bonds-page">
       <div class="page-header">
         <h1 class="page-title">Bonds</h1>
-        <a class="btn btn-primary" routerLink="/bonds/issue">Issue Bond</a>
+        @if (adminAccess.isAdmin()) {
+          <a class="btn btn-primary" routerLink="/bonds/issue">Issue Bond</a>
+        }
       </div>
+
+      <app-connect-prompt action="Browsing is open to everyone; subscribing to a bond needs a signed-in wallet." />
 
       @if (error()) {
         <div class="error-banner">{{ error() }}</div>
@@ -88,6 +94,8 @@ import { Bond } from '../../shared/interfaces/bond.interface';
 export class BondsListComponent implements OnInit {
   private readonly apiService = inject(ApiService);
   private readonly router = inject(Router);
+  /** Issuance is admin-only on the API, so only show the link to an admin (#168). */
+  readonly adminAccess = inject(AdminAccessService);
 
   readonly bonds = signal<Bond[]>([]);
   readonly loading = signal(true);

--- a/frontend/src/app/bonds/bonds.routes.ts
+++ b/frontend/src/app/bonds/bonds.routes.ts
@@ -1,8 +1,16 @@
 import { Routes } from '@angular/router';
+import { adminGuard } from '../auth/guards/auth.guard';
 
 const routes: Routes = [
+  // Public reads: GET /bonds and GET /bonds/:id are unauthenticated on the API.
+  // Their subscribe/claim/transfer affordances show a connect prompt instead.
   { path: '', loadComponent: () => import('./bonds-list/bonds-list.component').then(m => m.BondsListComponent) },
-  { path: 'issue', loadComponent: () => import('./issue-bond/issue-bond.component').then(m => m.IssueBondComponent) },
+  {
+    path: 'issue',
+    // POST /bonds is JwtAuthGuard + AdminGuard + IntentGuard.
+    canActivate: [adminGuard],
+    loadComponent: () => import('./issue-bond/issue-bond.component').then(m => m.IssueBondComponent),
+  },
   { path: ':id', loadComponent: () => import('./bond-detail/bond-detail.component').then(m => m.BondDetailComponent) },
 ];
 

--- a/frontend/src/app/bonds/issue-bond/issue-bond.component.ts
+++ b/frontend/src/app/bonds/issue-bond/issue-bond.component.ts
@@ -3,13 +3,15 @@ import { CommonModule } from '@angular/common';
 import { RouterModule, Router } from '@angular/router';
 import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ApiService } from '../../shared/services/api.service';
+import { AdminIntentService } from '../../shared/services/admin-intent.service';
+import { AdminSecretPromptComponent } from '../../shared/components/admin-secret-prompt/admin-secret-prompt.component';
 import { CreateBondDto } from '../../shared/interfaces/bond.interface';
 import { appErrorMessage } from '../../shared/errors/api-error';
 
 @Component({
   selector: 'app-issue-bond',
   standalone: true,
-  imports: [CommonModule, RouterModule, ReactiveFormsModule],
+  imports: [CommonModule, RouterModule, ReactiveFormsModule, AdminSecretPromptComponent],
   template: `
     <div class="issue-page">
       <a class="back-link" routerLink="/bonds">← Back to Bonds</a>
@@ -21,6 +23,25 @@ import { appErrorMessage } from '../../shared/errors/api-error';
       @if (success()) {
         <div class="success-banner">Bond issued successfully!</div>
       }
+
+      <!-- Issuance is behind IntentGuard on the API; say so up front (#166). -->
+      <div class="intent-banner" [class.unlocked]="adminIntent.hasSecret()">
+        @if (adminIntent.hasSecret()) {
+          <span>
+            Admin session unlocked as
+            <span class="mono">{{ adminIntent.unlockedAddress() }}</span>. Submissions will be signed.
+          </span>
+          <button type="button" class="btn btn-outline btn-sm" (click)="adminIntent.clearAdminSecret()">Lock</button>
+        } @else {
+          <span>
+            Issuing a bond requires a signed admin intent. You will be asked for your
+            admin secret key when you submit.
+          </span>
+          <button type="button" class="btn btn-outline btn-sm" (click)="secretPromptOpen.set(true)">
+            Unlock now
+          </button>
+        }
+      </div>
 
       <form class="issue-form" [formGroup]="form" (ngSubmit)="onSubmit()">
         <div class="form-group">
@@ -82,6 +103,15 @@ import { appErrorMessage } from '../../shared/errors/api-error';
           </button>
         </div>
       </form>
+
+      @if (secretPromptOpen()) {
+        <app-admin-secret-prompt
+          action="Issue a new bond"
+          description="POST /bonds is verified by the API's step-up IntentGuard."
+          (unlocked)="onSecretUnlocked()"
+          (cancelled)="onSecretCancelled()"
+        />
+      }
     </div>
   `,
   styles: [`
@@ -105,6 +135,10 @@ import { appErrorMessage } from '../../shared/errors/api-error';
     .btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
     .btn-outline { background: #fff; color: #1a1a2e; border: 1px solid #d1d5db; }
     .btn-outline:hover { background: #f0f2f5; }
+    .btn-sm { padding: 6px 12px; font-size: 0.8125rem; }
+    .intent-banner { display: flex; justify-content: space-between; align-items: center; gap: 12px; flex-wrap: wrap; padding: 12px 16px; border-radius: 8px; margin-bottom: 16px; font-size: 0.8125rem; background: #fffbeb; border: 1px solid #fde68a; color: #92400e; }
+    .intent-banner.unlocked { background: #f0fdf4; border-color: #bbf7d0; color: #166534; }
+    .mono { font-family: monospace; word-break: break-all; }
   `],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -112,10 +146,12 @@ export class IssueBondComponent {
   private readonly fb = inject(FormBuilder);
   private readonly apiService = inject(ApiService);
   private readonly router = inject(Router);
+  readonly adminIntent = inject(AdminIntentService);
 
   readonly submitting = signal(false);
   readonly error = signal('');
   readonly success = signal(false);
+  readonly secretPromptOpen = signal(false);
 
   form: FormGroup = this.fb.group({
     projectId: ['', Validators.required],
@@ -127,7 +163,31 @@ export class IssueBondComponent {
   });
 
   onSubmit(): void {
-    if (this.form.invalid) return;
+    if (this.form.invalid || this.submitting()) return;
+
+    // The API rejects POST /bonds without a fresh signed intent, so collect the
+    // admin secret before the request goes out rather than after a 401 (#166).
+    if (!this.adminIntent.hasSecret()) {
+      this.error.set('');
+      this.secretPromptOpen.set(true);
+      return;
+    }
+
+    this.submit();
+  }
+
+  /** The admin unlocked the session from the prompt: continue the submission. */
+  onSecretUnlocked(): void {
+    this.secretPromptOpen.set(false);
+    if (this.form.valid) this.submit();
+  }
+
+  onSecretCancelled(): void {
+    this.secretPromptOpen.set(false);
+    this.error.set('Bond issuance was cancelled: it needs a signed admin intent.');
+  }
+
+  private submit(): void {
     this.submitting.set(true);
     this.error.set('');
     this.success.set(false);

--- a/frontend/src/app/marketplace/marketplace-list/marketplace-list.component.ts
+++ b/frontend/src/app/marketplace/marketplace-list/marketplace-list.component.ts
@@ -10,6 +10,7 @@ import { WalletService } from '../../auth/wallet.service';
 import { StatusBadgeComponent } from '../../shared/components/status-badge/status-badge.component';
 import { LoadingSpinnerComponent } from '../../shared/components/loading-spinner/loading-spinner.component';
 import { QuoteBalanceComponent, QuoteBalances } from '../../shared/components/quote-balance/quote-balance.component';
+import { ConnectPromptComponent } from '../../shared/components/connect-prompt/connect-prompt.component';
 import { Order, Bond, QuoteAsset, PaginatedResponse } from '../../shared/interfaces/bond.interface';
 import { appErrorMessage, normalizeApiError } from '../../shared/errors/api-error';
 
@@ -24,7 +25,7 @@ export const ORDERS_POLL_INTERVAL_MS = 15000;
 @Component({
   selector: 'app-marketplace-list',
   standalone: true,
-  imports: [CommonModule, RouterModule, FormsModule, StatusBadgeComponent, LoadingSpinnerComponent, QuoteBalanceComponent],
+  imports: [CommonModule, RouterModule, FormsModule, StatusBadgeComponent, LoadingSpinnerComponent, QuoteBalanceComponent, ConnectPromptComponent],
   template: `
     <div class="marketplace-page">
       <div class="page-header">
@@ -33,6 +34,8 @@ export const ORDERS_POLL_INTERVAL_MS = 15000;
           List Tokens for Sale
         </a>
       </div>
+
+      <app-connect-prompt action="Listings are public; buying, selling, and cancelling need a signed-in wallet." />
 
       @if (error()) {
         <div class="error-banner">{{ error() }}</div>

--- a/frontend/src/app/marketplace/marketplace.routes.ts
+++ b/frontend/src/app/marketplace/marketplace.routes.ts
@@ -1,8 +1,16 @@
 import { Routes } from '@angular/router';
+import { authGuard } from '../auth/guards/auth.guard';
 
 const routes: Routes = [
+  // GET /marketplace/orders is public; the buy/cancel affordances inside show a
+  // connect prompt while anonymous.
   { path: '', loadComponent: () => import('./marketplace-list/marketplace-list.component').then(m => m.MarketplaceListComponent) },
-  { path: 'sell', loadComponent: () => import('./marketplace-sell/marketplace-sell.component').then(m => m.MarketplaceSellComponent) },
+  {
+    path: 'sell',
+    // POST /marketplace/list and the balance reads it depends on are JwtAuthGuard.
+    canActivate: [authGuard],
+    loadComponent: () => import('./marketplace-sell/marketplace-sell.component').then(m => m.MarketplaceSellComponent),
+  },
 ];
 
 export default routes;

--- a/frontend/src/app/shared/components/admin-secret-prompt/admin-secret-prompt.component.ts
+++ b/frontend/src/app/shared/components/admin-secret-prompt/admin-secret-prompt.component.ts
@@ -1,0 +1,122 @@
+import { Component, ChangeDetectionStrategy, EventEmitter, Input, Output, inject, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { AdminIntentService } from '../../services/admin-intent.service';
+import { AdminAccessService } from '../../services/admin-access.service';
+
+/**
+ * Step-up prompt for high-risk admin actions (issue #166).
+ *
+ * `POST /bonds`, `/bonds/:id/sweep-undistributed`, `/coupon` and `/mature` are
+ * all behind the API's `IntentGuard`, which demands a freshly signed, single-use
+ * intent. Nothing in the UI ever called `setAdminSecret`, so the
+ * `x-admin-intent` header was silently omitted and every submit died on a 401.
+ *
+ * This component is that missing entry point. It collects the admin's Stellar
+ * secret, validates it locally, and hands it to `AdminIntentService`, which
+ * keeps it in memory for the tab session only.
+ */
+@Component({
+  selector: 'app-admin-secret-prompt',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  template: `
+    <div class="backdrop" (click)="onCancel()"></div>
+    <div class="dialog" role="dialog" aria-modal="true" aria-labelledby="admin-secret-title">
+      <h2 id="admin-secret-title" class="dialog-title">Confirm: {{ action }}</h2>
+      @if (description) {
+        <p class="dialog-description">{{ description }}</p>
+      }
+
+      <p class="dialog-note">
+        This action requires a signed admin intent. Your secret key is used in this
+        browser tab only to sign the request — it is never stored or sent to the API.
+      </p>
+
+      @if (adminAccess.adminAddress(); as expected) {
+        <p class="dialog-note mono">Expected admin account: {{ expected }}</p>
+      } @else {
+        <p class="dialog-warning">
+          This build has no <code>adminAddress</code> configured, so the key cannot be
+          checked here. The API will still reject a key that is not the protocol admin.
+        </p>
+      }
+
+      <label class="field-label" for="adminSecret">Admin secret key</label>
+      <input
+        id="adminSecret"
+        class="field-input"
+        type="password"
+        autocomplete="off"
+        spellcheck="false"
+        placeholder="S…"
+        [(ngModel)]="secret"
+        (keyup.enter)="onUnlock()"
+      />
+
+      @if (error(); as message) {
+        <p class="dialog-error" role="alert">{{ message }}</p>
+      }
+
+      <div class="dialog-actions">
+        <button type="button" class="btn btn-outline" (click)="onCancel()">Cancel</button>
+        <button type="button" class="btn btn-primary" [disabled]="!secret" (click)="onUnlock()">
+          Unlock &amp; Continue
+        </button>
+      </div>
+    </div>
+  `,
+  styles: [`
+    .backdrop { position: fixed; inset: 0; background: rgba(15, 23, 42, 0.45); z-index: 40; }
+    .dialog { position: fixed; z-index: 41; top: 50%; left: 50%; transform: translate(-50%, -50%); width: min(460px, calc(100vw - 32px)); background: #fff; border-radius: 12px; padding: 24px; box-shadow: 0 12px 32px rgba(0,0,0,0.22); display: flex; flex-direction: column; gap: 10px; }
+    .dialog-title { font-size: 1.0625rem; font-weight: 700; margin: 0; }
+    .dialog-description { font-size: 0.8125rem; color: #374151; margin: 0; }
+    .dialog-note { font-size: 0.75rem; color: #6b7280; margin: 0; }
+    .dialog-note.mono { font-family: monospace; word-break: break-all; }
+    .dialog-warning { font-size: 0.75rem; color: #92400e; background: #fffbeb; border: 1px solid #fde68a; border-radius: 6px; padding: 8px 10px; margin: 0; }
+    .field-label { font-size: 0.8125rem; font-weight: 600; color: #1a1a2e; margin-top: 6px; }
+    .field-input { padding: 10px 12px; border: 1px solid #d1d5db; border-radius: 8px; font-size: 0.875rem; outline: none; font-family: monospace; }
+    .field-input:focus { border-color: #3b82f6; box-shadow: 0 0 0 2px rgba(59,130,246,0.15); }
+    .dialog-error { font-size: 0.8125rem; color: #ef4444; background: #fef2f2; border-radius: 6px; padding: 8px 10px; margin: 0; }
+    .dialog-actions { display: flex; justify-content: flex-end; gap: 10px; margin-top: 8px; }
+    .btn { padding: 9px 18px; border-radius: 8px; font-size: 0.875rem; font-weight: 500; cursor: pointer; border: none; }
+    .btn-primary { background: #1a1a2e; color: #fff; }
+    .btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
+    .btn-outline { background: #fff; color: #1a1a2e; border: 1px solid #d1d5db; }
+  `],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AdminSecretPromptComponent {
+  /** Human-readable name of the action being authorised. */
+  @Input({ required: true }) action = '';
+
+  /** Optional detail line, e.g. the target bond. */
+  @Input() description = '';
+
+  @Output() readonly unlocked = new EventEmitter<void>();
+  @Output() readonly cancelled = new EventEmitter<void>();
+
+  readonly adminAccess = inject(AdminAccessService);
+  private readonly adminIntent = inject(AdminIntentService);
+
+  secret = '';
+  readonly error = signal<string | null>(null);
+
+  onUnlock(): void {
+    this.error.set(null);
+    try {
+      this.adminIntent.setAdminSecret(this.secret);
+    } catch (e) {
+      this.error.set(e instanceof Error ? e.message : String(e));
+      return;
+    }
+    this.secret = '';
+    this.unlocked.emit();
+  }
+
+  onCancel(): void {
+    this.secret = '';
+    this.error.set(null);
+    this.cancelled.emit();
+  }
+}

--- a/frontend/src/app/shared/components/connect-prompt/connect-prompt.component.ts
+++ b/frontend/src/app/shared/components/connect-prompt/connect-prompt.component.ts
@@ -1,0 +1,90 @@
+import { Component, ChangeDetectionStrategy, Input, computed, inject, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { WalletService } from '../../../auth/wallet.service';
+import { AuthService } from '../../../auth/auth.service';
+
+/**
+ * Contextual "connect your wallet" banner for read-only routes (issue #168).
+ *
+ * Public pages (bond list/detail, marketplace listings) stay browsable while
+ * anonymous, but their write affordances need a wallet and a verified session.
+ * This banner says so up front instead of letting the user discover it through
+ * a 401. It renders nothing once the session is ready.
+ */
+@Component({
+  selector: 'app-connect-prompt',
+  standalone: true,
+  imports: [CommonModule, RouterModule],
+  template: `
+    @if (state() !== 'ready') {
+      <div class="connect-prompt" role="status">
+        <div class="prompt-copy">
+          <strong class="prompt-title">{{ title() }}</strong>
+          <span class="prompt-body">{{ action }}</span>
+        </div>
+
+        <div class="prompt-actions">
+          @if (state() === 'disconnected') {
+            <button type="button" class="btn btn-primary" [disabled]="walletService.isConnecting()" (click)="connect()">
+              {{ walletService.isConnecting() ? 'Connecting…' : 'Connect Wallet' }}
+            </button>
+          } @else {
+            <a class="btn btn-primary" routerLink="/auth">Sign In</a>
+          }
+        </div>
+      </div>
+
+      @if (walletService.errorMessage(); as message) {
+        <p class="prompt-error" role="alert">{{ message }}</p>
+      }
+      @if (connectError(); as message) {
+        <p class="prompt-error" role="alert">{{ message }}</p>
+      }
+    }
+  `,
+  styles: [`
+    .connect-prompt { display: flex; justify-content: space-between; align-items: center; gap: 16px; flex-wrap: wrap; padding: 14px 18px; margin-bottom: 20px; border: 1px solid #bfdbfe; background: #eff6ff; border-radius: 10px; }
+    .prompt-copy { display: flex; flex-direction: column; gap: 2px; }
+    .prompt-title { font-size: 0.875rem; color: #1d4ed8; }
+    .prompt-body { font-size: 0.8125rem; color: #1e40af; }
+    .prompt-actions { display: flex; gap: 8px; }
+    .btn { padding: 8px 16px; border-radius: 8px; font-size: 0.8125rem; font-weight: 500; cursor: pointer; border: none; text-decoration: none; display: inline-block; }
+    .btn-primary { background: #1a1a2e; color: #fff; }
+    .btn-primary:hover:not(:disabled) { background: #2a2a4e; }
+    .btn-primary:disabled { opacity: 0.5; cursor: wait; }
+    .prompt-error { margin: -12px 0 20px; font-size: 0.8125rem; color: #b45309; }
+  `],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ConnectPromptComponent {
+  /** What the visitor is being asked to unlock, e.g. "to subscribe to this bond". */
+  @Input() action = 'to use the actions on this page.';
+
+  readonly walletService = inject(WalletService);
+  private readonly authService = inject(AuthService);
+
+  readonly connectError = signal<string | null>(null);
+
+  readonly state = computed<'disconnected' | 'unauthenticated' | 'ready'>(() => {
+    if (!this.walletService.isConnected()) return 'disconnected';
+    return this.authService.isAuthenticated() ? 'ready' : 'unauthenticated';
+  });
+
+  readonly title = computed(() =>
+    this.state() === 'disconnected' ? 'Connect your wallet' : 'Finish signing in',
+  );
+
+  async connect(): Promise<void> {
+    this.connectError.set(null);
+    try {
+      await this.walletService.connect();
+    } catch (error) {
+      // `WalletService` already publishes a user-facing `errorMessage` for the
+      // states it understands; only surface anything it did not classify.
+      if (!this.walletService.errorMessage()) {
+        this.connectError.set(error instanceof Error ? error.message : String(error));
+      }
+    }
+  }
+}

--- a/frontend/src/app/shared/services/admin-access.service.ts
+++ b/frontend/src/app/shared/services/admin-access.service.ts
@@ -1,0 +1,65 @@
+import { Injectable, computed, inject, signal } from '@angular/core';
+import { StrKey } from '@stellar/stellar-sdk';
+import { WalletService } from '../../auth/wallet.service';
+import { environment } from '../../../environments/environment';
+
+/**
+ * The literal that used to ship in both environment files (issue #167). It is
+ * not a valid Stellar account, so every `address === environment.adminAddress`
+ * comparison silently evaluated to false. Kept here so the build-time check and
+ * the runtime warning can name it explicitly.
+ */
+export const ADMIN_ADDRESS_PLACEHOLDER = 'G...';
+
+export function isValidAdminAddress(value: string | null | undefined): boolean {
+  if (!value || value === ADMIN_ADDRESS_PLACEHOLDER) return false;
+  try {
+    return StrKey.isValidEd25519PublicKey(value);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Single source of truth for "is the connected wallet the protocol admin?".
+ *
+ * `environment.adminAddress` is validated once, on construction. A missing or
+ * malformed value disables every admin affordance and reports why, instead of
+ * comparing wallets against garbage and silently never matching.
+ */
+@Injectable({ providedIn: 'root' })
+export class AdminAccessService {
+  private readonly walletService = inject(WalletService);
+
+  /** The configured admin account, or `null` when unset/invalid. */
+  readonly adminAddress = signal<string | null>(
+    isValidAdminAddress(environment.adminAddress) ? environment.adminAddress : null,
+  );
+
+  /** False when this deployment has no usable admin address configured. */
+  readonly isConfigured = computed(() => this.adminAddress() !== null);
+
+  readonly isAdmin = computed(() => {
+    const admin = this.adminAddress();
+    return admin !== null && this.walletService.address() === admin;
+  });
+
+  /** Explains to an operator why the admin UI is hidden. */
+  readonly misconfigurationReason = computed(() => {
+    if (this.isConfigured()) return null;
+    if (environment.adminAddress === ADMIN_ADDRESS_PLACEHOLDER) {
+      return `environment.adminAddress is still the '${ADMIN_ADDRESS_PLACEHOLDER}' placeholder; admin features are disabled.`;
+    }
+    if (environment.adminAddress) {
+      return 'environment.adminAddress is not a valid Stellar public key; admin features are disabled.';
+    }
+    return 'environment.adminAddress is not configured for this deployment; admin features are disabled.';
+  });
+
+  constructor() {
+    const reason = this.misconfigurationReason();
+    if (reason) {
+      console.warn(`[AdminAccess] ${reason}`);
+    }
+  }
+}

--- a/frontend/src/app/shared/services/admin-intent.service.ts
+++ b/frontend/src/app/shared/services/admin-intent.service.ts
@@ -1,6 +1,7 @@
-import { Injectable } from '@angular/core';
-import { Keypair } from '@stellar/stellar-sdk';
-import { environment } from '../../environments/environment';
+import { Injectable, computed, inject, signal } from '@angular/core';
+import { Keypair, StrKey } from '@stellar/stellar-sdk';
+import { environment } from '../../../environments/environment';
+import { AdminAccessService } from './admin-access.service';
 
 export interface AdminIntentPayload {
   action: string;
@@ -14,6 +15,16 @@ export interface SignedAdminIntent extends AdminIntentPayload {
   signature: string;
 }
 
+/** Raised when a high-risk request is attempted without an unlocked secret. */
+export class AdminSecretMissingError extends Error {
+  constructor(action: string) {
+    super(
+      `"${action}" requires a signed admin intent. Unlock the admin session with your Stellar secret key and try again.`,
+    );
+    this.name = 'AdminSecretMissingError';
+  }
+}
+
 /**
  * Frontend/admin-tooling support for signed step-up intents (#115).
  *
@@ -21,17 +32,64 @@ export interface SignedAdminIntent extends AdminIntentPayload {
  * admin signs a canonical message (`action|target|chain|expiry|nonce`) with
  * their Stellar ed25519 secret key. In a browser context this secret is
  * supplied by the admin console (never the end-user Freighter wallet).
+ *
+ * The secret is held in memory for the tab session only: it is never written to
+ * `localStorage`, never sent to the API, and is dropped on reload or on
+ * `clearAdminSecret()`. See `AdminSecretPromptComponent` for the entry point
+ * that fills it (issue #166).
  */
 @Injectable({ providedIn: 'root' })
 export class AdminIntentService {
-  private secret: string | null = null;
+  private readonly adminAccess = inject(AdminAccessService);
 
+  private readonly secret = signal<string | null>(null);
+
+  /** True once an admin secret has been unlocked for this tab session. */
+  readonly hasSecret = computed(() => this.secret() !== null);
+
+  /** Public key derived from the unlocked secret, for display/confirmation. */
+  readonly unlockedAddress = computed(() => {
+    const secret = this.secret();
+    if (!secret) return null;
+    try {
+      return Keypair.fromSecret(secret).publicKey();
+    } catch {
+      return null;
+    }
+  });
+
+  /**
+   * Unlock the admin session.
+   *
+   * Rejects anything that is not a valid `S…` seed, and — when the deployment
+   * configures `adminAddress` — anything that does not derive to that account,
+   * so a wrong key fails here instead of as an opaque 401 from `IntentGuard`.
+   */
   setAdminSecret(secret: string | null): void {
-    this.secret = secret;
+    if (secret === null || secret === '') {
+      this.secret.set(null);
+      return;
+    }
+
+    const trimmed = secret.trim();
+    if (!StrKey.isValidEd25519SecretSeed(trimmed)) {
+      throw new Error('That is not a valid Stellar secret key (expected an S… seed).');
+    }
+
+    const derived = Keypair.fromSecret(trimmed).publicKey();
+    const expected = this.adminAccess.adminAddress();
+    if (expected && derived !== expected) {
+      throw new Error(
+        `That key belongs to ${derived}, which is not this deployment's admin account. The API will reject its intents.`,
+      );
+    }
+
+    this.secret.set(trimmed);
   }
 
-  get hasSecret(): boolean {
-    return !!this.secret;
+  /** Drop the in-memory secret. */
+  clearAdminSecret(): void {
+    this.secret.set(null);
   }
 
   build(action: string, target: string, chain: string = environment.networkPassphrase): AdminIntentPayload {
@@ -44,9 +102,9 @@ export class AdminIntentService {
     };
   }
 
-  sign(payload: AdminIntentPayload, secret: string | null = this.secret): SignedAdminIntent {
+  sign(payload: AdminIntentPayload, secret: string | null = this.secret()): SignedAdminIntent {
     if (!secret) {
-      throw new Error('Admin signing secret is not configured; cannot produce a signed intent.');
+      throw new AdminSecretMissingError(payload.action);
     }
     const keypair = Keypair.fromSecret(secret);
     const message = `${payload.action}|${payload.target}|${payload.chain}|${payload.expiry}|${payload.nonce}`;

--- a/frontend/src/app/shared/services/api.service.ts
+++ b/frontend/src/app/shared/services/api.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient, HttpErrorResponse, HttpHeaders, HttpParams } from '@angular/common/http';
-import { catchError, Observable, throwError } from 'rxjs';
+import { catchError, defer, Observable, throwError } from 'rxjs';
 import { AuthService } from '../../auth/auth.service';
 import { WalletService } from '../../auth/wallet.service';
 import { AdminIntentService, SignedAdminIntent } from './admin-intent.service';
@@ -107,15 +107,16 @@ export class ApiService {
     return headers;
   }
 
-  /** Produce an `x-admin-intent` header for a high-risk admin action (#115). */
-  private adminIntentHeader(action: string, target: string): Record<string, string> | undefined {
-    if (!this.adminIntent.hasSecret) return undefined;
-    try {
-      const intent: SignedAdminIntent = this.adminIntent.create(action, target);
-      return { 'x-admin-intent': JSON.stringify(intent) };
-    } catch {
-      return undefined;
-    }
+  /**
+   * Produce the `x-admin-intent` header for a high-risk admin action (#115).
+   *
+   * The API's `IntentGuard` rejects these routes outright without it, so a
+   * missing or unsignable secret throws here (#166). Previously the header was
+   * silently dropped and the caller saw an unexplained 401.
+   */
+  private adminIntentHeader(action: string, target: string): Record<string, string> {
+    const intent: SignedAdminIntent = this.adminIntent.create(action, target);
+    return { 'x-admin-intent': JSON.stringify(intent) };
   }
 
   /** Generate a stable idempotency key for a user action (#114). */
@@ -153,8 +154,12 @@ export class ApiService {
   }
 
   issueBond(data: CreateBondDto): Observable<Bond> {
-    const headers = this.headers(this.adminIntentHeader('issue_bond', 'global'));
-    return this.withProblemDetails(this.http.post<Bond>('/api/bonds', data, { headers }));
+    // `defer` keeps a missing-admin-secret failure on the observable's error
+    // path rather than throwing synchronously at call time (#166).
+    return this.withProblemDetails(defer(() => {
+      const headers = this.headers(this.adminIntentHeader('issue_bond', 'global'));
+      return this.http.post<Bond>('/api/bonds', data, { headers });
+    }));
   }
 
   subscribeToBond(id: number, amount: number, idempotencyKey?: string): Observable<SubscriptionResponse> {
@@ -195,12 +200,14 @@ export class ApiService {
   }
 
   sweepUndistributed(id: number): Observable<SweepUndistributedResponse> {
-    const headers = this.headers(this.adminIntentHeader('sweep_undistributed', String(id)));
-    return this.withProblemDetails(this.http.post<SweepUndistributedResponse>(
-      `/api/bonds/${id}/sweep-undistributed`,
-      {},
-      { headers },
-    ));
+    return this.withProblemDetails(defer(() => {
+      const headers = this.headers(this.adminIntentHeader('sweep_undistributed', String(id)));
+      return this.http.post<SweepUndistributedResponse>(
+        `/api/bonds/${id}/sweep-undistributed`,
+        {},
+        { headers },
+      );
+    }));
   }
 
   getProjects(page = 1, limit = 20): Observable<PaginatedResponse<Project>> {

--- a/frontend/src/environments/environment.prod.ts
+++ b/frontend/src/environments/environment.prod.ts
@@ -5,5 +5,14 @@ export const environment = {
   stellarHorizonUrl: 'https://horizon.stellar.org',
   networkPassphrase: 'Public Global Stellar Network ; September 2015',
   ipfsGateway: 'https://gateway.pinata.cloud/ipfs/',
-  adminAddress: 'G...' as const,
+  /**
+   * Stellar public key of the protocol admin, i.e. the API's
+   * `STELLAR_PUBLIC_KEY`. Set this per deployment — the value must be a real
+   * `G…` account, never a placeholder (see issue #167).
+   *
+   * Leave it empty to disable every admin affordance in the UI. Any other
+   * malformed value is rejected by `npm run check:env`, which runs before each
+   * build.
+   */
+  adminAddress: '',
 };

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -5,5 +5,14 @@ export const environment = {
   stellarHorizonUrl: 'https://horizon-testnet.stellar.org',
   networkPassphrase: 'Test SDF Network ; September 2015',
   ipfsGateway: 'https://gateway.pinata.cloud/ipfs/',
-  adminAddress: 'G...' as const,
+  /**
+   * Stellar public key of the protocol admin, i.e. the API's
+   * `STELLAR_PUBLIC_KEY`. Set this per deployment — the value must be a real
+   * `G…` account, never a placeholder (see issue #167).
+   *
+   * Leave it empty to disable every admin affordance in the UI. Any other
+   * malformed value is rejected by `npm run check:env`, which runs before each
+   * build.
+   */
+  adminAddress: '',
 };


### PR DESCRIPTION
## Summary

Four frontend issues that all land on the same seam — the wallet session and what the API will actually accept — so they are fixed together. Today the app cannot connect a wallet at all, lets anonymous visitors walk into authenticated flows, ships a placeholder admin address that never matches anything, and drops the header that every admin route requires.

Scope is `frontend/` only. No API, contract, or oracle changes.

---

### `#165` — Wallet connect crashes with `ReferenceError: getNetwork is not defined`

`wallet.service.ts` called `getNetwork()` on the network-verification path but only imported `isConnected`, `getAddress` and `signTransaction`. Every connect, sign-in and signature threw, and the status signal stayed stuck on `connecting`.

- Freighter calls now go through an injectable `FREIGHTER_API` token (`auth/freighter-api.token.ts`). The library exports module-level functions that cannot be spied on once bundled, so this is what makes `verifyNetwork()` testable at all.
- `verifyNetwork()` checks the `error` field Freighter returns instead of trusting an empty passphrase, names both the detected and expected network in the mismatch message, and clears a stale mismatch banner when the user switches back.
- `refreshAccountState()` no longer flattens a precise `network_mismatch` into the generic "Freighter is locked" message.
- **Also fixed:** the file referenced a `WalletStatus` type that was never declared anywhere in the repo, so `frontend/` did not compile. It is now defined and exported.
- New `wallet.service.spec.ts` covers the regression directly plus mismatch detection, unreadable-network, signing, and the missing/locked paths.

### `#167` — `adminAddress` is a hardcoded `'G...'` placeholder in both environment files

The literal `'G...'` is not a valid Stellar account, so `address === environment.adminAddress` silently evaluated to false in every environment and admin detection was quietly dead.

- `adminAddress` now defaults to `''` in both files, documented as a per-deployment value that must match the API's `STELLAR_PUBLIC_KEY`.
- New `AdminAccessService` is the single source of truth for "is this wallet the admin?". It validates the configured value with `StrKey` once at construction, disables all admin affordances when unset or malformed, and logs a warning naming the reason instead of comparing against garbage.
- New `frontend/scripts/check-environments.mjs` runs as `prebuild` (and standalone via `npm run check:env`). It **fails the build** on the `'G...'` placeholder or any malformed key, and warns on an empty value.
- **Note:** `angular.json` had no `fileReplacements`, so `environment.prod.ts` was dead code — a production build shipped the testnet passphrase. Added the replacement so the production environment (and the check that guards it) actually means something.

### `#168` — No route guards or wallet/network gating

`app.routes.ts` mounted every flow with no `canActivate` at all, so anonymous users reached dashboards and sell forms that can only ever return empty states and 401s.

- `authGuard` — requires a connected wallet **and** a verified session. Applied to `/dashboard` and `/marketplace/sell`.
- `adminGuard` — runs the `authGuard` checks first, then requires the configured admin wallet. Applied to `/bonds/issue`, mirroring the API's `AdminGuard`. An anonymous visitor gets a connect prompt rather than an "admin only" dead end.
- Denials redirect to `/auth` carrying `returnUrl` and a `reason`, so the sign-in page explains *why* and returns the user to where they were headed. `returnUrl` is sanitized against protocol-relative and absolute values.
- **Read-only routes stay public** and render a new contextual `<app-connect-prompt>` over their write affordances: bond list, bond detail, marketplace listings.
- **Projects stay public throughout**, per the acceptance criteria — `POST /projects` is genuinely unguarded on the API.
- The "Issue Bond" link on the bonds list is now only shown to an admin wallet.
- New `auth.guard.spec.ts` covers anonymous, connected-but-unauthenticated, authenticated, admin, non-admin, and unconfigured-admin cases.

### `#166` — Admin step-up intent is dead code

`setAdminSecret()` had zero call sites, so `ApiService.adminIntentHeader` always saw `hasSecret === false` and **silently dropped** `x-admin-intent`. Every `issue-bond` and `sweep` submit was a guaranteed 401 from `IntentGuard`, behind a UI that showed a success path.

- New `AdminSecretPromptComponent` is the missing entry point. It appears before a high-risk submit, validates the seed locally with `StrKey`, and rejects a key that does not derive to the configured admin account — so a wrong key fails there with a clear message rather than as an opaque 401.
- The secret is held **in memory for the tab session only**: never written to `localStorage`, never sent to the API, dropped on reload or via an explicit "Lock admin session" control.
- `AdminIntentService.hasSecret` is now a signal, with `clearAdminSecret()` and an `unlockedAddress` for confirmation in the UI.
- `ApiService` **throws `AdminSecretMissingError`** instead of omitting the header. `issueBond` and `sweepUndistributed` wrap header construction in `defer` so the failure arrives on the observable's error path rather than synchronously at call time.
- `IssueBondComponent` shows the step-up requirement up front and prompts on submit; the bond-detail sweep does the same.

---

## Verification

- `npm run check:env` fails on the `'G...'` literal and passes on the committed empty value.
- New specs: `wallet.service.spec.ts`, `auth.guard.spec.ts`. `bond-detail.component.spec.ts` was updated to configure the admin account through `AdminAccessService` and unlock a session, since it previously leaned on the placeholder.

**Not yet run in this environment:** the full `npm run build` / `npm test` / `npm run lint` sweep. CI should be treated as the source of truth on this branch before merge.

## Reviewer notes

- The `angular.json` `fileReplacements` addition changes what a production build ships (mainnet passphrase and Horizon URL, as `environment.prod.ts` always intended). Flagging it explicitly since it was previously inert.
- `adminAddress` ships empty. Deployments that want the admin UI must set it to their API's `STELLAR_PUBLIC_KEY`; until then admin affordances are hidden rather than broken.

Closes #165
Closes #166
Closes #167
Closes #168

